### PR TITLE
Save failed simulation logs

### DIFF
--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -8,10 +8,9 @@ If most or all of your simulations are failing (and generate messages like "Job 
 
 Check the simulation logs
 ^^^^^^^^^^^^^^^^^^^^^^^^^
-Rerun the fit with the debugging flag ``-d``.  Failed simulations 
-will send their logs (generally stdout and stderr) to a ``FailedSimLogs`` folder in the specified output directory. These logs should usually contain more information about why the simulator failed to run.
+Failed simulations will send their logs (generally stdout and stderr) to a ``FailedSimLogs`` folder in the specified output directory. These logs should usually contain more information about why the simulator failed to run.
 
-If the fit was run with ``delete_old_files=0`` in the config file, the logs can instead be found in the appropriate folder in the ``Simulations/`` directory.
+By default, PyBNF saves logs of roughly the first 10 failed simulations encountered. If PyBNF is run with the ``-d`` flag, logs from all failed simulations will be saved. If the fit was run with ``delete_old_files=0`` in the config file, all logs can be found in the appropriate folders in the ``Simulations/`` directory.
 
 For BNGL simulations
 ^^^^^^^^^^^^^^^^^^^^

--- a/pybnf/algorithms.py
+++ b/pybnf/algorithms.py
@@ -832,7 +832,7 @@ class Algorithm(object):
         else:
             psets = self.start_run()
 
-        if debug and not os.path.isdir(self.failed_logs_dir):
+        if not os.path.isdir(self.failed_logs_dir):
             os.mkdir(self.failed_logs_dir)
 
         if self.config.config['local_objective_eval'] == 0 and self.config.config['smoothing'] == 1 and \
@@ -850,7 +850,7 @@ class Algorithm(object):
         logger.info('Submitting initial set of %d Jobs' % len(jobs))
         futures = []
         for job in jobs:
-            f = client.submit(run_job, job, debug, self.failed_logs_dir)
+            f = client.submit(run_job, job, True, self.failed_logs_dir)
             futures.append(f)
             pending[f] = (job.params, job.job_id)
         pool = custom_as_completed(futures, with_results=True, raise_errors=False)
@@ -910,7 +910,7 @@ class Algorithm(object):
                 for ps in response:
                     new_js = self.make_job(ps)
                     for new_j in new_js:
-                        new_f = client.submit(run_job, new_j, debug, self.failed_logs_dir)
+                        new_f = client.submit(run_job, new_j, (debug or self.fail_count < 10), self.failed_logs_dir)
                         pending[new_f] = (ps, new_j.job_id)
                         new_futures.append(new_f)
                 logger.debug('Submitting %d new Jobs' % len(new_futures))

--- a/pybnf/algorithms.py
+++ b/pybnf/algorithms.py
@@ -888,8 +888,9 @@ class Algorithm(object):
                     print1('Job %s timed out' % res.name)
                 if self.success_count == 0 and self.fail_count >= 100:
                     raise PybnfError('Aborted because all jobs are failing',
-                                     'Your simulations are failing to run. See the log files in '
-                                     'the %s directory.' % ('FailedSimLogs' if debug else 'Simulations'))
+                                     'Your simulations are failing to run. Logs from failed simulations are saved in '
+                                     'the FailedSimLogs directory. For help troubleshooting this error, refer to '
+                                     'https://pybnf.readthedocs.io/en/latest/troubleshooting.html#failed-simulations')
             else:
                 self.success_count += 1
                 logger.debug('Job %s complete' % res.name)

--- a/pybnf/config.py
+++ b/pybnf/config.py
@@ -441,8 +441,11 @@ class Configuration(object):
         # path to the appropriate Model subclass
         if BNGLModel in model_types:
             if self.config['bng_command'] == '':
-                raise PybnfError('Path to BNG2.pl not defined.  Please specify using the "bng_command" parameter '
-                                 'in the configuration file or set the BNGPATH environmental variable')
+                raise PybnfError('The location of the BioNetGen simulator (BNG2.pl) is not specified. Please set the '
+                                 '"bng_command" configuration key to the location of the file BNG2.pl, or set the '
+                                 'BNGPATH environmental variable to the folder containing BNG2.pl.\n'
+                                 'If BioNetGen is not yet installed, please refer to installation instructions at '
+                                 'https://pybnf.readthedocs.io/en/latest/installation.html#bionetgen')
             elif re.search(r'BNG2.pl', self.config['bng_command']) is None:
                 raise PybnfError('The specified "bng_command" parameter in the configuration file must include the script '
                                  'name at the end of the path (e.g. /path/to/BNG2.pl)')
@@ -452,9 +455,11 @@ class Configuration(object):
                     subprocess.run(self.config['bng_command'] + ' -v', shell=True, check=True,
                                    stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
                 except subprocess.CalledProcessError:
-                    raise PybnfError('BioNetGen failed to execute.  Please check that "bng_command" parameter in the '
-                                     'configuration file points to the BNG2.pl script or that the BNGPATH environmental '
-                                     'variable is correctly set')
+                    raise PybnfError('BioNetGen failed to execute. Please check that "bng_command" parameter in the '
+                                     'configuration file points to the BNG2.pl script, or that the BNGPATH environmental '
+                                     'variable is set to the folder containing BNG2.pl.\n'
+                                     'For help, refer to '
+                                     'https://pybnf.readthedocs.io/en/latest/installation.html#bionetgen')
         # Check that the integrator is valid
         integrators = ('cvode', 'euler', 'rk4', 'gillespie')
         if self.config['sbml_integrator'] not in integrators:


### PR DESCRIPTION
Save the first few failed simulation logs even without the debug flag. Closes #144
I feel like this is often the behavior you would want, but then again, makes the behavior more unpredictable (which logs get saved? Arbitrarily, the ones for which there were less than 10 failures recorded at the time of submission), so I am undecided whether this is a good change.