### PR TITLE
Workaround for distributed/asyncio logging bug

### DIFF
--- a/pybnf/algorithms.py
+++ b/pybnf/algorithms.py
@@ -7,7 +7,7 @@ from subprocess import run
 from subprocess import CalledProcessError, TimeoutExpired
 from subprocess import STDOUT
 
-from .config import init_logging
+from .config import init_logging, reinit_logging
 from .data import Data
 from .pset import PSet
 from .pset import Trajectory
@@ -677,6 +677,9 @@ class Algorithm(object):
         else:
             client = Client()
             client.run(init_logging, log_prefix, debug)
+
+        # Required because with distributed v1.22.0, logger breaks after calling Client()
+        reinit_logging(log_prefix, debug)
 
         backup_every = self.get_backup_every()
         sim_count = 0

--- a/pybnf/config.py
+++ b/pybnf/config.py
@@ -56,6 +56,14 @@ def init_logging(file_prefix, debug=False):
         tlog.addHandler(dfh)
         talog.addHandler(dfh)
 
+def reinit_logging(file_prefix, debug=False):
+    """
+    Shut down logging, then restart it.
+    Used when some module (e.g. distributed v1.22.0) breaks the logging.
+    """
+    if logging.root:
+        del logging.root.handlers[:]
+    init_logging(file_prefix, debug)
 
 class Configuration(object):
     def __init__(self, d=dict()):


### PR DESCRIPTION
Adds a workaround so logging still works when using distributed v1.22.0, by reinitializing the logger after initializing the Client. Closes #163 