### PR TITLE
Remove dask-internals coupling behind #388 (drop custom_as_completed)

### DIFF
--- a/pybnf/algorithms.py
+++ b/pybnf/algorithms.py
@@ -43,7 +43,7 @@ import traceback
 import pickle
 from scipy import stats
 from glob import glob
-from concurrent.futures._base import CancelledError
+from concurrent.futures import CancelledError
 
 
 
@@ -493,41 +493,42 @@ class HybridJobGroup(JobGroup):
         return Result(replica_results[0].pset, avedata, self.job_id)
 
 
-class custom_as_completed(as_completed):
+def result_from_completed(future, result, params, job_id):
     """
-    Subclass created to modify a section of dask.distributed code.
-    By using this subclass instead of as_completed, if a job raises an exception,
-    that exception is returned as the result (wrapped in a DaskError) instead of the
-    job disappearing or a raw (type, exc, traceback) tuple leaking into the caller.
+    Translate one completed item from
+    ``as_completed(futures, with_results=True, raise_errors=False)`` into a Result.
 
-    We override _get_and_raise -- the synchronous hook that __next__ uses to pull each
-    completed future off the queue -- rather than the result-collecting coroutine.
-    Older dask exposed that coroutine as ``track_future``; dask renamed and rewrote it
-    (``async def _track_future``), so the previous ``track_future`` override silently
-    stopped running and errored futures leaked through as bare tuples. See lanl/PyBNF#388.
-    """
-    def _get_and_raise(self):
-        res = self.queue.get()
-        if self.with_results:
-            future, result = res
-            if future.status == 'error':
-                # For an errored future, dask stores ``result`` as the worker's
-                # (type, exception, traceback) tuple. Wrap it in a DaskError so the
-                # caller sees a recognizable object instead of a bare tuple.
-                typ, exc, tb = result
-                res = (future, DaskError(exc, ''.join(traceback.format_exception(typ, exc, tb))))
-            elif future.status == 'cancelled':
-                res = (future, CancelledError(future.key))
-        return res
+    With those flags, dask hands back per future:
+      * the job's return value (a Result / FailedSimulation) for a finished job,
+      * the worker's ``(type, exception, traceback)`` tuple for an errored job, and
+      * a ``CancelledError`` for a cancelled job.
 
+    A failed job becomes a ``FailedSimulation`` so the run continues, except a
+    user-targeted ``PybnfError`` is re-raised (it would fail every job, so failing
+    fast is better than burning the whole fit). A ``CancelledError`` is returned
+    unchanged for the caller to treat as fatal, and anything unrecognized is treated
+    as a failed simulation rather than crashing the run.
 
-class DaskError:
+    ``Future.status`` is part of dask's public Future API, so this relies on no
+    dask internals. See lanl/PyBNF#388 for the history (the previous approach
+    subclassed as_completed and overrode a private method that dask later renamed).
     """
-    Class representing the result of a job that failed due to a raised exception
-    """
-    def __init__(self, error, tb):
-        self.error = error
-        self.traceback = tb
+    if getattr(future, 'status', None) == 'error':
+        typ, exc, tb = result
+        if isinstance(exc, PybnfError):
+            raise exc  # User-targeted error should be raised instead of skipped
+        logger.error('Job %s failed with an exception' % job_id)
+        logger.error(''.join(traceback.format_exception(typ, exc, tb)))
+        return FailedSimulation(params, job_id, 3)
+    if isinstance(result, CancelledError):
+        return result
+    if not isinstance(result, Result):
+        # e.g. a raw tuple leaking from as_completed for an errored future whose
+        # status we somehow didn't catch; never crash the run over it.
+        logger.error('Job %s returned an unexpected result of type %s; treating as a failed simulation'
+                     % (job_id, type(result).__name__))
+        return FailedSimulation(params, job_id, 3)
+    return result
 
 
 class Algorithm(object):
@@ -1344,7 +1345,7 @@ class Algorithm(object):
             f = client.submit(run_job, job, True, self.failed_logs_dir)
             futures.append(f)
             pending[f] = (job.params, job.job_id)
