### PR TITLE
Differential evolution typo

### DIFF
--- a/pybnf/algorithms.py
+++ b/pybnf/algorithms.py
@@ -1173,7 +1173,7 @@ class DifferentialEvolution(Algorithm):
         new_pset_dict = dict()
         for p in base.keys():
             if np.random.random() < self.mutation_rate:
-                new_pset_dict[p] = self.add(base, p, self.mutation_rate * self.diff(others[0], others[1], p))
+                new_pset_dict[p] = self.add(base, p, self.mutation_factor * self.diff(others[0], others[1], p))
             else:
                 new_pset_dict[p] = base[p]
 

--- a/pybnf/config.py
+++ b/pybnf/config.py
@@ -125,7 +125,7 @@ class Configuration(object):
             'output_every': 20, 'initialization': 'lh', 'refine': 0, 'bng_command': bng_command, 'smoothing': 1,
             'backup_every': 1,
 
-            'mutation_rate': 0.5, 'mutation_factor': 1.0, 'islands': 1, 'migrate_every': 20, 'num_to_migrate': 3,
+            'mutation_rate': 0.5, 'mutation_factor': 0.5, 'islands': 1, 'migrate_every': 20, 'num_to_migrate': 3,
             'stop_tolerance': 0.002,
 
             'particle_weight': 1.0, 'adaptive_n_max': 30, 'adaptive_n_stop': np.inf, 'adaptive_abs_tol': 0.0,


### PR DESCRIPTION
Fixed typo of wrong hyperparameter name in differential evolution (mutation_rate -> mutation_factor). 

Changed the default value of mutation_factor to 0.5, which we have been inadvertently using already. Seems to work better than the existing value of 1.0.