### PR TITLE
CI: bump actions to Node 24 majors

### DIFF
--- a/.github/actions/setup-pybnf/action.yml
+++ b/.github/actions/setup-pybnf/action.yml
@@ -21,12 +21,12 @@ runs:
     # libpython3.10.so.1.0 on the loader path (3.12's does). setup-python's
     # Pythons are built --enable-shared with libpython discoverable, so
     # roadrunner imports on every matrix leg.
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       id: python
       with:
         python-version: ${{ inputs.python-version }}
 
-    - uses: astral-sh/setup-uv@v5
+    - uses: astral-sh/setup-uv@v7
       with:
         enable-cache: true
         # No uv.lock in this repo; key the cache on pyproject.toml so it can

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     name: slow recovery tests
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/setup-pybnf
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,9 +9,9 @@ jobs:
   ruff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
         python-version: ['3.10', '3.12']
     name: pytest (py${{ matrix.python-version }})
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/setup-pybnf
         with:


### PR DESCRIPTION
Routine follow-up to #395. GitHub force-migrates Node 20 actions to Node 24 on **2026-06-02** (Node 20 removed from runners 2026-09-16), which was flagged as an annotation on every CI run.

Bumps to the current majors (all Node 24):

- `actions/checkout@v4` → `v6` (lint, tests, integration)
- `actions/setup-python@v5` → `v6` (composite action)
- `astral-sh/setup-uv@v5` → `v8` (lint, composite action)

The `setup-uv` `enable-cache` / `cache-dependency-glob` inputs are unchanged in v8 (verified). CI on this PR validates the bumped actions before they reach `master`.