### PR TITLE
Delete old sorted_params

### DIFF
--- a/config_documentation.txt
+++ b/config_documentation.txt
@@ -30,7 +30,7 @@ logvar = name__FREE__ init step - a variable that starts at init with an initial
 ***General options***
 
 refine: If 1, after fitting is completed, refine the best fit parameter set by a local search with the simplex algorithm. Default: 0
-delete_old_files: If 1, delete simulation folders immediately after they complete. Default: 0
+delete_old_files: If 1 - delete simulation folders immediately after they complete. 2 - Delete both old simulation folders and old sorted_params.txt result files Default: 0
 num_to_output: The maximum number of PSets to write when writing the trajectory. Default: 1000000
 output_every: Write the Trajectory to file every x iterations. Default: 20
 wall_time_sim: Maximum time (in seconds) to wait for a simulation to finish.  Exceeding this (either for a simulation or network generation) results in an infinite objective function value.  Default: 3600

--- a/pybnf/algorithms.py
+++ b/pybnf/algorithms.py
@@ -571,13 +571,12 @@ class Algorithm(object):
 
         # If the user has asked for fewer output files, each time we're here, move the new file to
         # Results/sorted_params.txt, overwriting the previous one.
-        # Disabled this feature because it's more likely the user would just want the old Simulation folders deleted
-        # if self.config.config['delete_old_files'] == 1:
-        #     logger.debug("Overwriting previous 'sorted_params.txt'")
-        #     noname_filepath = '%s/Results/sorted_params.txt' % self.config.config['output_dir']
-        #     if os.path.isfile(noname_filepath):
-        #         os.remove(noname_filepath)
-        #     os.rename(filepath, noname_filepath)
+        if self.config.config['delete_old_files'] >= 2:
+            logger.debug("Overwriting previous 'sorted_params.txt'")
+            noname_filepath = '%s/Results/sorted_params.txt' % self.config.config['output_dir']
+            if os.path.isfile(noname_filepath):
+                os.remove(noname_filepath)
+            os.rename(filepath, noname_filepath)
 
     def backup(self, pending_psets=()):
         """
@@ -731,7 +730,7 @@ class Algorithm(object):
                 logger.info('Deleted pickled algorithm')
             except OSError:
                 logger.warning('Tried to delete pickled algorithm, but it was not found')
-            if self.config.config['delete_old_files'] == 1:
+            if self.config.config['delete_old_files'] >= 1:
                 shutil.rmtree('%s/Simulations' % self.config.config['output_dir'])
 
         logger.info("Fitting complete")


### PR DESCRIPTION
Reenabled an option to delete old sorted_params.txt files, activated when delete_old_files=2

Closes #36 