### PR TITLE
Clean up error messages

### DIFF
--- a/pybnf/algorithms.py
+++ b/pybnf/algorithms.py
@@ -152,7 +152,6 @@ class Job:
             model_file_prefix = self._name_with_id(model)
             model_with_params = model.copy_with_param_set(self.params)
             ds[model.name] = model_with_params.execute(self.folder, model_file_prefix, self.timeout)
-        self._copy_log_files('')  # Occurs when runs are successful.  Log files not used in this case yet
         return ds
 
     def _copy_log_files(self, failed_logs_dir):


### PR DESCRIPTION
Remove extraneous _copy_log_files('') call that sends extra error messages to log.
Closes #107 