### PR TITLE
Windows support

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -5,19 +5,38 @@ Installation
 
 Operating System
 ----------------
-PyBNF can be installed on any recent Linux or macOS operating system. Windows is not currently supported. 
+PyBNF can be installed on any recent Linux or macOS operating system.
+
+PyBNF can also be installed on Windows, but functionality on Windows has been less extensively tested (in particular, Windows clusters have not been tested). 
 
 Python
 ------
 
-PyBNF requires an installation of Python version 3.5 or higher. This comes built-in on many new Linux and Mac
-operating systems. To check if you have Python 3, run the command ``python3``. This will start Python and print
+PyBNF requires an installation of Python version 3.5 or higher. 
+
+Linux and Mac
+^^^^^^^^^^^^^
+
+Python 3 comes built-in on many new Linux and Mac operating systems. 
+To check if you have Python 3, run the command ``python3``. This will start Python and print
 the version number, or will give an error if you don't have Python 3.
 
 Also confirm that your Python 3 has the ``pip`` package manager, which is used to install PyBNF. Run the command ``python3 -m pip``. This will give a help message if you have pip, or an error if not. 
 
 If you are missing python3 or pip, an easy way to get them is by installing the `Anaconda`_ Python distribution for Python v3.5 or higher.
 Instructions for installing on various platforms can be found on the `Anaconda`_ website.
+
+Windows
+^^^^^^^
+
+Windows does not come with built-in Python, so it must be installed separately. Additionally, if :ref:`BioNetGen <bng_install>` will be used, Perl installation is required in the same environment as the python installation (i.e., the commands ``python`` and ``perl`` must both work on the same command line).
+
+Our recommended configuration consists of installing `Strawberry Perl`_ and `Anaconda`_ Python 3. The Windows distribution of Anaconda includes the application "Anaconda Prompt", which provides a command line. This is the command line that you should use whenever this documentation refers to the command line or terminal. After installing both Anaconda and Strawberry Perl, a system restart may be required for Anaconda Prompt to find the Perl installation. 
+
+For troubleshooting, or more advanced configuration, note that the requirement is to have both Python 3 and Perl on the current path. The current path can be checked with the command ``echo %PATH%`` and set (temporarily) with the command ``set PATH=[newpath]``, where ``[newpath]`` is a semicolon-delimited list of directories to search. 
+
+.. Permanently setting the path is a nightmare: https://stackoverflow.com/questions/19287379/how-do-i-add-to-the-windows-path-variable-using-setx-having-weird-problems
+
 
 PyBNF
 -----
@@ -28,6 +47,8 @@ Installing from PyPI
 Simply type the following in a terminal:
 
     :command:`python3 -m pip install pybnf`
+
+Windows users running Anaconda Python 3 from "Anaconda Prompt" should instead type only ``pip install pybnf``.
 
 The above command will use your current version of Python 3 to install the most recent version of PyBNF released on the Python Package Index, along with all required dependencies. 
 
@@ -49,12 +70,15 @@ anywhere in the filesystem.
 Installation of External Simulators
 -----------------------------------
 
+.. _bng_install:
+
 BioNetGen
 ^^^^^^^^^
 PyBNF is designed to work with simulators present in the BioNetGen software suite, version 2.3, available for download from 
-the `BioNetGen`_ website. Note that for Linux distributions other than Ubuntu, the pre-built binary is unreliable, and it is 
-necessary to rebuild BioNetGen from source. The current BioNetGen distribution includes support for both network-based 
-simulations and network-free simulations. 
+the `BioNetGen`_ website. 
+Note that for Linux distributions other than Ubuntu, the pre-built binary is unreliable, and it is necessary to rebuild BioNetGen from source. 
+For Windows, Perl must be installed separately as part of BioNetGen installation; the developers recommend `ActivePerl`_.
+The current BioNetGen distribution includes support for both network-based simulations and network-free simulations. 
 
 .. _set_bng_path:
 \
@@ -69,6 +93,9 @@ A convenient alternative is to set the environment variable ``BNGPATH`` to the B
 where ``/path/to/bng2`` is the path to the folder containing ``BNG2.pl``, not including the "BNG2.pl" file name. This 
 setting may be made permanent as of your next login, by copying above command into the file ``.bash_profile``
 in your home directory.
+
+On Windows systems, the equivalent commands are ``set BNGPATH=C:\path\to\bng2`` to set on the current command line, 
+and ``setx BNGPATH C:\path\to\bng2`` to permanently set for all future command lines (but not the current one). 
 
 SBML
 ^^^^
@@ -85,3 +112,4 @@ SBML format.
 .. _libroadrunner: http://libroadrunner.org/
 .. _COPASI: http://copasi.org/
 .. _virtualenv: https://packaging.python.org/guides/installing-using-pip-and-virtualenv/
