### PR TITLE
patching a function that's causing a crash

### DIFF
--- a/pybnf/pset.py
+++ b/pybnf/pset.py
@@ -246,6 +246,7 @@ class BNGLModel(Model):
 
     def find_t_length(self):
         text_list = []
+        fileText = self.bngl_file_text.replace('\\\n', '')
         fileText = self.bngl_file_text.split('\n')
         timeDict = {}
         


### PR DESCRIPTION
Correcting the function that finds the time length to account for differing syntax styles found in the .bngl file