### PR TITLE
Windows cleanup

### DIFF
--- a/pybnf/algorithms.py
+++ b/pybnf/algorithms.py
@@ -490,7 +490,10 @@ class Algorithm(object):
             self.failed_logs_dir = self.config.config['output_dir'] + '/FailedSimLogs-boot%s' % bootstrap
             for boot_dir in (self.sim_dir, self.res_dir, self.failed_logs_dir):
                 if os.path.exists(boot_dir):
-                    shutil.rmtree(boot_dir)
+                    try:
+                        shutil.rmtree(boot_dir)
+                    except OSError:
+                        logger.error('Failed to remove bootstrap directory '+boot_dir)
                 os.mkdir(boot_dir)
 
         self.best_fit_obj = None
@@ -985,7 +988,10 @@ class Algorithm(object):
         if (isinstance(self, SimplexAlgorithm) or self.config.config['refine'] != 1) and self.bootstrap_number is None:
             # End of fitting; delete unneeded files
             if self.config.config['delete_old_files'] >= 1:
-                shutil.rmtree(self.sim_dir)
+                try:
+                    shutil.rmtree(self.sim_dir)
+                except OSError:
+                    logger.error('Failed to remove simulations directory '+self.sim_dir)
 
         logger.info("Fitting complete")
 

--- a/pybnf/pybnf.py
+++ b/pybnf/pybnf.py
@@ -9,6 +9,7 @@ from .pset import Trajectory
 import pybnf.algorithms as algs
 import pybnf.printing as printing
 
+from subprocess import run
 from numpy import inf
 
 import logging
@@ -372,10 +373,16 @@ def main():
         # (exists in directory where workers were instantiated)
         # Tries current and home directories
         if os.path.isdir('dask-worker-space'):
-            shutil.rmtree('dask-worker-space', ignore_errors=True)
+            if os.name == 'nt':  # Windows
+                shutil.rmtree('dask-worker-space', ignore_errors=True)
+            else:
+                run(['rm', '-rf', 'dask-worker-space'])  # More likely to succeed than rmtree()
         home_dask_dir = os.path.expanduser(os.path.join('~', 'dask-worker-space'))
         if os.path.isdir(home_dask_dir):
-            shutil.rmtree(home_dask_dir, ignore_errors=True)
+            if os.name == 'nt':  # Windows
+                shutil.rmtree(home_dask_dir, ignore_errors=True)
+            else:
+                run(['rm', '-rf', home_dask_dir])
 
         # After any error, try to clean up.
         try:

--- a/pybnf/pybnf.py
+++ b/pybnf/pybnf.py
@@ -372,10 +372,10 @@ def main():
         # (exists in directory where workers were instantiated)
         # Tries current and home directories
         if os.path.isdir('dask-worker-space'):
-            shutil.rmtree('dask-worker-space')
+            shutil.rmtree('dask-worker-space', ignore_errors=True)
         home_dask_dir = os.path.expanduser(os.path.join('~', 'dask-worker-space'))
         if os.path.isdir(home_dask_dir):
-            shutil.rmtree(home_dask_dir)
+            shutil.rmtree(home_dask_dir, ignore_errors=True)
 
         # After any error, try to clean up.
         try:

--- a/tests/full_tests/run_all.py
+++ b/tests/full_tests/run_all.py
@@ -112,10 +112,15 @@ def run_test(name, folder, conffile, outstream, display_best=True):
     
     outstream.write('\nTest %s:\n' % name)
     
-    try:
-        proc = sp.run(['pybnf', '-c', '%s/%s' % (folder, conffile), '-l', name, '-o'],
-                      check=True, stdout=sp.PIPE, stderr=sp.PIPE, universal_newlines=True)
-    except sp.CalledProcessError:
+
+    proc = sp.run(['pybnf', '-c', '%s/%s' % (folder, conffile), '-l', name, '-o'],
+                  stdout=sp.PIPE, stderr=sp.PIPE, universal_newlines=True)
+    with open('%s_stdout.out' % name, 'w') as out:
+        out.write(proc.stdout)
+    with open('%s_stderr.out' % name, 'w') as out:
+        out.write(proc.stderr)
+
+    if proc.returncode != 0:
         outstream.write('Failed!\n')
         return
     
@@ -132,11 +137,6 @@ def run_test(name, folder, conffile, outstream, display_best=True):
         outstream.write('Failed to read run time!\n')
     else:
         outstream.write(grep.stdout)
-    
-    with open('%s_stdout.out' % name, 'w') as out:
-        out.write(proc.stdout)
-    with open('%s_stderr.out' % name, 'w') as out:
-        out.write(proc.stderr)
     
     outstream.write('Log has %s lines\n' % wc_summary('%s.log' % name))
     outstream.write('Stdout has %s lines\n' % wc_summary('%s_stdout.out' % name))


### PR DESCRIPTION
Fix new issues created by adding Windows support. 
In particular, switch back to using `rm -rf` instead of `shutil.rmtree()` on non-Windows systems.