### PR TITLE
feat(results): ADR-0048 — labelled best-fit BNGL artifact + opt-in tfun data embedding

### DIFF
--- a/docs/adr/0048-end-of-run-best-fit-bngl-artifact-is-the-min-objective-point-labelled-by-family-data-embeds-as-sidecar-tfun.md
+++ b/docs/adr/0048-end-of-run-best-fit-bngl-artifact-is-the-min-objective-point-labelled-by-family-data-embeds-as-sidecar-tfun.md
@@ -1,0 +1,151 @@
+# The end-of-run best-fit BNGL artifact is the recorded min-objective point, labelled honestly by algorithm family; embedded data rides sidecar `.tfun` files (issue #423-adjacent)
+
+**Status: Accepted → implemented.** At the end of every successful new-era (`edition >= 2`)
+run, PyBNF writes one stable-named, self-documenting `Results/<model>_bestfit.bngl` per model:
+the original model with the winning parameter set wired in and a header comment that records the
+objective value and **labels the point honestly per algorithm family** (an optimizer's *best
+fit*; a sampler's *maximum-likelihood point*, which is **not** the MAP). When the opt-in
+`embed_best_fit_data` key is set, each observable's experimental data is additionally embedded as
+a named `tfun()` reference function backed by a sidecar `.tfun` file, so the artifact self-contains
+its comparison curves. Built in two phases on one branch (the bare labelled artifact first, the
+data layer second) so the param-substitution change stays reviewable on its own.
+
+## Context
+
+A finished run already deep-copies the best-fit pset into each model and writes a runnable BNGL
+(`Algorithm._copy_best_fit_sims` → `BNGLModel.save_all`, `pset.py`), so *pure parameter
+substitution into a `.bngl` is not new*. But that file is named for the **winning pset's run id**
+(`<model>_<best_name>.bngl`, e.g. `model_iter5run2.bngl`) — opaque, unstable across runs, and
+**silent about what the point means**. There is no objective value in the file and, critically,
+no statement of whether the parameters are a least-objective optimum or a posterior summary.
+
+That last point is a real trap. **`Trajectory.best_fit()` is the recorded minimum-objective
+point for every algorithm, samplers included.** The trajectory is fed `res.score` — the bare
+objective / negative-log-likelihood — by `Algorithm.add_to_trajectory` (`base.py`), and
+`best_fit()` returns `max(...)` over `-score`. For a Bayesian sampler (`am`, `mh`, `pt`, `dream`,
+`p_dream`) the prior is folded in **only** inside the sampler's `got_result`
+(`lnposterior = lnprior + lnlikelihood`) to drive the accept ratio; it is **never recorded against
+the pset**. So `best_fit()` for a sampler is the **maximum-likelihood (MLE)** point, **not** the
+MAP. The two coincide only under flat/box priors and diverge under the informative priors PyBNF
+supports (normal, one-/two-sided truncated — ADR-0020/0047). The true per-sample `lnposterior`
+*is* available (`Results/samples.txt`'s `Ln_probability` column), so a real MAP is recoverable —
+but it is a *different* pset than the min-objective one whose simulations were just copied to
+`Results/`.
+
+## The decision
+
+**Emit the recorded min-objective `best_fit()` pset — the same point already copied to
+`Results/` — and label it honestly per family, rather than computing a separate MAP.**
+
+- An **optimizer** artifact's header reads *best fit (minimum objective)*.
+- A **sampler** artifact's header reads *maximum-likelihood point (minimum recorded objective);
+  NOT the MAP — the prior is not folded into the recorded objective. For the posterior mode, take
+  the max `Ln_probability` row of `Results/samples.txt`.*
+
+This was chosen over (a) re-ranking the in-memory trajectory by `ln_prior(pset) − objective` to
+synthesize a MAP, and (b) reading the MAP from `samples.txt`. Both produce a *different* pset than
+the min-objective one whose gdat/scan outputs `_copy_best_fit_sims` already wrote to `Results/`, so
+the `.bngl` would no longer match its sibling simulation files — a quiet inconsistency worse than
+an honest label. The label is correct in every case; under flat priors MLE *is* the MAP, and under
+informative priors the header names exactly where the difference lives and where to find the mode.
+(The discriminator is `isinstance(self, BayesianAlgorithm)` — the family base every sampler
+already subclasses.)
+
+### Edition scope: new-era (`edition >= 2`) only
+
+The artifact is written **only** when the resolved edition is modern
+(`edition.is_modern(...)`, ADR-0031). New-era is where the stable-name/self-documenting surface
+belongs, and `edition >= 2` is the contract that assumes the bngsim backend (ADR-0034) the data
+layer's `.tfun` round-trip relies on. Legacy runs are byte-for-byte unaffected — they keep only
+the existing `<model>_<best_name>.bngl`. The artifact is unconditional within new-era (it is a
+strict, near-free improvement over a file already being written); only the *data embedding* below
+is opt-in.
+
+### The data-embedding contract: sidecar `.tfun` only, opt-in, time-indexed
+
+When `embed_best_fit_data = 1`, for each `(experiment, observable)` in the model's `exp_data` the
+run writes a sidecar `<model>_bestfit_tfun/<experiment>__<observable>.tfun` and a reference
+function `expt_<experiment>_<observable>() = tfun('<rel-path>', time)` injected into the model's
+`begin functions` block (merged into an existing block, or a new standalone block before
+`end model` / `begin actions`). The data is thereby in the model namespace as a comparison curve;
+wiring it into gdat output (an observable, a print) is deliberately left to the user, so the
+embedded artifact's *simulation semantics are unchanged*.
+
+**Sidecar `.tfun` is the only embedding form — the inline `tfun([t...],[y...],time)` array form is
+not used.** The task framing imagined an inline-vs-sidecar size threshold, but verification found
+the inline-array form is **neither exercised nor referenced anywhere** in PyBNF or its tests
+(`grep tfun(\[` finds only a docstring), while the file-ref form is the one the bngsim bridge test
+covers *and* the one the existing staging machinery (`_stage_and_rewrite_tfun_files`, `pset.py`)
+is built around. A sidecar-always rule needs no threshold, reuses the tested path, and keeps every
+embedded curve auditable as a plain two-column file. Each `.tfun` carries the required
+`# <indvar> <obs>` header and **strictly increasing** index column (the experimental rows are
+sorted by time and de-duplicated, keeping the first value at a repeated time); `_SD` columns and
+the independent-variable column are not embedded.
+
+Embedding is restricted to **time-indexed** experiments (`exp_data.indvar == 'time'`). A
+parameter-scan / dose-response experiment's independent variable is a swept parameter, not `time`,
+so a `tfun(file, time)` reference would misrepresent it; such experiments are skipped with a log
+note rather than embedded wrong (a future ADR can index a scan curve by its swept parameter).
+
+## Mechanics
+
+- **Hook.** `Algorithm._emit_best_fit_bngl(best_pset, best_name)` is called from `run()`'s tail
+  (`base.py`), after `_copy_best_fit_sims` / `_rerun_best_fit_to_save_data` and before
+  `_finalize_backup_pickle` / `_teardown_sim_dir`. It no-ops off new-era and off a missing best
+  fit, so it cannot perturb a legacy run or a run with no successful evaluation.
+- **Rendering reuses the ADR-0034 path.** Each model is `copy_with_param_set(best_pset)` then
+  `model_text()`; legacy `__FREE` injection and new-era bind-by-id overrides are already handled
+  there. Pre-existing `tfun` file refs in the source model are staged with the same
+  `_stage_and_rewrite_tfun_files` `save()` uses (run *before* the embedded refs are injected, since
+  the new sidecars live in `Results/`, not the source dir).
+- **Objective value** comes from `Trajectory.best_score()` (the recorded minimum).
+- **Config.** `embed_best_fit_data: int = 0` on `GlobalConfig` (and the `parse.py` int-coercion
+  list); a no-op in legacy and when unset.
+
+## Scope
+
+**In:**
+- A stable `Results/<model>_bestfit.bngl` per model for new-era runs, with a family-labelled
+  header carrying the objective value (Phase 1).
+- Opt-in `embed_best_fit_data` embedding each time-indexed observable's experimental data as a
+  sidecar `.tfun` + reference function (Phase 2).
+- Tests: the emitted BNGL re-parses into a `BNGLModel` with the same parameter namespace; the
+  header is family-correct (optimizer vs sampler); the edition gate and the no-best-fit/empty-
+  trajectory/non-BNGL no-ops hold; the sidecar `.tfun` content is byte-faithful to `exp_data`,
+  sorted/de-duplicated and strictly increasing; `_SD`/indvar columns and non-time experiments are
+  skipped; and (bngsim-gated, auto-skipped when absent) the real engine's table-function reader
+  accepts the exact generated `.tfun` via `add_table_function` — the embedded data round-tripping
+  into bngsim. (A full re-simulation of an *embedded* model would require regenerating its network
+  and is left to the recovery tier.)
+
+**Out (boundaries):**
+- A *true MAP* artifact (re-ranked by posterior, or read from `samples.txt`) — rejected above as
+  inconsistent with the copied min-objective simulations; the honest label points to the mode.
+- The inline `tfun([...],[...],time)` array form — unverified against the bngsim parser; sidecar
+  only.
+- Embedding **non-time-indexed** (parameter-scan / dose-response) data — skipped with a log note.
+- Wiring embedded curves into gdat output — left to the user; simulation semantics stay unchanged.
+- Legacy (`edition < 2`) runs — unchanged; the existing `<model>_<best_name>.bngl` is their only
+  best-fit file.
+
+## Boundaries (in code, each pointing here)
+
+- `pybnf/algorithms/base.py` — `_emit_best_fit_bngl` (the hook, the edition gate, the family
+  label), `_build_exp_data_tfuns` / `_inject_function_lines` (the Phase-2 data layer).
+- `pybnf/pset.py` — `BNGLModel.copy_with_param_set` / `model_text` (ADR-0034 rendering, reused),
+  `_stage_and_rewrite_tfun_files` (staging pre-existing refs).
+- `pybnf/config_schema.py` + `pybnf/parse.py` — `embed_best_fit_data` (the opt-in key).
+- `pybnf/edition.py` — `is_modern` / `resolve_edition` (the new-era gate).
+
+## Consequences
+
+- Every new-era run leaves a self-documenting, stable-named best-fit model alongside its
+  simulations — runnable, and unambiguous about whether it is an optimum or a likelihood summary.
+- The sampler MLE-vs-MAP trap is named *in the artifact itself*, with a pointer to the posterior
+  mode, rather than being silently mislabelled "best fit".
+- The data-embedding path reuses the one tested `tfun` form and the existing staging machinery, so
+  it adds no new file-format surface.
+- See ADR-0034 (bind-by-id rendering this reuses), ADR-0028 (the new-era experiment/exp_data
+  surface the data layer reads), ADR-0031 (the `edition` gate), ADR-0020/0047 (the informative
+  priors that make MLE ≠ MAP real). Relates to #423.
+</content>

--- a/docs/config_keys.rst
+++ b/docs/config_keys.rst
@@ -726,10 +726,19 @@ Output Options
   If 1, run an extra simulation at the end of fitting using the best-fit parameters, and save the best-fit .gdat and .scan files to the Results directory. 
   
   Default: 0
-  
+
   Example:
-  
+
     * ``save_best_data = 1``
+
+**embed_best_fit_data**
+  Opt-in, new-era (``edition = 2``) only. When 1, the end-of-run ``Results/<model>_bestfit.bngl`` artifact additionally embeds each time-indexed observable's experimental data as a sidecar ``.tfun`` reference function, so the saved model self-contains its comparison curves. A no-op in the legacy edition and when unset.
+
+  Default: 0
+
+  Example:
+
+    * ``embed_best_fit_data = 1``
 
 **verbosity**
   An integer value that specifies the amount of information output to the terminal.

--- a/pybnf/algorithms/base.py
+++ b/pybnf/algorithms/base.py
@@ -16,7 +16,8 @@ from .core import (
     result_from_completed,
 )
 from subprocess import run, CalledProcessError, TimeoutExpired, STDOUT
-from ..pset import PSet, Trajectory, BNGLModel, NetModel, run_subprocess
+from ..pset import PSet, Trajectory, BNGLModel, NetModel, run_subprocess, _stage_and_rewrite_tfun_files
+from .. import edition
 from ..bngsim_model import (
     BngsimModel,
     BngsimNfModel,
@@ -1159,6 +1160,7 @@ class Algorithm(ABC):
         best_pset = self.trajectory.best_fit()
         self._copy_best_fit_sims(best_pset, best_name)
         self._rerun_best_fit_to_save_data(best_pset)
+        self._emit_best_fit_bngl(best_pset, best_name)
         self._finalize_backup_pickle()
         self._teardown_sim_dir()
 
@@ -1243,6 +1245,179 @@ class Algorithm(ABC):
             for m in self.model_list:
                 if hasattr(m, 'save_files'):
                     m.save_files = False
+
+    def _emit_best_fit_bngl(self, best_pset, best_name):
+        """Write a stable-named, family-labelled best-fit BNGL per model (ADR-0048).
+
+        New-era (``edition >= 2``) only, and a no-op when there is no best fit (e.g.
+        every evaluation failed). For each BNGL model, render ``best_pset`` into a
+        runnable ``Results/<model>_bestfit.bngl`` prefaced by a header comment that
+        records the objective value and labels the point honestly per algorithm
+        family: an optimizer's *best fit (minimum objective)*; a Bayesian sampler's
+        *maximum-likelihood point* -- the recorded objective excludes the prior, so
+        it is NOT the MAP (see :meth:`_best_fit_header` and the ADR). When
+        ``embed_best_fit_data`` is set, each time-indexed observable's experimental
+        data is embedded as a sidecar ``.tfun`` reference function
+        (:meth:`_build_exp_data_tfuns`).
+
+        Reuses the ADR-0034 rendering path (``copy_with_param_set`` -> ``model_text``)
+        and the same ``_stage_and_rewrite_tfun_files`` staging ``save()`` uses, so a
+        legacy run is untouched (it never reaches here) and a model carrying its own
+        tfun file refs stays runnable. Split out of run()'s tail so it can be unit
+        tested without a dask client; per-model failures are logged, never fatal.
+        """
+        if not edition.is_modern(edition.resolve_edition(self.config.config.get('edition'))):
+            return
+        if best_pset is None:
+            return
+        try:
+            best_obj = self.trajectory.best_score()
+        except (ValueError, IndexError):
+            # Empty trajectory -> no best fit to emit.
+            return
+        header = self._best_fit_header(best_obj, best_name)
+        embed = bool(self.config.config.get('embed_best_fit_data'))
+        for m in self.config.models:
+            model = self.config.models[m]
+            if not isinstance(model, BNGLModel):
+                # Only BNGL models render to a .bngl artifact; SBML/analytical models
+                # carry non-BNGL text and are out of scope here.
+                continue
+            try:
+                self._write_one_best_fit_bngl(model, best_pset, header, embed)
+            except Exception:
+                logger.exception('Failed to write best-fit BNGL for model %s' % m)
+                print1('Could not write the best-fit BNGL artifact for model %s; see log.' % m)
+
+    def _best_fit_header(self, best_obj, best_name):
+        """The comment block prefacing a best-fit BNGL, labelled by family (ADR-0048).
+
+        Optimizers get *best fit*; Bayesian samplers get *maximum-likelihood point*
+        with an explicit note that the recorded objective omits the prior (so it is
+        not the MAP) and a pointer to ``samples.txt`` for the posterior mode. The
+        discriminator is the ``BayesianAlgorithm`` family base every sampler
+        subclasses, imported lazily here to avoid the base<-sampler import cycle.
+        """
+        from .samplers.base import BayesianAlgorithm
+        lines = [
+            '# Best-fit model emitted by PyBNF (ADR-0048).',
+            '# fit_type: %s' % self.config.config.get('fit_type', '?'),
+            '# Parameter set: %s' % best_name,
+            '# Objective (minimum recorded): %.10g' % best_obj,
+        ]
+        if isinstance(self, BayesianAlgorithm):
+            lines += [
+                '# Point: MAXIMUM-LIKELIHOOD (minimum recorded objective).',
+                '# NOTE: this is NOT the MAP. The recorded objective is the negative',
+                '#   log-likelihood only -- the prior is not folded in. For the',
+                '#   posterior mode (MAP), take the row with the largest Ln_probability',
+                '#   in Results/samples.txt.',
+            ]
+        else:
+            lines.append('# Point: BEST FIT (minimum objective).')
+        return '\n'.join(lines) + '\n'
+
+    def _write_one_best_fit_bngl(self, model, best_pset, header, embed):
+        """Render one BNGL model's best-fit artifact (+ optional embedded data) to Results/."""
+        to_save = model.copy_with_param_set(best_pset)
+        text = to_save.model_text()
+        # Stage any tfun file refs the *source* model already carries (as save() does),
+        # before injecting the embedded refs below -- those point at sidecars already in
+        # Results/, which staging (source_dir -> dest_dir) must not try to copy in.
+        text = _stage_and_rewrite_tfun_files(
+            text, os.path.dirname(model.file_path), self.res_dir)
+        if embed:
+            text = self._inject_function_lines(text, self._build_exp_data_tfuns(model))
+        out_path = str(Path(self.res_dir) / ('%s_bestfit.bngl' % to_save.name))
+        with open(out_path, 'w') as f:
+            f.write(header + text)
+        logger.info('Wrote best-fit BNGL artifact %s' % out_path)
+
+    def _build_exp_data_tfuns(self, model):
+        """Embed this model's experimental data as sidecar ``.tfun`` reference functions.
+
+        For each time-indexed experiment in ``self.exp_data[model.name]`` and each of
+        its observable columns (excluding the independent variable and ``_SD`` noise
+        columns), write a ``Results/<model>_bestfit_tfun/<exp>__<obs>.tfun`` sidecar --
+        a ``# time <fn>`` header over the experimental (time, value) rows, sorted and
+        de-duplicated to the strictly-increasing index ``tfun`` requires -- and return
+        a ``<fn>() = tfun('<rel-path>', time)`` function line per sidecar (ADR-0048).
+
+        Non-time-indexed experiments (parameter scan / dose-response, whose indvar is
+        a swept parameter) are skipped with a log note: a ``tfun(file, time)`` would
+        misrepresent them. Columns with fewer than two finite points are skipped
+        (``tfun`` needs at least two). Returns ``[]`` when nothing is embeddable.
+        """
+        func_lines = []
+        model_data = self.exp_data.get(model.name, {})
+        tfun_dir = Path(self.res_dir) / ('%s_bestfit_tfun' % model.name)
+        for suffix in sorted(model_data):
+            data = model_data[suffix]
+            if data.indvar != 'time':
+                logger.info('best-fit data embed: skipping non-time experiment %r '
+                            '(independent variable %r)' % (suffix, data.indvar))
+                continue
+            times = data[data.indvar]
+            for obs in sorted(data.cols, key=data.cols.get):
+                if obs == data.indvar or obs.endswith('_SD'):
+                    continue
+                pairs = self._clean_tfun_pairs(times, data[obs])
+                if len(pairs) < 2:
+                    continue
+                fn = self._sanitize_id('expt_%s_%s' % (suffix, obs))
+                rel = '%s_bestfit_tfun/%s.tfun' % (model.name, self._sanitize_id('%s__%s' % (suffix, obs)))
+                tfun_dir.mkdir(parents=True, exist_ok=True)
+                with open(Path(self.res_dir) / rel, 'w') as f:
+                    f.write('# time %s\n' % fn)
+                    for t, v in pairs:
+                        f.write('%.17g %.17g\n' % (t, v))
+                func_lines.append("%s() = tfun('%s', time)" % (fn, rel))
+        return func_lines
+
+    @staticmethod
+    def _clean_tfun_pairs(times, values):
+        """(time, value) pairs ready for a ``.tfun``: finite, sorted, strictly increasing.
+
+        Drops NaN/Inf in either column, sorts by time, and collapses repeated times to
+        the first value seen (``tfun`` requires a strictly increasing index)."""
+        pairs = []
+        seen = set()
+        for t, v in sorted(zip(times, values), key=lambda p: p[0]):
+            if not (np.isfinite(t) and np.isfinite(v)) or t in seen:
+                continue
+            seen.add(t)
+            pairs.append((float(t), float(v)))
+        return pairs
+
+    @staticmethod
+    def _sanitize_id(name):
+        """A safe BNGL identifier / filename stem: non-word chars -> ``_``, never
+        leading-digit (the ``expt_``/``<exp>__`` prefixes already guarantee this)."""
+        s = re.sub(r'\W', '_', str(name))
+        return s if re.match(r'[A-Za-z_]', s) else '_' + s
+
+    @staticmethod
+    def _inject_function_lines(text, func_lines):
+        """Insert ``func_lines`` into ``text``'s ``begin functions`` block (ADR-0048).
+
+        Merges into an existing ``functions`` block (before its ``end functions``);
+        otherwise opens a fresh ``begin functions ... end functions`` block before the
+        model's ``end model`` (or, lacking one, ``begin actions``). A no-op for an
+        empty ``func_lines``."""
+        if not func_lines:
+            return text
+        body = '\n'.join(func_lines)
+        end_fn = re.search(r'(?im)^[ \t]*end[ \t]+functions\b', text)
+        if end_fn and re.search(r'(?im)^[ \t]*begin[ \t]+functions\b', text):
+            i = end_fn.start()
+            return text[:i] + body + '\n' + text[i:]
+        block = 'begin functions\n' + body + '\nend functions\n'
+        anchor = (re.search(r'(?im)^[ \t]*end[ \t]+model\b', text)
+                  or re.search(r'(?im)^[ \t]*begin[ \t]+actions\b', text))
+        if anchor:
+            i = anchor.start()
+            return text[:i] + block + text[i:]
+        return text + '\n' + block
 
     def _finalize_backup_pickle(self):
         """Rename the periodic backup pickle to its 'finished' name on completion.

--- a/pybnf/config_schema.py
+++ b/pybnf/config_schema.py
@@ -217,6 +217,12 @@ class GlobalConfig(PyBNFConfigModel):
     stochastic_seed: str = 'auto'
     parallel_count: Optional[int] = None
     save_best_data: int = 0
+    # Opt-in (new-era only): also embed each time-indexed observable's experimental
+    # data into the end-of-run Results/<model>_bestfit.bngl artifact as sidecar
+    # .tfun reference functions, so the model self-contains its comparison curves
+    # (ADR-0048). A no-op in legacy (the artifact itself is edition >= 2 only) and
+    # when unset.
+    embed_best_fit_data: int = 0
     simulation_dir: Optional[str] = None
     parallelize_models: int = 1
     starting_params: Any = None

--- a/pybnf/parse.py
+++ b/pybnf/parse.py
@@ -31,7 +31,8 @@ numkeys_int = ['verbosity', 'parallel_count', 'delete_old_files', 'population_si
                'local_min_limit', 'reserve_size', 'burn_in', 'sample_every', 'output_hist_every',
                'hist_bins', 'refine', 'simplex_max_iterations', 'wall_time_sim', 'wall_time_gen', 'verbosity',
                'exchange_every', 'backup_every', 'bootstrap', 'crossover_number', 'ind_var_rounding',
-               'local_objective_eval', 'reps_per_beta', 'save_best_data', 'parallelize_models', 'adaptive', 'continue_run',
+               'local_objective_eval', 'reps_per_beta', 'save_best_data', 'embed_best_fit_data',
+               'parallelize_models', 'adaptive', 'continue_run',
                'delta', 'archive_size', 'archive_thin_rate', 'adaptive_step_size', 'powell_max_iterations',
                'max_failed_simulations', 'random_seed', 'sbml_ssa_strict', 'diagnostics_every', 'edition']
 numkeys_float = ['min_objective', 'cognitive', 'social', 'particle_weight',

--- a/tests/golden_configs/effective_config_golden.json
+++ b/tests/golden_configs/effective_config_golden.json
@@ -99,6 +99,10 @@
     null
    ],
    [
+    "embed_best_fit_data",
+    0
+   ],
+   [
     "exchange_every",
     [
      "$float",
@@ -479,6 +483,10 @@
    [
     "edition",
     null
+   ],
+   [
+    "embed_best_fit_data",
+    0
    ],
    [
     "exchange_every",
@@ -879,6 +887,10 @@
     null
    ],
    [
+    "embed_best_fit_data",
+    0
+   ],
+   [
     "exchange_every",
     [
      "$float",
@@ -1257,6 +1269,10 @@
    [
     "edition",
     null
+   ],
+   [
+    "embed_best_fit_data",
+    0
    ],
    [
     "exchange_every",
@@ -1751,6 +1767,10 @@
    [
     "edition",
     null
+   ],
+   [
+    "embed_best_fit_data",
+    0
    ],
    [
     "exchange_every",
@@ -2263,6 +2283,10 @@
     null
    ],
    [
+    "embed_best_fit_data",
+    0
+   ],
+   [
     "exchange_every",
     [
      "$float",
@@ -2761,6 +2785,10 @@
     null
    ],
    [
+    "embed_best_fit_data",
+    0
+   ],
+   [
     "exchange_every",
     [
      "$float",
@@ -3141,6 +3169,10 @@
    [
     "edition",
     null
+   ],
+   [
+    "embed_best_fit_data",
+    0
    ],
    [
     "exchange_every",
@@ -3541,6 +3573,10 @@
     null
    ],
    [
+    "embed_best_fit_data",
+    0
+   ],
+   [
     "exchange_every",
     [
      "$float",
@@ -3873,6 +3909,10 @@
     null
    ],
    [
+    "embed_best_fit_data",
+    0
+   ],
+   [
     "exp_data",
     [
      "$set",
@@ -4202,6 +4242,10 @@
     null
    ],
    [
+    "embed_best_fit_data",
+    0
+   ],
+   [
     "exchange_every",
     [
      "$float",
@@ -4506,6 +4550,10 @@
     null
    ],
    [
+    "embed_best_fit_data",
+    0
+   ],
+   [
     "exp_data",
     [
      "$set",
@@ -4737,6 +4785,10 @@
    [
     "edition",
     null
+   ],
+   [
+    "embed_best_fit_data",
+    0
    ],
    [
     "exp_data",
@@ -4992,6 +5044,10 @@
    [
     "edition",
     null
+   ],
+   [
+    "embed_best_fit_data",
+    0
    ],
    [
     "exp_data",
@@ -5268,6 +5324,10 @@
     null
    ],
    [
+    "embed_best_fit_data",
+    0
+   ],
+   [
     "exp_data",
     [
      "$set",
@@ -5539,6 +5599,10 @@
    [
     "edition",
     null
+   ],
+   [
+    "embed_best_fit_data",
+    0
    ],
    [
     "exp_data",
@@ -5836,6 +5900,10 @@
    [
     "edition",
     null
+   ],
+   [
+    "embed_best_fit_data",
+    0
    ],
    [
     "exp_data",
@@ -6167,6 +6235,10 @@
     null
    ],
    [
+    "embed_best_fit_data",
+    0
+   ],
+   [
     "exp_data",
     [
      "$set",
@@ -6462,6 +6534,10 @@
    [
     "edition",
     null
+   ],
+   [
+    "embed_best_fit_data",
+    0
    ],
    [
     "exp_data",
@@ -6813,6 +6889,10 @@
     null
    ],
    [
+    "embed_best_fit_data",
+    0
+   ],
+   [
     "exchange_every",
     [
      "$float",
@@ -7117,6 +7197,10 @@
     null
    ],
    [
+    "embed_best_fit_data",
+    0
+   ],
+   [
     "exp_data",
     [
      "$set",
@@ -7412,6 +7496,10 @@
    [
     "edition",
     null
+   ],
+   [
+    "embed_best_fit_data",
+    0
    ],
    [
     "exp_data",
@@ -7711,6 +7799,10 @@
     null
    ],
    [
+    "embed_best_fit_data",
+    0
+   ],
+   [
     "exp_data",
     [
      "$set",
@@ -8008,6 +8100,10 @@
     null
    ],
    [
+    "embed_best_fit_data",
+    0
+   ],
+   [
     "exp_data",
     [
      "$set",
@@ -8299,6 +8395,10 @@
    [
     "edition",
     null
+   ],
+   [
+    "embed_best_fit_data",
+    0
    ],
    [
     "exp_data",
@@ -8600,6 +8700,10 @@
    [
     "edition",
     null
+   ],
+   [
+    "embed_best_fit_data",
+    0
    ],
    [
     "exp_data",
@@ -8926,6 +9030,10 @@
    [
     "edition",
     null
+   ],
+   [
+    "embed_best_fit_data",
+    0
    ],
    [
     "exchange_every",
@@ -9264,6 +9372,10 @@
     null
    ],
    [
+    "embed_best_fit_data",
+    0
+   ],
+   [
     "exchange_every",
     20
    ],
@@ -9575,6 +9687,10 @@
     null
    ],
    [
+    "embed_best_fit_data",
+    0
+   ],
+   [
     "exp_data",
     [
      "$set",
@@ -9846,6 +9962,10 @@
    [
     "edition",
     null
+   ],
+   [
+    "embed_best_fit_data",
+    0
    ],
    [
     "exp_data",
@@ -10136,6 +10256,10 @@
    [
     "edition",
     null
+   ],
+   [
+    "embed_best_fit_data",
+    0
    ],
    [
     "exp_data",

--- a/tests/test_benchmark_harness.py
+++ b/tests/test_benchmark_harness.py
@@ -46,13 +46,15 @@ import run_benchmark as rb  # noqa: E402  (path-dependent import of the harness 
 # (#424/ADR-0031; the modern objective-surface keys, both defaulting to None == the
 # legacy objfunc surface), and job_type (#423/ADR-0028; the modern run-selector key,
 # defaulting to None -- these legacy confs name the run with fit_type, so job_type is
-# a no-op here). These always carry no-op defaults here, so excluding them keeps the
-# oracle an independent *pre-migration* witness without regenerating it for keys the
-# original confs could not have carried.
+# a no-op here), and embed_best_fit_data (#423/ADR-0048; defaults to 0 == off -- the
+# end-of-run best-fit-BNGL data embedding is edition-2-only and opt-in, so these legacy
+# sampler confs never carried it). These always carry no-op defaults here, so excluding
+# them keeps the oracle an independent *pre-migration* witness without regenerating it
+# for keys the original confs could not have carried.
 _EXCLUDE = frozenset({
     'bng_command', 'output_dir', 'refine_method', 'noise_location',
     'initialization_distribution', 'edition', 'objective', 'profile_objective',
-    'job_type',
+    'job_type', 'embed_best_fit_data',
 })
 
 

--- a/tests/test_best_fit_bngl.py
+++ b/tests/test_best_fit_bngl.py
@@ -1,0 +1,275 @@
+"""End-of-run best-fit BNGL artifact (ADR-0048).
+
+``Algorithm._emit_best_fit_bngl`` writes a stable-named, family-labelled
+``Results/<model>_bestfit.bngl`` for new-era (``edition >= 2``) runs, optionally
+embedding each time-indexed observable's experimental data as a sidecar ``.tfun``
+reference function. The hook was split out of ``run()``'s tail so it is unit
+testable with no dask client (mirrors ``tests/test_run_loop.py``): build a bare
+``Algorithm`` instance carrying only the attributes the method reads
+(``config.models`` / ``config.config`` / ``res_dir`` / ``trajectory`` /
+``exp_data``), call the method, and assert on the real files under ``tmp_path``.
+
+The model fixture is ``bngl_files/e2e_ode_decay.bngl`` -- a new-era *bind-by-id*
+model (params ``S0``/``k``, observable ``Stot``; ADR-0034), so the artifact also
+exercises the bind-by-id rendering path. One ``@pytest.mark.bngsim`` test feeds
+the generated ``.tfun`` to the real engine (auto-skipped when bngsim is absent).
+"""
+
+import logging
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from .context import algorithms, pset, data
+from pybnf.pset import Trajectory, BNGLModel
+from pybnf.algorithms.samplers.base import BayesianAlgorithm
+
+
+DECAY = 'bngl_files/e2e_ode_decay.bngl'
+ARTIFACT = 'e2e_ode_decay_bestfit.bngl'
+TFUN_DIR = 'e2e_ode_decay_bestfit_tfun'
+
+
+class _Opt(algorithms.Algorithm):
+    """Concrete non-Bayesian Algorithm (start_run/got_result are abstract)."""
+    def start_run(self):
+        return []
+
+    def got_result(self, res):
+        return []
+
+
+class _Bayes(BayesianAlgorithm):
+    """Concrete Bayesian Algorithm -- only isinstance(...) matters for the label."""
+    def start_run(self):
+        return []
+
+    def got_result(self, res):
+        return []
+
+
+def _decay_model():
+    return BNGLModel(DECAY, suppress_free_param_error=True)
+
+
+def _decay_pset(k=0.5, S0=42.0):
+    return pset.PSet([pset.FreeParameter('k', 'uniform_var', 0, 10, value=k),
+                      pset.FreeParameter('S0', 'uniform_var', 0, 200, value=S0)])
+
+
+def _exp(headers, rows, indvar='time'):
+    return data.Data.from_columns(np.array(rows, dtype=float), headers, indvar=indvar)
+
+
+def _decay_exp(rows=((0, 100), (2, 55), (5, 22.3), (10, 5))):
+    return {'e2e_ode_decay': {'tc': _exp(['time', 'Stot'], list(rows))}}
+
+
+def _algo(tmp_path, *, edition=2, fit_type='de', embed=0, exp_data=None,
+          bayesian=False, obj=12.5, models=None):
+    """A bare Algorithm carrying only what _emit_best_fit_bngl reads."""
+    res_dir = str(tmp_path / 'Results')
+    os.makedirs(res_dir, exist_ok=True)
+    algo = object.__new__(_Bayes if bayesian else _Opt)
+    cfg = type('Cfg', (), {})()
+    cfg.config = {'edition': edition, 'fit_type': fit_type, 'embed_best_fit_data': embed}
+    cfg.models = {'e2e_ode_decay': _decay_model()} if models is None else models
+    algo.config = cfg
+    algo.res_dir = res_dir
+    algo.exp_data = exp_data or {}
+    best = _decay_pset()
+    traj = Trajectory(100)
+    traj.add(best, obj, 'iter5run0')
+    algo.trajectory = traj
+    return algo, best
+
+
+def _artifact_text(algo):
+    return (Path(algo.res_dir) / ARTIFACT).read_text()
+
+
+# --------------------------------------------------------------------------- #
+# Phase 1: the bare, labelled artifact
+# --------------------------------------------------------------------------- #
+class TestBareArtifact:
+
+    def test_emits_stable_named_runnable_bngl(self, tmp_path):
+        """A new-era run writes Results/<model>_bestfit.bngl with the fit values wired
+        in (ADR-0034 bind-by-id) and re-parses back into the same parameter namespace."""
+        algo, best = _algo(tmp_path)
+        algo._emit_best_fit_bngl(best, 'iter5run0')
+
+        out = Path(algo.res_dir) / ARTIFACT
+        assert out.is_file()
+        text = out.read_text()
+        assert '\nk 0.5\n' in text and '\nS0 42.0\n' in text   # fit values applied
+        assert '0.3' not in text and ' 100\n' not in text       # nominal values gone
+
+        reparsed = BNGLModel(str(out), suppress_free_param_error=True)
+        assert set(reparsed.model_param_names) == {'S0', 'k'}
+
+    def test_optimizer_header_labels_best_fit(self, tmp_path):
+        algo, best = _algo(tmp_path, fit_type='de', obj=3.25)
+        algo._emit_best_fit_bngl(best, 'iter5run0')
+
+        text = _artifact_text(algo)
+        assert '# Point: BEST FIT (minimum objective).' in text
+        assert '# fit_type: de' in text
+        assert 'Objective (minimum recorded): 3.25' in text
+        assert 'MAXIMUM-LIKELIHOOD' not in text and 'samples.txt' not in text
+
+    def test_sampler_header_labels_max_likelihood_not_map(self, tmp_path):
+        """A sampler's best_fit() is the MLE, not the MAP -- the header must say so and
+        point at samples.txt for the posterior mode (the core ADR-0048 decision)."""
+        algo, best = _algo(tmp_path, fit_type='am', bayesian=True)
+        algo._emit_best_fit_bngl(best, 'iter5run0')
+
+        text = _artifact_text(algo)
+        assert 'MAXIMUM-LIKELIHOOD' in text
+        assert 'NOT the MAP' in text
+        assert 'Results/samples.txt' in text
+        assert '# Point: BEST FIT' not in text
+
+    @pytest.mark.parametrize('ed', [None, 1])
+    def test_legacy_edition_emits_nothing(self, tmp_path, ed):
+        """Edition-2-only: a legacy run is untouched (it keeps only its existing
+        <model>_<best_name>.bngl, written elsewhere)."""
+        algo, best = _algo(tmp_path, edition=ed)
+        algo._emit_best_fit_bngl(best, 'iter5run0')
+        assert not list(Path(algo.res_dir).glob('*_bestfit.bngl'))
+
+    def test_no_best_pset_is_noop(self, tmp_path):
+        algo, _ = _algo(tmp_path)
+        algo._emit_best_fit_bngl(None, 'iter5run0')
+        assert not list(Path(algo.res_dir).glob('*_bestfit.bngl'))
+
+    def test_empty_trajectory_is_noop(self, tmp_path):
+        """No successful evaluation -> empty trajectory -> nothing emitted, no crash."""
+        algo, best = _algo(tmp_path)
+        algo.trajectory = Trajectory(100)
+        algo._emit_best_fit_bngl(best, 'iter5run0')
+        assert not list(Path(algo.res_dir).glob('*_bestfit.bngl'))
+
+    def test_non_bngl_model_skipped(self, tmp_path):
+        """SBML/analytical models carry non-BNGL text and are out of scope."""
+        not_bngl = type('NotBngl', (), {'name': 'sbmlmod'})()
+        algo, best = _algo(tmp_path, models={'sbmlmod': not_bngl})
+        algo._emit_best_fit_bngl(best, 'iter5run0')
+        assert not list(Path(algo.res_dir).glob('*_bestfit.bngl'))
+
+
+# --------------------------------------------------------------------------- #
+# Phase 2: embedded experimental data as sidecar .tfun reference functions
+# --------------------------------------------------------------------------- #
+class TestDataEmbedding:
+
+    def test_writes_sidecar_and_injects_function(self, tmp_path):
+        algo, best = _algo(tmp_path, embed=1, exp_data=_decay_exp())
+        algo._emit_best_fit_bngl(best, 'iter5run0')
+
+        text = _artifact_text(algo)
+        assert "expt_tc_Stot() = tfun('%s/tc__Stot.tfun', time)" % TFUN_DIR in text
+        assert 'begin functions' in text and 'end functions' in text
+
+        sidecar = Path(algo.res_dir) / TFUN_DIR / 'tc__Stot.tfun'
+        assert sidecar.is_file()
+        assert sidecar.read_text().splitlines()[0] == '# time expt_tc_Stot'
+
+    def test_sidecar_data_roundtrips_strictly_increasing(self, tmp_path):
+        algo, best = _algo(tmp_path, embed=1, exp_data=_decay_exp())
+        algo._emit_best_fit_bngl(best, 'iter5run0')
+
+        arr = np.loadtxt(Path(algo.res_dir) / TFUN_DIR / 'tc__Stot.tfun')
+        np.testing.assert_array_equal(arr[:, 0], [0, 2, 5, 10])
+        np.testing.assert_allclose(arr[:, 1], [100, 55, 22.3, 5])
+        assert np.all(np.diff(arr[:, 0]) > 0)
+
+    def test_sorts_and_dedupes_repeated_times(self, tmp_path):
+        """Unsorted rows with a repeated time become a strictly-increasing index,
+        keeping the first value seen at the repeated time (tfun's requirement)."""
+        exp = {'e2e_ode_decay': {'tc': _exp(
+            ['time', 'Stot'], [[5, 22], [0, 100], [2, 55], [2, 999], [10, 5]])}}
+        algo, best = _algo(tmp_path, embed=1, exp_data=exp)
+        algo._emit_best_fit_bngl(best, 'iter5run0')
+
+        arr = np.loadtxt(Path(algo.res_dir) / TFUN_DIR / 'tc__Stot.tfun')
+        np.testing.assert_array_equal(arr[:, 0], [0, 2, 5, 10])
+        np.testing.assert_array_equal(arr[:, 1], [100, 55, 22, 5])  # first value at t=2
+
+    def test_skips_indvar_and_sd_columns(self, tmp_path):
+        exp = {'e2e_ode_decay': {'tc': _exp(
+            ['time', 'Stot', 'Stot_SD'], [[0, 100, 1], [2, 55, 2], [5, 22, 3]])}}
+        algo, best = _algo(tmp_path, embed=1, exp_data=exp)
+        algo._emit_best_fit_bngl(best, 'iter5run0')
+
+        names = sorted(p.name for p in (Path(algo.res_dir) / TFUN_DIR).iterdir())
+        assert names == ['tc__Stot.tfun']  # no time, no Stot_SD
+
+    def test_skips_non_time_experiment(self, tmp_path, caplog):
+        """A parameter-scan experiment's indvar is a swept parameter, not time, so a
+        tfun(file, time) would misrepresent it -- skip with a log note."""
+        exp = {'e2e_ode_decay': {'dose': _exp(
+            ['dose', 'Stot'], [[0, 1], [1, 2], [2, 3]], indvar='dose')}}
+        algo, best = _algo(tmp_path, embed=1, exp_data=exp)
+        with caplog.at_level(logging.INFO, logger='pybnf.algorithms'):
+            algo._emit_best_fit_bngl(best, 'iter5run0')
+
+        assert 'tfun(' not in _artifact_text(algo)
+        assert not (Path(algo.res_dir) / TFUN_DIR).exists()
+        assert 'non-time' in caplog.text.lower()
+
+    def test_off_by_default(self, tmp_path):
+        algo, best = _algo(tmp_path, embed=0, exp_data=_decay_exp())
+        algo._emit_best_fit_bngl(best, 'iter5run0')
+
+        assert 'tfun(' not in _artifact_text(algo)
+        assert not (Path(algo.res_dir) / TFUN_DIR).exists()
+
+
+# --------------------------------------------------------------------------- #
+# Pure helpers (no filesystem, no engine)
+# --------------------------------------------------------------------------- #
+class TestPureHelpers:
+
+    def test_inject_opens_standalone_block_before_end_model(self):
+        t = 'begin model\nbegin parameters\nend parameters\nend model\nbegin actions\nend actions\n'
+        out = algorithms.Algorithm._inject_function_lines(t, ["f() = tfun('a', time)"])
+        assert "begin functions\nf() = tfun('a', time)\nend functions\n" in out
+        assert out.index('begin functions') < out.index('end model')
+
+    def test_inject_merges_into_existing_block(self):
+        t = 'begin functions\n  g()=1\nend functions\n'
+        out = algorithms.Algorithm._inject_function_lines(t, ["f() = tfun('a', time)"])
+        assert out.count('begin functions') == 1 and out.count('end functions') == 1
+        assert out.index('g()=1') < out.index('f() = tfun') < out.index('end functions')
+
+    def test_inject_empty_is_noop(self):
+        assert algorithms.Algorithm._inject_function_lines('x', []) == 'x'
+
+    def test_clean_pairs_drops_nonfinite_sorts_dedupes(self):
+        pairs = algorithms.Algorithm._clean_tfun_pairs(
+            [0, 2, 2, 1, np.nan, 3], [10, 20, 99, 15, 5, np.inf])
+        assert pairs == [(0., 10.), (1., 15.), (2., 20.)]
+
+    def test_sanitize_id(self):
+        assert algorithms.Algorithm._sanitize_id('a b/c') == 'a_b_c'
+        assert algorithms.Algorithm._sanitize_id('1x') == '_1x'
+
+
+# --------------------------------------------------------------------------- #
+# Real engine: the generated .tfun loads into bngsim (auto-skipped if absent)
+# --------------------------------------------------------------------------- #
+@pytest.mark.bngsim
+def test_generated_tfun_loads_into_real_bngsim_engine(tmp_path):
+    """The exact sidecar this feature writes is accepted by the real bngsim table-
+    function reader -- the embedded data round-trips into the engine (ADR-0048)."""
+    from pybnf.bngsim_model import _runtime
+
+    algo, best = _algo(tmp_path, embed=1, exp_data=_decay_exp())
+    algo._emit_best_fit_bngl(best, 'iter5run0')
+    sidecar = Path(algo.res_dir) / TFUN_DIR / 'tc__Stot.tfun'
+
+    engine = _runtime.bngsim.Model.from_net('tests/bngl_files/e2e_ode_decay.net')
+    engine.add_table_function('expt_tc_Stot', file=str(sidecar), index='time', method='linear')


### PR DESCRIPTION
## What

At the end of each successful **new-era (`edition >= 2`)** run, PyBNF now writes a stable-named, self-documenting `Results/<model>_bestfit.bngl` per BNGL model — the model with the winning parameter set wired in (reusing the ADR-0034 bind-by-id render path) plus a header comment that records the objective value and **labels the point honestly per algorithm family**. Opt-in `embed_best_fit_data` additionally embeds each observable's experimental data as a sidecar `.tfun` comparison curve.

See **ADR-0048** in this PR for the full decision record.

## The key decision: MLE ≠ MAP, labelled honestly

`Trajectory.best_fit()` is the recorded **minimum-objective** pset for *every* algorithm, samplers included: the trajectory stores the bare objective (NLL); a sampler's prior is folded into its acceptance ratio only and is **never recorded against the pset**. So a sampler's `best_fit()` is the **maximum-likelihood** point, **not the MAP**. Rather than synthesize a MAP (which would mismatch the min-objective gdat already copied to `Results/`), the artifact emits the min-objective point and the header says exactly what it is — pointing at `Results/samples.txt` for the posterior mode.

## Scope

- Edition-2 only; legacy runs unchanged (they keep only the existing `<model>_<best_name>.bngl` — the new artifact is **additive**).
- Hook in `run()`'s tail; no-ops off legacy edition / no best fit / non-BNGL models.
- Data embedding is **sidecar `.tfun` only** (the inline `tfun([...],[...],time)` array form is unused/untested in-tree); skips `_SD`/independent-variable columns and non-time experiments; rows sorted + de-duplicated to the strictly-increasing index `tfun` requires.

## Tests

`tests/test_best_fit_bngl.py` (20 tests): stable name + bind-by-id re-parse, family-correct header (optimizer vs sampler), edition gate + no-op guards, sidecar byte-fidelity / sort / dedup, `_SD`/indvar/non-time skips, embed-off default, pure helpers, and a `@pytest.mark.bngsim` round trip that the real engine accepts the generated `.tfun` via `add_table_function`. Verified end-to-end on the `parabola_v2` demo (artifact + `par1__x/y.tfun` sidecars match `par1.exp`).

Adds the run-level `embed_best_fit_data` key (GlobalConfig + `parse.py`, documented in `config_keys.rst`); regenerates the effective-config golden (purely additive — the key, default `0`, joins every fit) and excludes it from the pre-migration benchmark oracle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)