+.. _Strawberry Perl: http://strawberryperl.com/

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -7,7 +7,7 @@ Operating System
 ----------------
 PyBNF can be installed on any recent Linux or macOS operating system.
 
-PyBNF can also be installed on Windows, but functionality on Windows has been less extensively tested (in particular, Windows clusters have not been tested). 
+PyBNF can also be installed on Windows, but functionality on Windows has been less extensively tested (in particular, Windows clusters and multicore workstations have not been tested). 
 
 Python
 ------

--- a/pybnf/algorithms.py
+++ b/pybnf/algorithms.py
@@ -549,6 +549,9 @@ class Algorithm(object):
                 default_pset = PSet([var.set_value(var.default_value) for var in self.variables])
                 m.save(gnm_name, gen_only=True, pset=default_pset)
                 gn_cmd = [self.config.config['bng_command'], '%s.bngl' % gnm_name]
+                if os.name == 'nt':  # Windows
+                    # Explicitly call perl because the #! line in BNG2.pl is not supported.
+                    gn_cmd = ['perl'] + gn_cmd
                 try:
                     with open('%s.log' % gnm_name, 'w') as lf:
                         print2('Generating network for model %s.bngl' % gnm_name)

--- a/pybnf/algorithms.py
+++ b/pybnf/algorithms.py
@@ -294,9 +294,9 @@ class Job:
                 res.simdata = None
         if self.delete_folder:
             try:
-                run(['rm', '-rf', self.folder], check=True, timeout=1800)
+                shutil.rmtree(self.folder)
                 self.jlogger.debug('Removed folder %s' % self.folder)
-            except (CalledProcessError, TimeoutExpired):
+            except OSError:
                 self.jlogger.error('Failed to remove folder %s.' % self.folder)
 
         return res
@@ -982,7 +982,7 @@ class Algorithm(object):
         if (isinstance(self, SimplexAlgorithm) or self.config.config['refine'] != 1) and self.bootstrap_number is None:
             # End of fitting; delete unneeded files
             if self.config.config['delete_old_files'] >= 1:
-                run(['rm', '-rf', self.sim_dir])
+                shutil.rmtree(self.sim_dir)
 
         logger.info("Fitting complete")
 

--- a/pybnf/algorithms.py
+++ b/pybnf/algorithms.py
@@ -770,7 +770,7 @@ class Algorithm(object):
             noname_filepath = '%s/sorted_params.txt' % self.res_dir
             if os.path.isfile(noname_filepath):
                 os.remove(noname_filepath)
-            os.rename(filepath, noname_filepath)
+            os.replace(filepath, noname_filepath)
 
     def backup(self, pending_psets=()):
         """
@@ -793,7 +793,7 @@ class Algorithm(object):
             f = open(temppicklepath, 'wb')
             pickle.dump((self, pending_psets), f)
             f.close()
-            os.rename(temppicklepath, picklepath)
+            os.replace(temppicklepath, picklepath)
         except IOError as e:
             logger.exception('Failed to save backup of algorithm')
             print1('Failed to save backup of the algorithm.\nSee log for more information')
@@ -971,7 +971,7 @@ class Algorithm(object):
 
         if self.bootstrap_number is None or self.bootstrap_number == self.config.config['bootstrap']:
             try:
-                os.rename('%s/alg_backup.bp' % self.config.config['output_dir'],
+                os.replace('%s/alg_backup.bp' % self.config.config['output_dir'],
                           '%s/alg_%s.bp' % (self.config.config['output_dir'],
                                             ('finished' if not self.refine else 'refine_finished')))
                 logger.info('Renamed pickled algorithm backup to alg_%s.bp' %

--- a/pybnf/config.py
+++ b/pybnf/config.py
@@ -452,8 +452,10 @@ class Configuration(object):
             else:  # check to make sure BNG2.pl is available
                 try:
                     logger.info('Checking to make sure bng_command is appropriately set')
-                    subprocess.run(self.config['bng_command'] + ' -v', shell=True, check=True,
-                                   stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
+                    cmd = [self.config['bng_command'], '-v']
+                    if os.name == 'nt':  # Windows
+                        cmd = ['perl'] + cmd
+                    subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
                 except subprocess.CalledProcessError:
                     raise PybnfError('BioNetGen failed to execute. Please check that "bng_command" parameter in the '
                                      'configuration file points to the BNG2.pl script, or that the BNGPATH environmental '

--- a/pybnf/config.py
+++ b/pybnf/config.py
@@ -345,6 +345,14 @@ class Configuration(object):
         Convert relative paths to absolute paths
         """
         home_dir = os.getcwd()
