### PR TITLE
Add support for scheduler-file argument

### DIFF
--- a/pybnf/algorithms.py
+++ b/pybnf/algorithms.py
@@ -728,7 +728,10 @@ class Algorithm(object):
         if self.refine:
             logger.debug('Setting up Simplex refinement of previous algorithm')
 
-        if scheduler_node:
+        if 'scheduler_file' in self.config.config:
+            # Scheduler node read in from scheduler file stored on shared file system
+            client = Client(scheduler_file=self.config.config['scheduler_file'])
+        elif scheduler_node:
             client = Client('%s:8786' % scheduler_node)
         elif self.config.config['parallel_count'] is not None:
             lc = LocalCluster(n_workers=self.config.config['parallel_count'], threads_per_worker=1)

--- a/pybnf/config.py
+++ b/pybnf/config.py
@@ -159,6 +159,7 @@ class Configuration(object):
 
             'cluster_type': None,
             'scheduler_node': None,
+            'scheduler_file': None,
             'worker_nodes': None,
 
             'gamma_prob': 0.1,

--- a/pybnf/parse.py
+++ b/pybnf/parse.py
@@ -32,7 +32,7 @@ b_var_def_keys = ['uniform_var', 'loguniform_var']
 var_def_keys = ['lognormal_var', 'normal_var']
 var_def_keys_1or2nums = ['var', 'logvar']
 strkeylist = ['bng_command', 'output_dir', 'fit_type', 'objfunc', 'initialization',
-              'cluster_type', 'scheduler_node', 'de_strategy', 'sbml_integrator']
+              'cluster_type', 'scheduler_node', 'scheduler_file', 'de_strategy', 'sbml_integrator']
 multstrkeys = ['worker_nodes', 'postprocess']
 dictkeys = ['time_course', 'param_scan']
 punctuation_safe = re.sub('[:,]', '', punctuation)

--- a/pybnf/pybnf.py
+++ b/pybnf/pybnf.py
@@ -40,6 +40,8 @@ def main():
                         help='automatically overwrites existing folders if necessary')
     parser.add_argument('-t', '--cluster_type', action='store',
                         help='optional string denoting the type of cluster')
+    parser.add_argument('-s', '--scheduler_file', action='store',
+                        help='optional file on shared filesystem to get scheduler location, should be same as passed to dask-scheduler and dask-worker.')
     parser.add_argument('-r', '--resume', action='store', nargs='?', const=0, default=None, type=int,
                         metavar='iterations',
                         help='automatically resume the previously stopped fitting run; '
@@ -186,12 +188,18 @@ def main():
             else:
                 raise PybnfError('Invalid fit_type %s. Options are: pso, de, ade, ss, bmc, pt, sa, sim' % config.config['fit_type'])
 
-        # override cluster type value in configuration file if specified with cmdline args
+        # Override configuration values if provided on command line
         if cmdline_args.cluster_type:
             config.config['cluster_type'] = cmdline_args.cluster_type
+        if cmdline_args.scheduler_file:
+            config.config['scheduler_file'] = cmdline_args.scheduler_file
 
         # Set up cluster
-        if config.config['scheduler_node'] and config.config['worker_nodes']:
+        if config.config['scheduler_file']:
+            # Scheduler node will be read in from scheduler file stored on shared file system
+            node_string = None
+            scheduler_node = None
+        elif config.config['scheduler_node'] and config.config['worker_nodes']:
             scheduler_node = config.config['scheduler_node']
             node_string = ' '.join(config.config['worker_nodes'])
         elif config.config['scheduler_node']:


### PR DESCRIPTION
When `--scheduler-location` is passed to `dask-scheduler` on startup, it saves the location that the scheduler can be contacted.  This is typically used by passing the same argument to `dask-worker` to simplify cluster setup, but it can also be used by `pybnf` to easily connect to the scheduler.

This is an alternative to dask-ssh, and allows more control over how workers are provisioned.