### PR TITLE
Roadrunner simulation fix

### DIFF
--- a/pybnf/pset.py
+++ b/pybnf/pset.py
@@ -602,7 +602,7 @@ class SbmlModelNoTimeout(Model):
 
         # Run the model actions
         result_dict = dict()
-        selection = ['time'] + list(self.species_names)
+        selection = ['time'] + ['[%s]' % s for s in self.species_names]
         for mut in self.mutants:
             # Apply all mutations
             self._apply_mutant(mut, runner)


### PR DESCRIPTION
Change roadrunner output from "particles" to "concentration".
Avoids unexpected results if SBML declares a compartment with a volume. Now PyBNF always works with SBML "concentrations".

Closes #219