+        if os.name == 'nt':  # Windows
+            if directory == '':
+                return ''
+            # Check for both unix-like and windows-like paths starting from root
+            if directory[0] == '/' or re.match(r'[A-Z]:', directory):
+                return directory
+            else:
+                return os.path.join(home_dir, directory)
         return '' if directory == '' else directory if directory[0] == '/' else home_dir + '/' + directory
 
     def _load_models(self):

--- a/pybnf/config.py
+++ b/pybnf/config.py
@@ -465,10 +465,18 @@ class Configuration(object):
                         cmd = ['perl'] + cmd
                     subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
                 except subprocess.CalledProcessError:
+                    #  Occurs on Windows if BNG2.pl is nonexistent, or on Mac/Linux if BNG2.pl exists but crashed
                     raise PybnfError('BioNetGen failed to execute. Please check that "bng_command" parameter in the '
                                      'configuration file points to the BNG2.pl script, or that the BNGPATH environmental '
                                      'variable is set to the folder containing BNG2.pl.\n'
                                      'For help, refer to '
+                                     'https://pybnf.readthedocs.io/en/latest/installation.html#bionetgen')
+                except FileNotFoundError:
+                    #  Occurs on Mac/Linux if BNG2.pl is nonexistent.
+                    raise PybnfError('The BioNetGen simulator (BNG2.pl) was not found at the specified location. Please set the '
+                                     '"bng_command" configuration key to the location of the file BNG2.pl, or set the '
+                                     'BNGPATH environmental variable to the folder containing BNG2.pl.\n'
+                                     'If BioNetGen is not yet installed, please refer to installation instructions at '
                                      'https://pybnf.readthedocs.io/en/latest/installation.html#bionetgen')
         # Check that the integrator is valid
         integrators = ('cvode', 'euler', 'rk4', 'gillespie')

--- a/pybnf/pset.py
+++ b/pybnf/pset.py
@@ -14,6 +14,7 @@ import traceback
 import roadrunner as rr
 import pickle
 from os.path import abspath, dirname, join, isfile
+import os
 from sys import executable
 
 ROOT_DIRECTORY = join(dirname(abspath(__file__)), '..')
@@ -343,6 +344,9 @@ class BNGLModel(Model):
         # Run BioNetGen
         cmd = [self.bng_command, '%s.bngl' % file, '--outdir', folder]
         log_file = '%s.log' % file
+        if os.name == 'nt':  # Windows
+            # Explicitly call perl because the #! line in BNG2.pl is not supported.
+            cmd = ['perl'] + cmd
         with open(log_file, 'w') as lf:
             run(cmd, check=True, stderr=STDOUT, stdout=lf, timeout=timeout)
 

--- a/pybnf/pybnf.py
+++ b/pybnf/pybnf.py
@@ -9,7 +9,6 @@ from .pset import Trajectory
 import pybnf.algorithms as algs
 import pybnf.printing as printing
 
-from subprocess import run
 from numpy import inf
 
 import logging
@@ -373,9 +372,10 @@ def main():
         # (exists in directory where workers were instantiated)
         # Tries current and home directories
         if os.path.isdir('dask-worker-space'):
-            run(['rm', '-rf', 'dask-worker-space'])
-        if os.path.isdir(os.environ['HOME'] + '/dask-worker-space'):
-            run(['rm', '-rf', os.environ['HOME'] + '/dask-worker-space'])
+            shutil.rmtree('dask-worker-space')
+        home_dask_dir = os.path.expanduser(os.path.join('~', 'dask-worker-space'))
+        if os.path.isdir(home_dask_dir):
+            shutil.rmtree(home_dask_dir)
 
         # After any error, try to clean up.
         try:

--- a/tests/full_tests/run_all.py
+++ b/tests/full_tests/run_all.py
@@ -10,6 +10,8 @@ Run with the argument ssh to use PyBNF's automatic cluster setup with dask-ssh
 Run with the argument sf to use manual cluster setup, with a preconfigured dask cluster with scheduler file named sf
 Bash files are provided in this folder to run this script using the cluster options. 
 
+This test script is not Windows compatible due to extensive use of `grep`
+
 The output file test_summary.txt should be manually checked to confirm success of the tests. 
 The output can be compared to example_summary.txt, which is the result from running on commit e34ba3b (14 Mar 2019)
 shortly before the v1.0.0 release.


### PR DESCRIPTION
Add (partial?) support for Windows. 
Currently, examples/demo works for both BNGL and SBML, provided the path is set up correctly for both Perl and Python. Harder tasks are not tested. 

We still need a documented reproducible method to set up Perl and Python. 