### PR TITLE
CI: run integration suite nightly (08:00 UTC)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -8,10 +8,14 @@ name: integration
 # wheel. They remain covered by the local pre-push hook (.pre-commit-config.yaml)
 # on a dev machine until bngsim ships Linux wheels.
 #
-# A nightly `schedule:` cron could be added here, but is intentionally omitted
-# pending a maintainer decision.
+# Runs nightly and on manual dispatch.
 on:
   workflow_dispatch:
+  schedule:
+    # 08:00 UTC daily. GitHub cron is fixed UTC (no DST), so this is ~02:00 in
+    # Denver during Mountain Daylight Time and ~01:00 during Mountain Standard
+    # Time -- middle of the night either way.
+    - cron: '0 8 * * *'
 
 jobs:
   slow:


### PR DESCRIPTION
Adds a `schedule:` trigger to `integration.yml` so the slow statistical-recovery tests run nightly against `master`, not only on manual dispatch.

- **When:** `0 8 * * *` — 08:00 UTC, ≈02:00 Denver in summer (MDT) / ≈01:00 in winter (MST). GitHub cron is fixed UTC, so it drifts an hour across the DST switch; either way it's the middle of the night.
- **What:** `pytest -m slow -n auto`, py3.12 only (the slow tests are pure-Python numerics; the per-PR `tests` job keeps the py3.10/py3.12 matrix).
- **Why:** fast tests already run on every push/PR; the slow tier only ran on manual dispatch, so it was the one likely to silently rot.
- `workflow_dispatch` is retained for ad-hoc runs.

Note: the nightly selects `-m slow`, so future integration tests should carry `@pytest.mark.slow` to be included.

Scheduled runs only fire from the default branch, so the cron activates once this merges; I'll manual-dispatch post-merge to confirm the workflow is still valid.