-        pool = custom_as_completed(futures, with_results=True, raise_errors=False)
+        pool = as_completed(futures, with_results=True, raise_errors=False)
         backed_up = True
         while True:
             if sim_count % backup_every == 0 and not backed_up:
@@ -1358,20 +1359,7 @@ class Algorithm(object):
                                'are out of bounds. Ending run.')
                 print1('Warning: job pool exhausted (all proposals may have been out of bounds). Ending run.')
                 break
-            if isinstance(res, DaskError):
-                if isinstance(res.error, PybnfError):
-                    raise res.error  # User-targeted error should be raised instead of skipped
-                logger.error('Job failed with an exception')
-                logger.error(res.traceback)
-                res = FailedSimulation(pending[f][0], pending[f][1], 3)
-            elif not isinstance(res, (Result, CancelledError)):
-                # Defensive: a completed job should yield a Result (or, on failure, a
-                # DaskError / CancelledError handled above). Anything else -- e.g. a raw
-                # (type, exc, traceback) tuple leaking from as_completed -- is treated as a
-                # failed simulation rather than crashing the whole run. See lanl/PyBNF#388.
-                logger.error('Job %s returned an unexpected result of type %s; treating as a failed simulation'
-                             % (pending[f][1], type(res).__name__))
-                res = FailedSimulation(pending[f][0], pending[f][1], 3)
+            res = result_from_completed(f, res, pending[f][0], pending[f][1])
             # Handle if this result is one of multiple instances for smoothing
             del pending[f]
             if self.config.config['smoothing'] > 1 or self.config.config['parallelize_models'] > 1:

--- a/tests/test_failed_sim_handling.py
+++ b/tests/test_failed_sim_handling.py
@@ -6,18 +6,20 @@ objective) so the run continues, rather than crashing the whole fit with
 ``AttributeError: 'tuple' object has no attribute 'score'``.
 
 The crash came from ``custom_as_completed`` silently no longer wrapping errored
