### PR TITLE
fix(petab): preserve generate_network caps on PEtab v2 export (#485)

### DIFF
--- a/pybnf/petab/export.py
+++ b/pybnf/petab/export.py
@@ -1445,17 +1445,55 @@ def _read_model(model_file, path, language):
 # Emitting the PEtab-clean model and problem.yaml
 # ---------------------------------------------------------------------------
 
+# The ``begin actions`` ... ``end actions`` block, capturing its inner body. PEtab drives
+# simulation from the measurement times / experiments, so the *simulation* actions are
+# dropped -- but ``generate_network`` is a network-definition / compilation directive, not a
+# simulation action, and it carries the finiteness cap (``max_stoich`` / ``max_agg`` /
+# ``max_iter``) that keeps a rule-based network finite (#485). See _strip_simulation_actions.
+_ACTIONS_BLOCK = re.compile(
+    r'^[ \t]*begin\s+actions\b[^\n]*\n(?P<body>.*?)^[ \t]*end\s+actions\b[^\n]*\n?',
+    flags=re.S | re.I | re.M)
+# A ``generate_network`` action line (the directive we keep). Anchored past leading indent so
+# a commented-out ``# generate_network(...)`` line does not match (it is documentation, not a
+# live directive), consistent with pset.py's ``BNGLModel`` scanner (#473).
+_GENERATE_NETWORK_LINE = re.compile(r'^[ \t]*generate_network\b', flags=re.I)
+
+
+def _strip_simulation_actions(match):
+    """Rewrite one matched ``begin actions`` block, keeping only its network-definition
+    directives (``generate_network``, which carries the model's finiteness cap -- #485) and
+    dropping the simulation actions (``simulate*`` / ``parameter_scan`` / ``bifurcate`` / ...).
+
+    Returns the empty string when nothing survives, so a simulation-only block disappears
+    exactly as the whole-block strip did before. A kept line is emitted verbatim (its cap
+    args intact) inside a minimal, column-0 ``begin actions`` / ``end actions`` wrapper.
+    """
+    kept = [line for line in match.group('body').splitlines()
+            if _GENERATE_NETWORK_LINE.match(line)]
+    if not kept:
+        return ''
+    return 'begin actions\n' + '\n'.join(kept) + '\nend actions\n'
+
+
 def clean_model_for_petab(text):
-    """Return a PEtab-clean copy of a BNGL model: the ``begin actions`` block stripped.
+    """Return a PEtab-clean copy of a BNGL model: the ``begin actions`` block reduced to its
+    network-definition directives (``generate_network``), its simulation actions dropped.
 
     New-era BNGL binds free parameters **by id** (ADR-0034), so the source model already
     carries bare parameter ids with real nominal values -- exactly what PEtab estimates.
-    "PEtab-clean" therefore collapses to dropping the ``begin actions`` block (PEtab
-    drives simulation via the measurement times / experiments, not the model's own
-    actions); the reaction network and the ``begin functions`` block -- which carry the
-    measurement model -- are carried verbatim. A fit-and-mutated parameter keeps its model
-    name (``v1``) here as a plain nominal-valued parameter (always overridden by its
-    Condition); only the parameter *table* carries the surrogate ``v1__REF`` (ADR-0027).
+    "PEtab-clean" therefore drops the *simulation* actions (PEtab drives simulation via the
+    measurement times / experiments, not the model's own ``simulate`` calls) while keeping
+    ``generate_network`` -- a network-definition / compilation directive, not a simulation
+    action. That directive carries the model's finiteness cap (``max_stoich`` / ``max_agg`` /
+    ``max_iter``); dropping it would silently turn a model that is finite only under the cap
+    into one that network-generates unbounded, with no error or warning (#485). The exported
+    model then carries its own cap, so ``import_.py`` (which copies the model byte-verbatim)
+    round-trips it for free and any BNG2.pl / PyBNF consumer stays finite; a simulation-only
+    block (no ``generate_network`` line) still disappears entirely. The reaction network and
+    the ``begin functions`` block -- which carry the measurement model -- are carried verbatim.
+    A fit-and-mutated parameter keeps its model name (``v1``) here as a plain nominal-valued
+    parameter (always overridden by its Condition); only the parameter *table* carries the
+    surrogate ``v1__REF`` (ADR-0027).
 
     A legacy ``<name>__FREE`` marker in the model **code** is **rejected**: new-era binds by
     id, so a model still carrying one was not modernized, and shipping it would dangle an
@@ -1471,8 +1509,7 @@ def clean_model_for_petab(text):
             "new-era feature where free parameters bind by id (ADR-0034). Declare the "
             "model's fit parameters as bare ids with nominal values (e.g. 'v1 0.5', not "
             "'v1 v1__FREE') and list them as free parameters in the .conf.")
-    return re.sub(r'^[ \t]*begin\s+actions\b.*?^[ \t]*end\s+actions\b[^\n]*\n?',
-                  '', text, flags=re.S | re.I | re.M)
+    return _ACTIONS_BLOCK.sub(_strip_simulation_actions, text)
 
 
 def write_problem_yaml(path, models, has_conditions=False, has_experiments=False,

--- a/tests/test_petab_export.py
+++ b/tests/test_petab_export.py
@@ -1732,6 +1732,42 @@ class TestCleanModelUnit:
         with pytest.raises(PybnfError, match='__FREE'):
             clean_model_for_petab(src)
 
+    def test_generate_network_cap_survives_actions_strip(self):
+        # #485: generate_network is a network-definition directive, not a simulation action.
+        # Its finiteness cap (max_stoich / max_agg / max_iter) is what keeps a rule-based
+        # network finite, so the cleaner keeps the directive verbatim while dropping the
+        # simulate action (PEtab drives simulation from the measurement times instead).
+        src = (
+            "begin model\n begin parameters\n  k1 3\n end parameters\nend model\n\n"
+            "begin actions\n"
+            "  generate_network({overwrite=>1,max_stoich=>{EGF=>4,EGFR=>4}})\n"
+            '  simulate({method=>"ode",t_end=>2})\n'
+            "end actions\n")
+        out = clean_model_for_petab(src)
+        assert 'generate_network({overwrite=>1,max_stoich=>{EGF=>4,EGFR=>4}})' in out
+        assert 'max_stoich' in out                        # the cap itself, verbatim
+        assert 'simulate' not in out                      # the simulation action is dropped
+        assert 'k1 3' in out                              # the model body is untouched
+        # Idempotent: re-cleaning an already-clean model keeps the cap unchanged.
+        assert clean_model_for_petab(out) == out
+
+    def test_simulation_only_actions_block_fully_dropped(self):
+        # A block with no generate_network line (simulation-only) disappears entirely, exactly
+        # as the whole-block strip did before -- no network-definition directive to keep.
+        src = ("begin model\nend model\n\nbegin actions\n"
+               " simulate({})\n parameter_scan({})\nend actions\n")
+        out = clean_model_for_petab(src)
+        assert 'begin actions' not in out
+        assert 'simulate' not in out and 'parameter_scan' not in out
+
+    def test_commented_generate_network_is_not_kept(self):
+        # A commented-out '# generate_network(...)' is documentation, not a live directive: it
+        # must not resurrect the block (consistent with pset.py's BNGLModel scanner, #473).
+        src = ("begin model\nend model\n\nbegin actions\n"
+               "# generate_network({overwrite=>1})\n simulate({})\nend actions\n")
+        out = clean_model_for_petab(src)
+        assert 'begin actions' not in out and 'generate_network' not in out
+
     def test_parse_model_captures_function_bodies(self):
         # Phase A (ADR-0035): parse_model records each global function's body verbatim;
         # function_names is exactly the body keys; a function WITH arguments (not the
@@ -2084,6 +2120,58 @@ def _assert_petab_clean(exported):
                 ValidationIssueSeverity.ERROR:
             errors.append((type(task).__name__, issue.message))
     assert errors == []
+
+
+class TestExportPreservesNetworkCap:
+    """#485: a ``generate_network`` finiteness cap (``max_stoich`` / ``max_agg`` /
+    ``max_iter``) must survive PEtab export. A model that is finite *only* under the cap
+    becomes one that network-generates unbounded (a silent hang) if the cap is dropped, so the
+    exported model has to carry it. The cap rides in the model's own actions block, so
+    ``import_`` -- which copies the model byte-verbatim -- round-trips it for free."""
+
+    CAP = 'generate_network({overwrite=>1,max_stoich=>{counter=>4}})'
+
+    def _capped_fixture(self, d):
+        # Reuse the shared parabola2 model, swapping its bare generate_network for a capped one.
+        model = _PARABOLA2_BNGL.replace(
+            'generate_network({overwrite=>1})', self.CAP)
+        assert self.CAP in model                          # guard the fixture edit
+        (d / 'parabola2.bngl').write_text(model)
+        (d / 'par1.exp').write_text(
+            '# time x y x_SD y_SD\n0\t-10\t3\t1\t1\n1\t-9\t2\t1\t1\n2\t-8\t1\t1\t1\n')
+        conf = d / 'job.conf'
+        conf.write_text(
+            'edition = 2\njob_type = de\nobjective = chi_sq\n'
+            'model: parabola2.bngl\n'
+            'experiment: par1, data: par1.exp\n'
+            'uniform_var = v1 0 10\nuniform_var = v2 0 10\nuniform_var = v3 0 10\n')
+        return conf
+
+    def test_exported_model_carries_the_cap(self, tmp_path):
+        conf = self._capped_fixture(tmp_path)
+        out = tmp_path / 'petab'
+        export_job(conf, out)
+        model = (out / 'parabola2.bngl').read_text()
+        assert self.CAP in model                          # cap survives clean_model_for_petab
+        assert 'simulate' not in model                    # the simulation action is still dropped
+
+    def test_exported_capped_model_is_petab_valid(self, tmp_path):
+        # petab.v2 lint accepts a BNGL model that retains a generate_network line.
+        conf = self._capped_fixture(tmp_path)
+        out = tmp_path / 'petab'
+        export_job(conf, out)
+        _assert_petab_clean(out)
+
+    def test_cap_round_trips_through_import(self, tmp_path):
+        # The exporter records the cap in the model itself, so the importer (byte-verbatim
+        # model copy) recovers it with no new PEtab metadata field.
+        pytest.importorskip('petab.v2')
+        from pybnf.petab.import_ import import_job
+        conf = self._capped_fixture(tmp_path)
+        out = tmp_path / 'petab'
+        export_job(conf, out)
+        imp = import_job(out / 'problem.yaml', tmp_path / 'imp')
+        assert self.CAP in (imp / 'parabola2.bngl').read_text()
 
 
 class TestConditionMappingUnit:


### PR DESCRIPTION
## Summary

Closes #485 (item 1 — the primary, in-repo fix).

`clean_model_for_petab` stripped the **entire** `begin actions` block, dropping any `generate_network` finiteness cap (`max_stoich` / `max_agg` / `max_iter`) carried on it. A model whose reaction network is finite **only** under such a cap became one that **network-generates unbounded** once exported — a silent hang, with no error or warning.

This treats `generate_network` as a **network-definition / compilation directive**, not a simulation action: the cleaner now keeps `generate_network` line(s) verbatim and drops only the simulation actions (`simulate*` / `parameter_scan` / `bifurcate` / …).

## Why this is correct and self-contained

- The exported `.bngl` carries its own cap, so PyBNF's own `BNGLModel` reads it back (`pset.py`, the #473 machinery) and the PEtab **importer round-trips it for free** — the model file is copied byte-verbatim, so no new PEtab metadata field is needed.
- `petab.v2` lint accepts a BNGL model that retains a `generate_network` line (asserted by the full-task oracle).
- A simulation-only block (no `generate_network`) still disappears entirely, exactly as before.

## Tests

`tests/test_petab_export.py`:
- **Unit** (`TestCleanModelUnit`): a capped directive survives + is idempotent; a simulation-only block is fully dropped; a commented-out `# generate_network(...)` is not resurrected.
- **Full-task** (`TestExportPreservesNetworkCap`): the exported model carries the cap; it passes `petab.v2` lint; the cap round-trips through `import_job`.

Full `test_petab_export.py` + `test_petab_import.py` + `test_new_era_validation.py` suites pass (with `BNGPATH` set for the BNG2.pl-gated round-trip fits); the new tests need no BNG2.pl.

## Not in this PR (item 2 — separate repo)

Item 2 of #485 — bngsim re-prepending a bare `generate_network({overwrite=>1})` when materializing a protocol model — is a robustness fix in the separate **lanl/bngsim** repo, and needs a bngsim release + a PyBNF floor bump before it is live for PyBNF users. That is deliberately **held** for now; item 1 alone fully fixes the PyBNF export defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
