### PR TITLE
Small SBML bug fix

### DIFF
--- a/pybnf/pset.py
+++ b/pybnf/pset.py
@@ -463,6 +463,7 @@ class SbmlModelNoTimeout(Model):
         logger.info('Generating model text for %s' % self.name)
         runner = rr.RoadRunner(self.abs_file_path)
         self._modify_params(runner)
+        runner.reset()
         return runner.getCurrentSBML()
 
     def save(self, file_prefix):


### PR DESCRIPTION
Added reset when saving SBML model text. Needed for correct output when SBML has events that fire at time 0.