### PR TITLE
Fix NFsim path over-binding (issue #391)

### DIFF
--- a/tests/test_bngsim_nf_e2e.py
+++ b/tests/test_bngsim_nf_e2e.py
@@ -10,9 +10,10 @@ computable distribution via the chemical master equation -- see
 This complements the routing-and-stub coverage in ``test_bngsim_bridge.py``,
 which never actually runs an NF session.
 
-NOTE: the NFsim path currently over-binds by ~10% on this model (300-replicate
-mean ~55.3 vs the exact master-equation mean 50.08); see issue #391. The NFsim
-tests below are therefore ``xfail``. RuleMonkey reproduces the exact oracle.
+Both NFsim and RuleMonkey reproduce the exact master-equation oracle. (The
+NFsim path previously over-bound by ~10% because ``System::stepTo`` discarded
+the boundary-crossing reaction-time sample and re-sampled on the next output
+step; see issue #391, fixed by carrying the pending sample across calls.)
 """
 
 from pathlib import Path
@@ -134,11 +135,6 @@ def _assert_matches_master_equation(label, finals):
 
 
 @pytest.mark.bngsim_nfsim
-@pytest.mark.xfail(
-    reason='NFsim over-binds ~10% on this model (bound mean ~55.3 vs exact '
-           'master-equation 50.08); see issue #391',
-    strict=True,
-)
 def test_bngsim_nf_bimolecular_binding_matches_master_equation(tmp_path):
     """NFsim path: bound count at t_end should match the exact CME mean."""
     model = _nf_model('nf')
@@ -164,12 +160,6 @@ def test_bngsim_rm_bimolecular_binding_matches_master_equation(tmp_path):
 
 @pytest.mark.bngsim_nfsim
 @pytest.mark.bngsim_rulemonkey
-@pytest.mark.xfail(
-    reason='NFsim over-binds ~10% (issue #391), so it disagrees with the '
-           'correct RuleMonkey result. Non-strict: the two-sample test sits '
-           '~6 SE apart, so it occasionally passes by chance.',
-    strict=False,
-)
 def test_bngsim_nfsim_and_rm_agree_statistically(tmp_path):
     """NFsim and RuleMonkey simulate the same master equation and should
     agree on the bound-count distribution. Two-sample 5-SE test on the


### PR DESCRIPTION
## Summary

Fixes #391 — the NFsim execution path over-bound by ~10% (300-replicate `bound` mean ~55.3 vs the exact master-equation value 50.08), while RuleMonkey on the identical fixture was correct.

## Root cause

The bug is in bngsim's vendored NFsim, in `System::stepTo()` — the function bngsim's session API uses to drive NFsim across output steps. When the sampled inter-event time `delta_t` overshot the output time, `stepTo()` **discarded it** and the next call **re-sampled** a fresh `delta_t` from `current_time`, which is still *before* the previous stopping time.

That re-sample is biased: the next event can land inside the `[current_time, stoppingTime]` window already reported event-free, so each output step re-simulates that leftover interval and reactions over-fire — accumulating linearly with the number of output steps. This matches the issue's signature (correct at `t=1`, then drifting ~+0.6/step). It is a latent never-implemented cache (`invalidateStepToCache()` was a no-op), not a regression from #389.

The fix lives in the bngsim repo: `stepTo()` now carries the overshooting waiting time to the next call instead of discarding it. After the fix, NFsim `bound(10)` over 400 replicates is `50.21 ± 0.19` (exact: 50.08).

## Changes in this PR

- Remove the `xfail` markers from the two NFsim e2e tests in `tests/test_bngsim_nf_e2e.py`; both now reproduce the exact CME oracle.
- Update the module docstring.

Requires the companion bngsim fix (`System::stepTo` carry-over) to be present in the pinned bngsim build.

## Verification

`tests/test_bngsim_nf_e2e.py` — all 3 tests pass (NFsim, RuleMonkey, and NFsim-vs-RM agreement). `test_bngsim_bridge.py` + `test_stochastic_seed_policy.py` also pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)