-futures (dask renamed the coroutine it used to override), so an errored future
-leaked into the main loop as a raw ``(type, exc, traceback)`` tuple. These tests
-pin down both the wrapping behavior and the eval-failure -> FailedSimulation path.
+futures (dask renamed the private coroutine it used to override), so an errored
+future leaked into the main loop as a raw ``(type, exc, traceback)`` tuple. That
+subclass has been replaced by ``result_from_completed``, which translates the
+output of stock ``as_completed(with_results=True, raise_errors=False)`` using only
+dask's public Future API. These tests pin down that translation and the
+eval-failure -> FailedSimulation path.
 """
 
-import os
-import queue as queuemod
 import shutil
 import tempfile
 import types
 
 import numpy as np
+import pytest
 
 from .context import algorithms, data, pset, printing
 
@@ -38,59 +40,58 @@ def _make_data():
 
 
 class _FakeFuture:
-    def __init__(self, status, key='sim_1'):
+    """Minimal stand-in for a dask Future: result_from_completed only reads .status."""
+    def __init__(self, status):
         self.status = status
-        self.key = key
-
-
-def _bare_completed(with_results=True):
-    """A custom_as_completed instance with just the attributes _get_and_raise needs."""
-    ac = object.__new__(algorithms.custom_as_completed)
-    ac.with_results = with_results
-    ac.queue = queuemod.Queue()
-    return ac
 
 
 # ---------------------------------------------------------------------------
-# custom_as_completed._get_and_raise: the root-cause fix
+# result_from_completed: the root-cause fix
 # ---------------------------------------------------------------------------
 
-def test_errored_future_wrapped_in_daskerror():
-    """An errored future must surface as a DaskError, not a raw (typ, exc, tb) tuple."""
-    ac = _bare_completed()
-    fut = _FakeFuture('error')
-    exc = ValueError('boom')
-    ac.queue.put((fut, (ValueError, exc, exc.__traceback__)))
+def test_errored_future_becomes_failed_simulation():
+    """An errored future (raw (typ, exc, tb) tuple) must become a FailedSimulation."""
+    exc = RuntimeError('boom')
+    res = algorithms.result_from_completed(
+        _FakeFuture('error'), (RuntimeError, exc, exc.__traceback__), _make_pset(), 'sim_1')
 
-    out_fut, result = ac._get_and_raise()
-
-    assert out_fut is fut
-    assert isinstance(result, algorithms.DaskError)
-    assert result.error is exc
-    assert 'boom' in result.traceback
+    assert isinstance(res, algorithms.FailedSimulation)
+    assert res.fail_type == 3
 
 
-def test_cancelled_future_wrapped_in_cancellederror():
-    ac = _bare_completed()
-    fut = _FakeFuture('cancelled', key='sim_42')
-    ac.queue.put((fut, None))
+def test_errored_future_pybnferror_is_reraised():
+    """A user-targeted PybnfError should abort the run, not be silently penalized."""
+    exc = printing.PybnfError('bad config that would fail every job')
+    with pytest.raises(printing.PybnfError):
+        algorithms.result_from_completed(
+            _FakeFuture('error'), (printing.PybnfError, exc, exc.__traceback__),
+            _make_pset(), 'sim_1')
 
-    _out_fut, result = ac._get_and_raise()
 
-    assert isinstance(result, algorithms.CancelledError)
+def test_cancelled_future_returned_unchanged():
+    fut = _FakeFuture('cancelled')
+    ce = algorithms.CancelledError('sim_1')
+    res = algorithms.result_from_completed(fut, ce, _make_pset(), 'sim_1')
+
+    assert res is ce
 
 
-def test_successful_future_passes_through_unchanged():
-    ac = _bare_completed()
+def test_successful_result_passes_through_unchanged():
     fut = _FakeFuture('finished')
-    res = algorithms.Result(_make_pset(), {}, 'sim_1')
-    res.score = 1.23
-    ac.queue.put((fut, res))
+    result = algorithms.Result(_make_pset(), {}, 'sim_1')
+    result.score = 1.23
+    out = algorithms.result_from_completed(fut, result, _make_pset(), 'sim_1')
 
-    out_fut, result = ac._get_and_raise()
+    assert out is result
 
-    assert out_fut is fut
-    assert result is res
+
+def test_unexpected_result_type_becomes_failed_simulation():
+    """A bare tuple leaking through (the original #388 crash) is handled, not fatal."""
+    out = algorithms.result_from_completed(
+        _FakeFuture('finished'), ('a', 'bare', 'tuple'), _make_pset(), 'sim_1')
+
+    assert isinstance(out, algorithms.FailedSimulation)
+    assert out.fail_type == 3
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Removes the fragile dask-internals coupling that caused #388.

`custom_as_completed` subclassed dask's `as_completed` and reimplemented a **private** method (`track_future`) by copying its body, to wrap failed jobs in a `DaskError`. dask later renamed that method to `_track_future` (tornado→asyncio migration), so the override silently became dead code and errored futures leaked into the run loop as raw `(type, exc, traceback)` tuples — the root cause of #388.

dask already exposes the behavior we wanted as **public API**:
`as_completed(with_results=True, raise_errors=False)` yields each job's result, the worker's `(type, exc, traceback)` tuple for an errored future, or a `CancelledError` for a cancelled one.

## Changes

- **Delete** `custom_as_completed` and the now-orphaned `DaskError` class; use stock `as_completed` directly.
- **Add** `result_from_completed()`, a pure helper that translates a `(future, result)` pair into a `Result`/`FailedSimulation` using only the public `Future.status`. It re-raises a user-targeted `PybnfError`, penalizes other failures, and treats any unrecognized result as a failed simulation so the run never crashes on it.
- **Fix** a private import: `concurrent.futures._base.CancelledError` → `concurrent.futures.CancelledError` (verified identical class, and the same one dask raises).
- **Retarget** the #388 regression tests at `result_from_completed`.

## Behavior

Functionally unchanged from the #388 fix already on `master` — this is the structural cleanup so the bug can't recur via the same mechanism. The deliberate dask/distributed un-pinning (the larger debt this exposed) is tracked separately in #393.

## Testing

Full local suite: **530 passed** (BNG-backed). New unit tests cover errored-future → `FailedSimulation`, `PybnfError` re-raise, cancelled passthrough, success passthrough, and the bare-tuple defensive path.

Note: GitHub Actions is unavailable to us until June 1, so CI here reflects local runs only.

Refs #388. See #393 for follow-up.