### PR TITLE
feat(gntr): general-objective Fisher/Gauss-Newton trust-region optimizer (#481)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ All notable changes to PyBNF are documented below. This project adheres to
 ## [Unreleased]
 
 ### Added
+- **General-objective trust-region optimizer: `fit_type = gntr` (ADR-0068, #481).** Fills the last
+  empty cell of the gradient-fitting (objective × curvature-model) matrix. `trf` gives a
+  trust-region step with a `JᵀJ` (Gauss-Newton / empirical-Fisher) Hessian but only for an exact
+  least-squares objective; the moment the objective stops being a pure sum of squares — an estimated
+  noise scale, a Laplace / count likelihood, or an active constraint — the gradient path dropped to
+  `lbfgs` (limited-memory quasi-Newton). `gntr` extends `trf`'s well-conditioned trust-region step
+  to those general-NLL objectives: its Hessian is the **expected-Fisher / Gauss-Newton information**
+  `H = Σ κᵢ sᵢsᵢᵀ` (+ estimated-noise and constraint blocks), built from the same #385 forward
+  sensitivities `sᵢ = ∂predᵢ/∂θ` plus small analytic per-family curvature factors (new
+  `NoiseModel.location_fisher` / `noise_param_fisher` and `Constraint.penalty_curvature` seams) — no
+  second-order sensitivities. It consumes the *same scalar gradient* as `lbfgs`; only the curvature
+  differs. Internally it reuses `trf`'s Coleman–Li reflective machinery unchanged by feeding
+  `(g, H)` through a ridge-regularised pseudo-Jacobian, so on a Gaussian least-squares fit it reduces
+  to `trf`'s step exactly. It runs natively in the distributed propose/score loop (picklable, no
+  `run()` override, concurrent `N`-start multi-start, registered as a box-start refiner) like every
+  other `fit_type`. New config keys `gntr_grad_tol` (1e-8), `gntr_step_tol` (1e-8), `gntr_ridge`
+  (1e-10), and the runtime-guarded `gntr_max_iterations`. This cut supports an estimated-σ Gaussian
+  (`chi_sq_dynamic`), a fixed-scale Laplace, a fixed-dispersion mean-centered negative-binomial, and
+  a Gaussian fit with static-hinge constraints; the coupled corners it cannot yet build the Fisher
+  Hessian for (a mean-on-log estimated scale, a free-dispersion / median count family, an estimated
+  Student-t df, or an estimated constraint scale) refuse with a pointer to `lbfgs`, which fits them.
+  `trf` / `lbfgs` are byte-identical (they never form the Hessian).
 - **Multi-Try DREAM: the `n_try` count (ADR-0067, Stage 2; MT-DREAM(ZS), #357).** A new integer
   `n_try` config key turns each chain-generation into a multiple-try step (Liu, Liang & Wong 2000;
   Laloy & Vrugt 2012): with `n_try = k > 1` a chain draws `k` candidate proposals, selects one in

--- a/docs/adr/0068-general-objective-trust-region-optimizer-is-native-efim-gauss-newton-hessian-fed-through-trfs-coleman-li-core-via-a-pseudo-jacobian.md
+++ b/docs/adr/0068-general-objective-trust-region-optimizer-is-native-efim-gauss-newton-hessian-fed-through-trfs-coleman-li-core-via-a-pseudo-jacobian.md
@@ -1,0 +1,124 @@
+# The general-objective trust-region optimizer is a native EFIM (Gauss-Newton) Hessian fed through TRF's Coleman-Li core via a pseudo-Jacobian (issue #481)
+
+**Status: Accepted (implemented 2026-07-17).** Fills the last empty cell of the
+(objective × curvature-model) matrix the #385 gradient epic and #386 gradient optimizers
+opened. `trf` (ADR-0007 run-loop contract; the Branch–Coleman–Li trust-region-reflective
+least-squares method) already gives a trust-region step with a `JᵀJ` (Gauss-Newton /
+empirical-Fisher) Hessian — but **only** for an exact least-squares objective. This adds the
+same step quality for the general-NLL objectives `trf` refuses, as a new `fit_type = gntr`.
+
+## The gap
+
+| | least-squares (`chi_sq`) | general NLL (estimated σ, Laplace/count, constrained) |
+|---|---|---|
+| **trust-region, EFIM `JᵀJ` Hessian** | `trf` ✅ | **`gntr` ✅ (this ADR)** |
+| **quasi-Newton** | (`trf` preferred) | `lbfgs` ✅ |
+
+The moment an objective stops being a pure sum of squares — an estimated noise scale (the
+`+log σ` normalizer, ADR-0021/#451), a Laplace / count likelihood (#454/#458), or an active
+constraint penalty (#456) — `trf` refuses it (`GradientResult.least_squares_exact == False`)
+and the only gradient path left was `lbfgs`, a limited-memory quasi-Newton method whose Hessian
+is built from gradient differences. On the ill-conditioned NLL landscapes typical of those
+problems that is a real downgrade: an empirical-Fisher (`JᵀJ`) trust-region step is far better
+conditioned than a history-built BFGS Hessian. We had that benefit for least squares; we lost it
+exactly where the objective gets harder.
+
+## Why native, not an optional pip trust-region backend
+
+The same reason `trf` / `lbfgs` / `powell` are native (ADR-0007): a blocking scipy/pip driver
+calls `fun`/`jac` synchronously and cannot farm its evaluations to PyBNF's distributed
+propose/score loop, so backup/resume and the concurrent `N`-start multi-start (#386) would break.
+`gntr` is an explicit, **picklable** step machine driven by `GradientOptimizer` inside the
+run-loop contract — no `run()` override — so one evaluation is one scheduler job and a fit runs
+`N` starts concurrently, exactly like every other `fit_type`. scipy stays a **test oracle only**
+(`tests/test_gradient_runner.py`), never an in-loop driver.
+
+## The decision
+
+### The curvature model is the expected-Fisher / Gauss-Newton information — a first-order object
+
+For a general per-observation NLL the EFIM Hessian is
+
+    H = Σ_i wᵢ κᵢ sᵢ sᵢᵀ   +   Σ_estimated-noise wᵢ I_scale eₚ eₚᵀ   +   Σ_constraints P''(q)₊ ∇q ∇qᵀ
+
+built entirely from the #385 **forward output-sensitivity** plumbing already in place — `sᵢ =
+∂predᵢ/∂θ` is the very sensitivity `trf`/`lbfgs` consume, and the per-observation curvatures are
+small analytic per-family factors. No second-order sensitivities are needed; avoiding them is the
+point of the EFIM approximation.
+
+* **Location block** `κᵢ` (the location's expected Fisher): for a **residual-bearing** family
+  (Gaussian, Student-t) it is `(∂ρ/∂pred)²` — *identically* the residual Jacobian's per-point
+  `JᵀJ`, so it is read straight off the existing residual assembly with **no new family math**;
+  for a **non-residual** family it is a new `NoiseModel.location_fisher` (Laplace `1/b²`,
+  negative-binomial MEAN `r/(μ(r+μ))`). Using the *expected* Fisher (not the observed second
+  derivative) is what keeps each term PSD — Laplace's observed curvature is 0 a.e., useless for a
+  Newton step; its expected Fisher `1/b²` is well-posed.
+* **Noise block** `I_scale` (a new `NoiseModel.noise_param_fisher`): the estimated scale's Fisher
+  on its own coordinate — Gaussian `2/σ²`, Laplace `1/b²`. The location–scale cross-Fisher is 0 by
+  symmetry on the linear/MEDIAN corner, so the block is diagonal there.
+* **Constraint block**: the Gauss-Newton curvature `P''(q)₊ ∇q ∇qᵀ` of the penalty
+  (`Constraint.penalty_curvature`), the second-order readout sensitivity dropped and `P''` clamped
+  ≥ 0. A **static hinge** (`.con`) penalty is piecewise-linear, so `P'' == 0` — it contributes no
+  curvature, correctly (its pull rides the gradient). The smooth (probit/logit) `P''` is a central
+  finite difference of the analytic penalty slope `_smooth_slope`, consistent-by-construction with
+  the gradient.
+
+The scalar gradient `g` is **unchanged** — `gntr` consumes exactly the
+`assemble_gaussian_gradient` + `assemble_constraint_gradient` gradient `lbfgs` already does; only
+the added `assemble_fisher_hessian` / `assemble_constraint_hessian` Hessian is new.
+
+### The step reuses TRF's Coleman-Li reflective core unchanged, via a pseudo-Jacobian
+
+`trf`'s bound-constrained trust-region-reflective machinery (the Coleman–Li affine scaling, the
+augmented-Jacobian SVD subproblem, the reflective step selection) is written for a residual `r`
+and Jacobian `J` with Hessian `JᵀJ` and gradient `Jᵀr`. `gntr` reuses **all of it** by building a
+*pseudo* residual model from the general `(g, H)`: ridge-regularise `H ← H + λI` (λ ∝ `trace(H)/n`,
+making `H` strictly PD so **no gradient direction lands in a flat curvature direction and gets
+projected away** — the key robustness fix for the constraint/noise blocks whose curvature can floor
+to zero), eigen-decompose `H = Q diag(w) Qᵀ`, and set `J = diag(√w) Qᵀ` (so `JᵀJ = H`) and
+`r = diag(1/√w) Qᵀ g` (so `Jᵀr = g`). Feeding `(jacobian=J, residual=r)` into the `_TRFRunner`
+reproduces the exact Coleman-Li-scaled Newton step `p = -(D H D + C)⁻¹ D g` for the model
+`½ sᵀ H s + gᵀ s`. Nothing in the `trf` runner assumes `½‖r‖² == score` — its accept/reject and
+trust-radius updates use the **real** objective score, and the predicted reduction is the quadratic
+model — so the pseudo residual's norm being unrelated to the objective is harmless. `_GNTRRunner`
+is therefore a ~20-line fork of `_TRFRunner`: it overrides only the exact-residual gate (a no-op —
+the EFIM is the curvature, not a residual) and the model construction (`_set_model` builds the
+pseudo `(J, r)`). For a Gaussian least-squares fit (`H = JᵀJ`, `g = Jᵀr`) the step reduces to
+**exactly** `trf`'s / scipy's — the offline oracle test.
+
+### Scope — the tractable configurations; the rest refuse cleanly to `lbfgs`
+
+This cut supports an estimated-σ Gaussian (`chi_sq_dynamic`), a fixed-scale Laplace, a
+fixed-dispersion negative-binomial (MEAN), and a Gaussian fit with (static-hinge) constraints.
+The **coupled corners** whose Fisher this cut does not assemble refuse with a `PybnfError`
+pointing at `fit_type = lbfgs` (which consumes the scalar gradient and fits them): a MEAN-on-log
+estimated scale (a nonzero location–scale cross-Fisher), the count family's free dispersion or
+MEDIAN centering (the betainc median→mean chain), the Student-t estimated-df 2×2 block, and an
+estimated constraint scale (ADR-0061). This mirrors how the #385 epic layered its own support —
+a configuration outside the supported set raises `GradientNotSupported`, caught and re-raised as
+the `lbfgs`-pointing refusal.
+
+## Alternatives considered
+
+* **Empirical Fisher (outer product of per-observation gradients), `Σ gᵢ gᵢᵀ`.** Needs no new
+  family math (reuses the gradient seams), but it is *not* `trf`'s `JᵀJ` — it weights each
+  observation by its squared residual, so it degrades far from the optimum and would **not** match
+  `trf` on a Gaussian fit (the anchor property). Rejected in favour of the expected Fisher.
+* **A dedicated general trust-region-Newton runner** (dogleg / Moré–Sorensen on `H` directly).
+  Would reimplement the carefully-ported Coleman–Li reflective bound handling — risk with no gain.
+  The pseudo-Jacobian bridge reuses that battle-tested code verbatim.
+* **An optional pip trust-region backend.** A blocking driver breaks backup/resume and the
+  distributed `N`-start loop (see *Why native*).
+
+## Consequences
+
+* A new `fit_type = gntr` (`GNTRConfig`: `gntr_grad_tol`, `gntr_step_tol`, `gntr_ridge`;
+  `gntr_max_iterations` runtime-guarded), registered as a box-start refiner like `trf`/`lbfgs`.
+* Two new `NoiseModel` seams (`location_fisher`, `noise_param_fisher`) and one `Constraint` seam
+  (`penalty_curvature`) — each raising `GradientNotSupported` on the base / for an out-of-scope
+  corner, so the refusal surface is explicit. The smooth-penalty slope is factored to
+  `_smooth_slope`, shared by the gradient and the curvature (no duplication).
+* Cost: `gntr` forms an `n × n` EFIM per evaluation (`O(n²·n_obs)`) vs `trf`'s residual Jacobian —
+  negligible for PyBNF's small-`n` fits. `trf` / `lbfgs` are byte-identical (the Hessian hook is a
+  no-op there; they never form `H`).
+* The refused corners are not a regression: they fit today via `lbfgs`, exactly as before.

--- a/docs/algorithms.rst
+++ b/docs/algorithms.rst
@@ -43,7 +43,7 @@ Summary of Available Algorithms
 
 
 In addition to the population-based and Metropolis samplers in the table above,
-PyBNF provides gradient-based optimizers (``trf``, ``lbfgs``) and
+PyBNF provides gradient-based optimizers (``trf``, ``lbfgs``, ``gntr``) and
 profile-likelihood analysis — see :ref:`Gradient-based optimization
 <alg-gradient>` — the :ref:`Hamiltonian Monte Carlo (NUTS) <alg-hmc>` and
 :ref:`Preconditioned DREAM <alg-p_dream>` samplers, and :ref:`model checking
@@ -642,15 +642,19 @@ distribution's spread. As a refiner the start is always the injected best fit.
 Gradient-based optimization
 ---------------------------
 
-For edition-2 fits of ODE-network models, PyBNF offers two gradient-based
+For edition-2 fits of ODE-network models, PyBNF offers three gradient-based
 optimizers driven by exact forward parameter sensitivities:
 
 * ``fit_type = trf`` — a trust-region least-squares method (Trust-Region
-  Reflective), for objectives that are a sum of squared residuals; and
+  Reflective), for objectives that are a sum of squared residuals;
 * ``fit_type = lbfgs`` — a quasi-Newton method (L-BFGS-B) that minimizes a scalar
-  objective from its analytic gradient.
+  objective from its analytic gradient; and
+* ``fit_type = gntr`` — a general-objective Fisher/Gauss-Newton trust-region method
+  that gives ``trf``'s trust-region step quality for the general-NLL objectives ``trf``
+  refuses (an estimated noise scale, the Laplace / count families, constrained fits),
+  using an expected-Fisher Hessian built from the same sensitivities.
 
-Both converge far faster than the metaheuristics near a good fit, and the same
+All three converge far faster than the metaheuristics near a good fit, and the same
 sensitivity machinery drives profile-likelihood identifiability analysis
 (``fit_type = profile_likelihood``). These methods, the noise families and
 constraints they support, and the capability gate that decides when a gradient fit

--- a/docs/config_keys.rst
+++ b/docs/config_keys.rst
@@ -194,7 +194,7 @@ Required Keys
   taking the same values as :ref:`fit_type <fit_type>` above. It replaces ``fit_type``
   because that name was a misnomer -- the key selects across point-estimate
   *optimizers* (``de`` / ``ade`` / ``pso`` / ``ss`` / ``sim`` / ``powell`` / ``cmaes``
-  / ``sa``, and the gradient-based :ref:`trf / lbfgs <gradient_fitting>`), Bayesian
+  / ``sa``, and the gradient-based :ref:`trf / lbfgs / gntr <gradient_fitting>`), Bayesian
   *samplers* (``am`` / ``dream`` / ``p_dream`` / ``pt`` / ``mh``, and the
   gradient-based :ref:`hmc <alg-hmc>` for analytical objectives), the
   :ref:`profile-likelihood <gradient_fitting>` identifiability analysis

--- a/docs/gradient_fitting.rst
+++ b/docs/gradient_fitting.rst
@@ -11,7 +11,7 @@ trust-region least-squares) stands on: it lets the fit follow the true downhill 
 instead of probing it parameter-by-parameter.
 
 This page describes the gradient *plumbing* — what it computes, the objective
-configurations it supports, how to enable it, and what it costs — and the two
+configurations it supports, how to enable it, and what it costs — and the three
 gradient-based optimizers that consume it (see *Running a gradient fit* below).
 
 .. note::
@@ -32,7 +32,7 @@ gradient-based optimizers that consume it (see *Running a gradient fit* below).
 Running a gradient fit
 ----------------------
 
-Two optimizers consume the gradient, both opt-in via ``fit_type``:
+Three optimizers consume the gradient, all opt-in via ``fit_type``:
 
 * ``fit_type = trf`` — a **Trust-Region-Reflective least-squares** optimizer
   (Branch–Coleman–Li, matching ``scipy.optimize.least_squares(method="trf")``). It
@@ -53,10 +53,26 @@ Two optimizers consume the gradient, both opt-in via ``fit_type``:
   ``trf`` refuses: an estimated noise scale, the Laplace / count families, and active constraint
   penalties.
 
-Both run natively inside PyBNF's distributed propose/score loop (one objective evaluation is one
+* ``fit_type = gntr`` — a **general-objective Fisher/Gauss-Newton trust-region** optimizer. It gives
+  ``trf``'s trust-region step quality — the well-conditioned :math:`J^{\mathsf T}J`-style curvature —
+  for the very objectives ``trf`` refuses and only ``lbfgs`` could handle. Its Hessian is the
+  **expected-Fisher / Gauss-Newton information**
+  :math:`H = \sum_i \kappa_i\, s_i s_i^{\mathsf T}` (plus estimated-noise and constraint blocks),
+  built from the same forward sensitivities :math:`s_i = \partial \mathrm{pred}_i/\partial\theta`
+  plus small analytic per-family curvature factors — no second-order sensitivities. It consumes the
+  *same scalar gradient* as ``lbfgs``; only the curvature model differs. Internally it feeds
+  :math:`(g, H)` through the same Coleman–Li reflective machinery ``trf`` uses (so on a Gaussian
+  least-squares fit it reduces to ``trf``'s step exactly), but with the general Fisher Hessian.
+  This cut supports an estimated-σ Gaussian (``chi_sq_dynamic``), a fixed-scale Laplace, a
+  fixed-dispersion negative-binomial (mean-centered), and a Gaussian fit with static-hinge
+  constraints; a coupled corner it cannot yet build the Fisher Hessian for (a mean-on-log-scale
+  estimated scale, a free-dispersion / median count family, an estimated Student-t df, or an
+  estimated constraint scale) is refused with a pointer to ``lbfgs``, which fits it.
+
+All three run natively inside PyBNF's distributed propose/score loop (one objective evaluation is one
 scheduler job) rather than through a blocking ``scipy`` driver, so backup/resume work exactly as for
-every other ``fit_type``. They are also registered as **refiners** (``refine_method = trf`` / ``lbfgs``),
-so a gradient step can polish a metaheuristic's best fit.
+every other ``fit_type``. They are also registered as **refiners** (``refine_method = trf`` / ``lbfgs``
+/ ``gntr``), so a gradient step can polish a metaheuristic's best fit.
 
 **Local multi-start.** A gradient method is purely *local*: it descends into whatever basin its
 start point lands in. To guard against a bad basin on a multimodal or bound-active landscape, a
@@ -84,8 +100,13 @@ step tolerance is met, or the per-start iteration budget is exhausted:
   tolerance, default ``1e-8``), ``lbfgs_history`` (number of stored correction pairs, default
   ``10``), and the line-search constants ``lbfgs_c1`` (Armijo sufficient-decrease, default ``1e-4``)
   and ``lbfgs_backtrack`` (step-length reduction factor, :math:`0 < \beta < 1`, default ``0.5``).
+* ``gntr`` — ``gntr_grad_tol`` (first-order optimality on the scaled gradient, default ``1e-8``) and
+  ``gntr_step_tol`` (accepted step negligible, default ``1e-8``), identical in meaning to ``trf``'s
+  (it *is* a trust-region step), plus ``gntr_ridge`` — a small relative Levenberg ridge added to the
+  Fisher Hessian before the step solve (default ``1e-10``), large enough to keep the Hessian strictly
+  positive definite, small enough not to perturb the Newton step.
 
-For both, ``<method>_max_iterations`` caps the iterations per start and defaults to the global
+For all three, ``<method>_max_iterations`` caps the iterations per start and defaults to the global
 ``max_iterations``.
 
 

--- a/pybnf/algorithms/__init__.py
+++ b/pybnf/algorithms/__init__.py
@@ -53,10 +53,13 @@ from .optimizers.cmaes import CMAESAlgorithm as CMAESAlgorithm
 # Levenberg–Marquardt, primary) consumes #385's residual Jacobian; lbfgs (bounded
 # limited-memory BFGS, the scalar-gradient fallback) consumes the scalar gradient and
 # so handles the objectives trf refuses (estimated noise scale, Laplace/count,
-# constraints). Each is a GradientOptimizer (optimizers/gradient_base.py); importing
-# the leaf runs its @register_fit_type.
+# constraints). gntr (#481) is the missing cell: a trust-region step with trf's
+# Gauss-Newton/EFIM Hessian extended to those same general-NLL objectives (a Fisher
+# Hessian atop the scalar gradient). Each is a GradientOptimizer
+# (optimizers/gradient_base.py); importing the leaf runs its @register_fit_type.
 from .optimizers.trf import TRFAlgorithm as TRFAlgorithm
 from .optimizers.lbfgs import LBFGSAlgorithm as LBFGSAlgorithm
+from .optimizers.gntr import GNTRAlgorithm as GNTRAlgorithm
 # Profile likelihood (#446/#466): a standalone new-era job_type that reuses the same
 # gradient path -- a multi-start TRF polish to the optimum, then one adaptive re-optimized
 # profile per parameter for confidence intervals + identifiability. Importing the leaf runs

--- a/pybnf/algorithms/optimizers/gntr.py
+++ b/pybnf/algorithms/optimizers/gntr.py
@@ -1,0 +1,218 @@
+"""General-objective Fisher/Gauss-Newton trust-region optimizer (``gntr`` fit type, #481).
+
+The missing cell of the (objective x curvature-model) matrix. ``trf`` gives a trust-region
+step with a ``J^T J`` (Gauss-Newton / empirical-Fisher) Hessian, but **only** for an exact
+least-squares objective; the moment the objective stops being a pure sum of squares -- an
+estimated noise scale, a Laplace / count likelihood, or an active constraint -- the gradient
+path drops to ``lbfgs``, a limited-memory quasi-Newton method whose Hessian is built from
+gradient differences. On the ill-conditioned NLL landscapes typical of those problems that is
+a real downgrade. ``gntr`` closes the gap: a native, picklable trust-region optimizer whose
+Hessian is the **expected-Fisher / Gauss-Newton information**
+
+    H = sum_i kappa_i s_i s_i^T   (+ estimated-noise and constraint blocks)
+
+built entirely from the #385 forward-sensitivity plumbing (``s_i = d(prediction_i)/d theta``,
+``kappa_i`` the per-observation location Fisher) plus small analytic per-family factors
+(:func:`~pybnf.gradient.assembly.assemble_fisher_hessian`), extending ``trf``'s step quality to
+any NLL objective ``lbfgs`` handles. It consumes the **same scalar gradient** ``lbfgs`` does
+(``GradientResult.gradient``); only the curvature model differs.
+
+Why native (not a scipy/pip trust-region driver): the same reason ``trf`` / ``lbfgs`` /
+``powell`` document -- a blocking driver calls ``fun`` / ``jac`` synchronously and cannot farm
+its evaluations to PyBNF's distributed propose/score loop. The method is an explicit, *picklable*
+step machine driven by :class:`~pybnf.algorithms.optimizers.gradient_base.GradientOptimizer`
+inside the run-loop contract (no ``run()`` override, ADR-0007), so backup/resume and local
+multi-start work exactly as for every other ``fit_type``.
+
+The step math -- reusing ``trf``'s Coleman-Li reflective core via a pseudo-Jacobian
+--------------------------------------------------------------------------------------
+``trf``'s bound-constrained trust-region-reflective machinery (the Branch-Coleman-Li affine
+scaling, the augmented-Jacobian SVD subproblem solve, the reflective step selection) is written
+in terms of a residual ``r`` and residual-Jacobian ``J`` with Hessian ``J^T J`` and gradient
+``J^T r``. For a general PSD Hessian ``H`` and gradient ``g`` this runner **reuses that whole
+apparatus unchanged** by building a *pseudo* residual model: ridge-regularise ``H <- H + lambda
+I`` (``lambda`` proportional to ``trace(H)/n``, making ``H`` strictly positive definite so no
+gradient direction is projected onto a flat curvature direction and lost -- the key robustness
+fix for the constraint / estimated-noise blocks whose curvature can floor to zero), eigen-
+decompose ``H = Q diag(w) Q^T``, and set
+
+    J_pseudo = diag(sqrt(w)) Q^T          (so J_pseudo^T J_pseudo == H)
+    r_pseudo = diag(1/sqrt(w)) Q^T g       (so J_pseudo^T r_pseudo == g)
+
+Feeding ``(jacobian=J_pseudo, residual=r_pseudo)`` into :class:`~pybnf.algorithms.optimizers.trf._TRFRunner`
+reproduces the exact Coleman-Li-scaled Newton step ``p = -(D H D + C)^{-1} D g`` for the
+quadratic model ``1/2 s^T H s + g^T s``. Nothing else in the ``trf`` runner assumes the residual
+norm equals the objective -- its accept/reject and trust-radius updates use the **real** objective
+score (``self.cost`` / ``self.fval`` set from ``score``), and the predicted reduction comes from
+the quadratic model, so ``1/2 ||r_pseudo||^2 != score`` is harmless. For a pure Gaussian
+least-squares fit (``H = J^T J``, ``g = J^T r``) the step reduces to exactly ``trf``'s / scipy's,
+the offline oracle in ``tests/test_gradient_runner.py``.
+
+Scope (this cut -- the tractable configurations; the rest cleanly refuse to ``lbfgs``). Supports
+an estimated-sigma Gaussian (``chi_sq_dynamic``), a fixed-scale Laplace, a fixed-dispersion
+negative-binomial (MEAN), and a Gaussian fit with (static-hinge) constraints. Refuses -- with a
+:class:`~pybnf.printing.PybnfError` pointing at ``fit_type = lbfgs`` -- the coupled corners whose
+Fisher this cut does not assemble: a MEAN-on-log estimated scale, the count family's free
+dispersion or MEDIAN centering, the Student-t estimated-df 2x2 block, and an estimated constraint
+scale. Local multi-start is provided by :class:`GradientOptimizer` (``N`` concurrent starts,
+global best).
+
+All runner state is plain ``numpy`` / ``float`` (inherited from ``_TRFRunner`` -- the point, the
+pseudo residual model, the trust radius, the cached scaling + SVD), so ``Algorithm.backup``
+checkpoints the optimizer mid-run like every other method (ADR-0007).
+"""
+
+from typing import ClassVar
+
+import numpy as np
+
+from .gradient_base import GradientOptimizer
+from .trf import _TRFRunner
+from ...config_schema import PyBNFConfigModel
+from ...gradient import assemble_constraint_hessian, assemble_fisher_hessian
+from ...printing import PybnfError
+from ...registry import register_fit_type
+
+
+class GNTRConfig(PyBNFConfigModel):
+    """GNTR (Fisher/Gauss-Newton trust-region) config fields, co-located with the method
+    (ADR-0006).
+
+    ``gntr_grad_tol`` and ``gntr_step_tol`` are the first-order-optimality and negligible-step
+    stopping tolerances, identical in meaning to ``trf``'s (the runner is a ``trf`` runner fed a
+    pseudo-Jacobian): the run ends when the largest component of the **scaled** gradient
+    ``v * g`` falls below ``gntr_grad_tol`` (the Coleman-Li optimality test that reads as zero on
+    an active bound) or an accepted step becomes negligible relative to the point. ``gntr_ridge``
+    is the relative Levenberg ridge added to the EFIM Hessian before the pseudo-Jacobian
+    factorisation (``lambda = gntr_ridge * trace(H)/n``) -- large enough to keep ``H`` strictly
+    positive definite (so every gradient direction is representable and the pseudo residual is
+    bounded), small enough not to perturb the Newton step; the default ``1e-10`` is negligible on
+    a well-conditioned fit. Like ``trf`` / ``lbfgs``, ``gntr_max_iterations`` is runtime-guarded
+    (it defaults to the global ``max_iterations`` when unset), so it is a valid key but not a
+    schema field, and ``gntr_start_point`` is internal (the refiner injects it)."""
+
+    gntr_grad_tol: float = 1e-8
+    gntr_step_tol: float = 1e-8
+    gntr_ridge: float = 1e-10
+
+    RUNTIME_KEYS: ClassVar[frozenset] = frozenset({'gntr_max_iterations'})
+
+
+@register_fit_type('gntr', family='optimizer',
+                   display_name='Fisher/Gauss-Newton Trust Region',
+                   schema=GNTRConfig, refiner=True, start_from_box=True)
+class GNTRAlgorithm(GradientOptimizer):
+    """General-objective Fisher/Gauss-Newton trust-region: a method-agnostic multi-start
+    orchestrator (:class:`GradientOptimizer`) over per-start :class:`_GNTRRunner` step machines.
+    It differs from ``trf`` in exactly two seams -- it attaches the EFIM Hessian to the assembled
+    gradient (:meth:`_attach_curvature`) and its runner consumes ``(gradient, hessian)`` instead
+    of a residual model -- inheriting everything else (multi-start, routing, gates, reporting)."""
+
+    #: Message label + refiner start-point key (see StartPointOptimizer).
+    fit_type = 'gntr'
+    START_POINT_KEY = 'gntr_start_point'
+    _method_label = 'GNTR'
+
+    def __init__(self, config, refine=False):
+        super().__init__(config, refine=refine)
+        self.grad_tol = config.config['gntr_grad_tol']
+        self.step_tol = config.config['gntr_step_tol']
+        self.ridge = config.config['gntr_ridge']
+        if 'gntr_max_iterations' in config.config:
+            self.max_iterations = config.config['gntr_max_iterations']
+        else:
+            self.max_iterations = config.config['max_iterations']
+
+    def _start_banner(self):
+        return ("Running Fisher/Gauss-Newton trust-region (general-objective EFIM) for up to "
+                "%i iterations from %i start point(s)" % (self.max_iterations, self.n_starts))
+
+    def _make_runner(self, u0):
+        """One Fisher/Gauss-Newton trust-region step machine seeded at ``u0`` (sampling space),
+        carrying this fit's box + tunables. The orchestrator builds one per start."""
+        return _GNTRRunner(u0, self._u_lower, self._u_upper, self.max_iterations,
+                           grad_tol=self.grad_tol, step_tol=self.step_tol, ridge=self.ridge)
+
+    def _attach_curvature(self, grad, res, experiments, free_params):
+        """Attach the expected-Fisher / Gauss-Newton Hessian to the assembled gradient (#481):
+        the data-fit EFIM (:func:`~pybnf.gradient.assembly.assemble_fisher_hessian`) plus, for a
+        constrained fit, the constraint Gauss-Newton block
+        (:func:`~pybnf.gradient.assembly.assemble_constraint_hessian`). Runs inside
+        ``gradient_at``'s ``GradientNotSupported`` guard, so an unsupported-curvature corner
+        refuses cleanly to ``lbfgs`` (:meth:`_unsupported_gradient_error`)."""
+        hessian = assemble_fisher_hessian(self.objective, experiments, free_params)
+        if self.config.constraints:
+            hessian = hessian + assemble_constraint_hessian(
+                self.config.constraints, res.simdata, self._routings, free_params)
+        grad.hessian = hessian
+
+    def _unsupported_gradient_error(self, exc):
+        """Point the refusal at ``lbfgs`` (which consumes the scalar gradient and needs no Fisher
+        Hessian), not at a metaheuristic: the corners ``gntr`` cannot build an EFIM Hessian for --
+        a MEAN-on-log estimated scale, the count family's free dispersion / MEDIAN centering, the
+        Student-t 2-parameter block, an estimated constraint scale -- all fit under ``lbfgs``."""
+        return PybnfError(
+            "Fisher/Gauss-Newton trust-region fitting (fit_type = gntr) cannot build the EFIM "
+            "Hessian for this fit's objective: %s" % exc,
+            "Use the gradient quasi-Newton fallback 'fit_type = lbfgs', which consumes the "
+            "scalar gradient and needs no Fisher Hessian -- it handles the estimated noise "
+            "scales, the Laplace / count families, and the constraint penalties whose curvature "
+            "the EFIM trust-region step does not (yet) assemble.")
+
+
+class _GNTRRunner(_TRFRunner):
+    """One Fisher/Gauss-Newton trust-region start: a :class:`~pybnf.algorithms.optimizers.trf._TRFRunner`
+    fed a **pseudo-Jacobian** built from the general EFIM ``(gradient, hessian)`` rather than a
+    least-squares residual model (#481).
+
+    It overrides exactly two seams of the ``trf`` runner: :meth:`_require_exact` (a no-op -- the
+    curvature is the EFIM, not an exact residual, so any objective the assembly could build a
+    Hessian for is accepted; that gate is upstream in :meth:`GNTRAlgorithm._attach_curvature`),
+    and :meth:`_set_model` (ridge-regularise ``H`` and eigen-factor ``(g, H)`` into the pseudo
+    ``(J, r)`` the inherited step machine consumes). Everything else -- the Coleman-Li scaling,
+    the augmented-Jacobian SVD trust-region subproblem, the reflective step selection, the
+    accept/reject + trust-radius state machine, the convergence tests, picklability -- is
+    inherited unchanged. See the module docstring for why the reduction is exact."""
+
+    def __init__(self, u0, lower, upper, max_iterations, *, grad_tol, step_tol, ridge):
+        super().__init__(u0, lower, upper, max_iterations, grad_tol=grad_tol, step_tol=step_tol)
+        self.ridge = ridge
+
+    def progress_detail(self):
+        return 'trust radius %g (EFIM)' % self.Delta
+
+    def _require_exact(self, grad):
+        """Accept any assembled gradient: the EFIM Hessian is the curvature model, not an exact
+        least-squares residual, so the ``trf`` runner's exact-residual gate does not apply. The
+        real gate -- whether the Fisher Hessian could be assembled at all -- fired upstream in
+        :meth:`GNTRAlgorithm._attach_curvature` (raising :class:`GradientNotSupported` for an
+        out-of-scope corner)."""
+        return grad
+
+    def _set_model(self, grad):
+        """Build the pseudo residual model ``(J, r)`` from the general ``(gradient, hessian)`` so
+        the inherited ``trf`` step machine computes the EFIM-scaled Newton step.
+
+        Ridge-regularise ``H <- H + lambda I`` (``lambda = ridge * trace(H)/n``, an absolute floor
+        of ``ridge`` when the trace is zero) to make ``H`` strictly positive definite -- so no
+        gradient component lands in a flat curvature direction that the factorisation would project
+        away (the constraint / estimated-noise blocks can floor to zero curvature), and the pseudo
+        residual stays bounded. Then eigen-decompose the symmetric ``H = Q diag(w) Q^T`` and set
+        ``J = diag(sqrt(w)) Q^T`` (so ``J^T J == H``) and ``r = diag(1/sqrt(w)) Q^T g`` (so
+        ``J^T r == g``). ``self.g`` recomputed as ``J^T r`` is exactly ``g`` -- the value the
+        Coleman-Li scaling and the convergence test read."""
+        g = np.asarray(grad.gradient, dtype=float)
+        hessian = np.asarray(grad.hessian, dtype=float)
+        n = self.n
+        lam = self.ridge * (float(np.trace(hessian)) / n) if n else 0.0
+        if lam <= 0.0:
+            lam = self.ridge
+        hessian = 0.5 * (hessian + hessian.T) + lam * np.eye(n)
+        w, q = np.linalg.eigh(hessian)
+        # Positive definite after the ridge; the floor only mops up eigen roundoff.
+        w = np.clip(w, lam * 1e-12, None)
+        sqrt_w = np.sqrt(w)
+        self.J = (q * sqrt_w).T              # rows sqrt(w_i) * q_i^T  =>  J^T J == H
+        self.r = (q.T @ g) / sqrt_w          # J^T r == Q Q^T g == g
+        self.g = self.J.T @ self.r
+        self.m = n

--- a/pybnf/algorithms/optimizers/gntr.py
+++ b/pybnf/algorithms/optimizers/gntr.py
@@ -201,6 +201,16 @@ class _GNTRRunner(_TRFRunner):
         ``J = diag(sqrt(w)) Q^T`` (so ``J^T J == H``) and ``r = diag(1/sqrt(w)) Q^T g`` (so
         ``J^T r == g``). ``self.g`` recomputed as ``J^T r`` is exactly ``g`` -- the value the
         Coleman-Li scaling and the convergence test read."""
+        if getattr(grad, 'hessian', None) is None:
+            # The EFIM leaf attaches the Fisher Hessian in GNTRAlgorithm._attach_curvature
+            # before the runner ever sees the gradient; a None here means this runner was
+            # driven off the residual-form (trf/lbfgs) path by mistake. Fail fast with the
+            # cause rather than an opaque numpy error deep in the eigen-factorisation.
+            raise PybnfError(
+                "The GNTR (Fisher/Gauss-Newton trust-region) runner requires an assembled "
+                "EFIM Hessian, but the gradient carried none. This is an internal wiring "
+                "error -- a gntr runner must be driven by GNTRAlgorithm, which attaches the "
+                "Hessian in _attach_curvature.")
         g = np.asarray(grad.gradient, dtype=float)
         hessian = np.asarray(grad.hessian, dtype=float)
         n = self.n

--- a/pybnf/algorithms/optimizers/gradient_base.py
+++ b/pybnf/algorithms/optimizers/gradient_base.py
@@ -468,12 +468,32 @@ class GradientOptimizer(StartPointOptimizer):
                     self.config.constraints, res.simdata, self._routings, free_params)
                 grad.gradient = grad.gradient + cgrad
                 grad.least_squares_exact = False
+            self._attach_curvature(grad, res, experiments, free_params)
         except GradientNotSupported as e:
-            raise PybnfError(
-                "Gradient-based fitting (fit_type = %s) cannot differentiate this "
-                "fit's objective: %s" % (self._fit_type_label(), e),
-                _FALLBACK_HINT) from e
+            raise self._unsupported_gradient_error(e) from e
         return grad
+
+    def _attach_curvature(self, grad, res, experiments, free_params):
+        """Hook for a curvature-consuming leaf to attach its Hessian to the assembled
+        gradient. A **no-op on the base**, so the residual-form (``trf``) and scalar-gradient
+        (``lbfgs``) leaves -- which never form a Hessian -- are byte-identical; the EFIM
+        trust-region leaf (``fit_type = gntr``, #481) overrides it to set ``grad.hessian``
+        (:func:`~pybnf.gradient.assembly.assemble_fisher_hessian` plus, for a constrained fit,
+        :func:`~pybnf.gradient.assembly.assemble_constraint_hessian`). Called **inside**
+        :meth:`gradient_at`'s :class:`GradientNotSupported` guard, so an unsupported-curvature
+        corner (a MEDIAN-count Fisher, a MEAN-on-log estimated scale, an estimated constraint
+        scale, ...) converts to the same fail-fast :class:`PybnfError`."""
+
+    def _unsupported_gradient_error(self, exc):
+        """Wrap a :class:`GradientNotSupported` as the leaf's fail-fast :class:`PybnfError`
+        with an actionable fallback hint. The base points at a metaheuristic ``fit_type``;
+        the EFIM leaf (``gntr``) overrides the hint to point at ``lbfgs`` -- which consumes the
+        scalar gradient and needs no Fisher Hessian, so it fits the very corners ``gntr``
+        refuses."""
+        return PybnfError(
+            "Gradient-based fitting (fit_type = %s) cannot differentiate this "
+            "fit's objective: %s" % (self._fit_type_label(), exc),
+            _FALLBACK_HINT)
 
     # --- u-space box ------------------------------------------------------- #
     def _u_bounds(self):

--- a/pybnf/constraint.py
+++ b/pybnf/constraint.py
@@ -920,14 +920,9 @@ class Constraint:
         scale -- the estimated free parameter's live value if tied, else the
         authored tolerance."""
         difference, a = self._difference_argmax(sim_data_dict, imin, imax, once, require_length, imin2, imax2)
-        k = self._effective_scale(pset_values)
-        if k == 0:
+        if self._effective_scale(pset_values) == 0:
             return np.zeros(n_param)
-        x = -difference / k
-        phi = np.exp(-0.5 * x * x) / np.sqrt(2. * np.pi)
-        prob = (1. + erf(x / np.sqrt(2.))) / 2.
-        adjusted = (self.pmax - self.pmin) * prob + self.pmin
-        slope = (self.pmax - self.pmin) * phi / (k * adjusted)
+        slope = self._smooth_slope(difference, pset_values)
         imin2_eff = imin if imin2 is None else imin2
         return slope * self._readout_gradient(
             raw_sens, n_param, self.qkeys1, self.quant1, imin + a,
@@ -946,17 +941,37 @@ class Constraint:
         unclipped (``pmin=0, pmax=1``). ``s`` is the effective scale -- the estimated free
         parameter's live value if tied, else the authored scale."""
         difference, a = self._difference_argmax(sim_data_dict, imin, imax, once, require_length, imin2, imax2)
-        s = self._effective_scale(pset_values)
-        x = difference / s
-        if self.pmin is None:
-            slope = _sigmoid(x) / s
-        else:
-            adjusted = self.pmin + (self.pmax - self.pmin) * _sigmoid(-x)
-            slope = (self.pmax - self.pmin) * _sigmoid(-x) * _sigmoid(x) / (s * adjusted)
+        slope = self._smooth_slope(difference, pset_values)
         imin2_eff = imin if imin2 is None else imin2
         return slope * self._readout_gradient(
             raw_sens, n_param, self.qkeys1, self.quant1, imin + a,
             self.qkeys2, self.quant2, imin2_eff + a)
+
+    def _smooth_slope(self, difference, pset_values):
+        """The smooth penalty's local slope ``P'(difference)`` -- the probit / logit factor the
+        gradient multiplies ``d(readout)/d theta`` by (#456), extracted so it is a **pure scalar
+        function of the readout ``difference``** that the EFIM curvature (#481) central-differences
+        for ``P''`` (consistent-by-construction with the gradient). Reads the effective scale (an
+        estimated free parameter's live value if tied, else the authored tolerance / logit scale)
+        through :meth:`_effective_scale`. Returns 0 for a zero probit tolerance (the step-function
+        edge the gradient special-cases). Only called for the smooth models (static has a constant
+        slope handled inline)."""
+        if self.penalty_model == 'likelihood':
+            k = self._effective_scale(pset_values)
+            if k == 0:
+                return 0.0
+            x = -difference / k
+            phi = np.exp(-0.5 * x * x) / np.sqrt(2. * np.pi)
+            prob = (1. + erf(x / np.sqrt(2.))) / 2.
+            adjusted = (self.pmax - self.pmin) * prob + self.pmin
+            return (self.pmax - self.pmin) * phi / (k * adjusted)
+        # logit
+        s = self._effective_scale(pset_values)
+        x = difference / s
+        if self.pmin is None:
+            return _sigmoid(x) / s
+        adjusted = self.pmin + (self.pmax - self.pmin) * _sigmoid(-x)
+        return (self.pmax - self.pmin) * _sigmoid(-x) * _sigmoid(x) / (s * adjusted)
 
     def penalty_gradient(self, sim_data_dict, raw_sens, index, n_param, pset_values=None):
         """The gradient of this constraint's total penalty w.r.t. the free parameters (layer I,
@@ -978,6 +993,64 @@ class Constraint:
             grad += self.get_penalty_gradient(sim_data_dict, raw_sens, index, n_param,
                                               pset_values=pset_values, **interval)
         return grad
+
+    def get_penalty_curvature(self, sim_data_dict, raw_sens, index, n_param, imin, imax,
+                              once=False, require_length=None, imin2=None, imax2=None,
+                              pset_values=None):
+        """The **Gauss-Newton curvature** of this interval's penalty w.r.t. the free parameters --
+        the constraint block of the EFIM trust-region Hessian (``fit_type = gntr``, #481), the
+        curvature twin of :meth:`get_penalty_gradient`. The penalty is ``P(q)`` for the at-/
+        between-time readout ``q = q1 - q2``, so its Gauss-Newton curvature is
+        ``max(P''(q), 0) * outer(grad q, grad q)`` -- the second-order readout sensitivity
+        ``hess q`` dropped (as the EFIM drops it for the data fit) and ``P''`` clamped to its
+        positive part (keeping the block PSD). Taken at the same achieving point (argmax) and with
+        the same ``_readout_gradient`` the gradient uses (Danskin).
+
+        * **static** (piecewise-linear hinge, ``.con``): ``P'' == 0`` -- a linear penalty carries no
+          curvature, so the constraint contributes none here (its pull rides the gradient, and the
+          data-fit Fisher + ridge supply the step's curvature). Returns zeros.
+        * **smooth** (probit / logit ``.prop``): ``P''`` by a central finite difference of the
+          analytic slope :meth:`_smooth_slope` (accurate to ~1e-9 on the smooth slope, and
+          consistent-by-construction with the gradient's slope), clamped to ``>= 0``."""
+        if self.penalty_model == 'static':
+            return np.zeros((n_param, n_param))
+        difference, a = self._difference_argmax(sim_data_dict, imin, imax, once, require_length,
+                                                imin2, imax2)
+        scale = self._effective_scale(pset_values)
+        if scale == 0:
+            return np.zeros((n_param, n_param))
+        h = 1e-6 * max(abs(difference), scale)
+        curv = (self._smooth_slope(difference + h, pset_values)
+                - self._smooth_slope(difference - h, pset_values)) / (2. * h)
+        curv = max(curv, 0.0)
+        if curv == 0.0:
+            return np.zeros((n_param, n_param))
+        imin2_eff = imin if imin2 is None else imin2
+        grad_q = self._readout_gradient(raw_sens, n_param, self.qkeys1, self.quant1, imin + a,
+                                        self.qkeys2, self.quant2, imin2_eff + a)
+        return curv * np.outer(grad_q, grad_q)
+
+    def penalty_curvature(self, sim_data_dict, raw_sens, index, n_param, pset_values=None):
+        """The Gauss-Newton curvature of this constraint's **total** penalty (summed over the same
+        enforcement intervals :meth:`penalty_gradient` sums the gradient over) -- the constraint
+        block the EFIM trust-region path (``fit_type = gntr``) adds to the data-fit Hessian (#481),
+        the curvature sibling of :meth:`penalty_gradient`.
+
+        An **estimated constraint scale** (``scale_param``, ADR-0061) couples the readout to the
+        scale (an off-diagonal Fisher block this cut does not assemble), so it is refused with a
+        pointer to the scalar-gradient (L-BFGS-B) path -- on which the estimated-scale column still
+        fits (it rides :meth:`get_penalty_gradient`). Returns zeros for an empty constraint set (a
+        satisfied constraint, or an all-static one, adds no curvature)."""
+        if self.scale_param is not None:
+            from .gradient.errors import GradientNotSupported
+            raise GradientNotSupported(
+                "A constraint with an estimated scale ('%s') couples the readout and scale on the "
+                "EFIM trust-region path (fit_type = gntr, #481); use fit_type = lbfgs." % self.scale_param)
+        curv = np.zeros((n_param, n_param))
+        for interval in self._penalty_intervals(sim_data_dict):
+            curv += self.get_penalty_curvature(sim_data_dict, raw_sens, index, n_param,
+                                               pset_values=pset_values, **interval)
+        return curv
 
 
 class AtConstraint(Constraint):

--- a/pybnf/gradient/__init__.py
+++ b/pybnf/gradient/__init__.py
@@ -14,7 +14,9 @@ bngsim's forward output-sensitivity tensor. This package hosts the PyBNF-side ma
   normalization (#453), the asymmetric Laplace / Student-t families and mean centering (#454),
   and -- via the sibling ``assemble_constraint_gradient`` -- qualitative / inequality constraint
   penalties (#456). A configuration outside the supported set raises :class:`GradientNotSupported`,
-  so a caller can fall back to a gradient-free step.
+  so a caller can fall back to a gradient-free step. For the EFIM trust-region optimizer
+  (``fit_type = gntr``, #481) it additionally assembles the expected-Fisher / Gauss-Newton
+  **Hessian** (``assemble_fisher_hessian`` + the constraint sibling ``assemble_constraint_hessian``).
 
 The capability gate and the per-layer math are documented in ``docs/gradient_fitting.rst``.
 """
@@ -32,7 +34,13 @@ from .routing import (
     route_for_model,
     apply_routing,
 )
-from .assembly import GradientResult, assemble_constraint_gradient, assemble_gaussian_gradient
+from .assembly import (
+    GradientResult,
+    assemble_constraint_gradient,
+    assemble_constraint_hessian,
+    assemble_fisher_hessian,
+    assemble_gaussian_gradient,
+)
 
 __all__ = [
     'GradientNotSupported',
@@ -49,4 +57,6 @@ __all__ = [
     'GradientResult',
     'assemble_gaussian_gradient',
     'assemble_constraint_gradient',
+    'assemble_fisher_hessian',
+    'assemble_constraint_hessian',
 ]

--- a/pybnf/gradient/assembly.py
+++ b/pybnf/gradient/assembly.py
@@ -177,6 +177,10 @@ class GradientResult:
     gradient: np.ndarray      # (n_param,) = J^T rho + estimated-noise columns
     param_names: list         # free-parameter order of the columns / gradient
     least_squares_exact: bool = True   # False once an estimated sigma is present
+    #: The expected-Fisher / Gauss-Newton Hessian (n_param, n_param), sampling space --
+    #: attached only on the EFIM trust-region path (``fit_type = gntr``, #481) by
+    #: :func:`assemble_fisher_hessian`; ``None`` for ``trf`` / ``lbfgs``, which never form it.
+    hessian: np.ndarray = None
 
 
 def assemble_gaussian_gradient(objective, experiments, free_params):
@@ -332,6 +336,102 @@ def _accumulate_experiment(objective, sim_data, exp_data, routing, index, n_para
                 data_fit_gradient += weight * dfit_dpred * dpred_dtheta
                 inexact = True
     return inexact
+
+
+def assemble_fisher_hessian(objective, experiments, free_params):
+    """Assemble the expected-Fisher / Gauss-Newton **Hessian** ``H`` (n_param x n_param),
+    summed across experiments -- the curvature the EFIM trust-region path
+    (``fit_type = gntr``, #481) consumes alongside the scalar gradient
+    :func:`assemble_gaussian_gradient` already produces.
+
+    ``H = sum_i w_i [ kappa_i * outer(s_i, s_i) ]  +  sum_estimated-noise w_i * I_scale *
+    outer(e_p, e_p)`` where ``s_i = d(prediction_i)/d(theta)`` is the same forward
+    sensitivity the gradient uses (through the objective's ``prediction_sensitivity``
+    seam), ``kappa_i`` the per-point location Fisher (``objective.location_fisher_point``:
+    ``(d rho/d pred)**2`` for a residual-bearing Gaussian/Student-t column, the family's
+    ``location_fisher`` for Laplace/count), and ``I_scale`` each estimated noise parameter's
+    Fisher (``objective.noise_fisher_point``). Every rank-1 term is PSD (``kappa >= 0``,
+    ``I_scale >= 0``), so ``H`` is PSD by construction. The location and noise blocks are
+    disjoint (a noise parameter never enters ``s_i``, which is 0 in its column), so the
+    Gaussian estimated-sigma Hessian is block-diagonal, exactly the Fisher predicts.
+
+    ``experiments`` is the same ``(sim_data, exp_data, routing)`` iterable
+    :func:`assemble_gaussian_gradient` consumes, ``free_params`` the same ordered free-
+    parameter list. Mirrors that assembler's point loop exactly (same points, same
+    ``raw_sens`` accessor, same ``prediction_sensitivity``), so the Hessian is formed over
+    precisely the points the gradient and objective score. The native -> sampling transform
+    (ADR-0029) is the gradient's ``d theta/d u`` factor applied on **both** axes:
+    ``H <- diag(f) H diag(f)``. Raises :class:`GradientNotSupported` for a configuration whose
+    Fisher this cut does not assemble (a MEDIAN-centered count, a MEAN-on-log estimated scale,
+    ...), so the fit refuses the EFIM step with a pointer to the L-BFGS-B path."""
+    names = [p.name for p in free_params]
+    index = {name: j for j, name in enumerate(names)}
+    n_param = len(free_params)
+
+    # An estimated free noise scale reads its value from the objective's per-evaluation pset
+    # map (ADR-0021); seed it from the current point exactly as assemble_gaussian_gradient
+    # does, so the Fisher is formed at u (idempotent -- the gradient assembly already seeded it).
+    existing = getattr(objective, '_pset_values', None) or {}
+    objective._pset_values = {**existing, **{p.name: p.value for p in free_params}}
+
+    hessian = np.zeros((n_param, n_param))
+    for sim_data, exp_data, routing in experiments:
+        _accumulate_experiment_fisher(objective, sim_data, exp_data, routing, index, n_param,
+                                      hessian)
+
+    # Native -> sampling space, applied once on both axes (ADR-0029): the same per-parameter
+    # d theta/d u factor the gradient scales its columns by, here as an outer product.
+    factors = _sampling_scale_factors(free_params)
+    return hessian * np.outer(factors, factors)
+
+
+def _accumulate_experiment_fisher(objective, sim_data, exp_data, routing, index, n_param,
+                                  hessian):
+    """Accumulate one experiment's per-point Fisher rank-1 terms into ``hessian`` (the
+    curvature twin of :func:`_accumulate_experiment`). Same independent variable, same
+    comparable-column intersection, same NaN skip, same ``_sim_row_for`` row match, same
+    sorted-column walk -- so the Hessian is assembled over precisely the points the gradient
+    is. The location block reads ``kappa_i`` (``location_fisher_point``) and the noise block
+    each estimated parameter's ``I_scale`` (``noise_fisher_point``)."""
+    sens = sim_data.output_sensitivities
+    if sens is None:
+        raise GradientNotSupported(
+            "An experiment carries no forward-sensitivity tensor; enable the gradient "
+            "path (apply_routing) on every scored model before assembling the Hessian.")
+
+    indvar = min(exp_data.cols, key=exp_data.cols.get)
+    comparable = set(sim_data.cols) | set(objective._per_measurement_models)
+    compare_cols = set(exp_data.cols).intersection(comparable)
+    compare_cols.discard(indvar)
+
+    raw_sens = _raw_sensitivity_accessor(objective, sim_data, sens, routing, index, n_param, indvar)
+
+    for rownum in range(exp_data.data.shape[0]):
+        sim_row = objective._sim_row_for(sim_data, exp_data, indvar, rownum, show_warnings=False)
+        for col_name in sorted(compare_cols):
+            observation = exp_data.data[rownum, exp_data.cols[col_name]]
+            if np.isnan(observation):
+                continue
+            weight = exp_data.weights[rownum, exp_data.cols[col_name]]
+            # d(prediction)/d(theta) through the objective's transform seam -- the SAME
+            # s_i the gradient's residual-Jacobian / data-fit column is built from.
+            dpred_dtheta = objective.prediction_sensitivity(
+                sim_data, sim_row, col_name, exp_data, rownum, raw_sens, index)
+            # Location block: w_i * kappa_i * outer(s_i, s_i). A column whose location
+            # curvature is 0 (a pinned/constant prediction) adds nothing.
+            kappa = objective.location_fisher_point(sim_data, exp_data, sim_row, rownum, col_name)
+            if kappa:
+                hessian += (weight * kappa) * np.outer(dpred_dtheta, dpred_dtheta)
+            # Noise block: each estimated noise parameter's Fisher on its own coordinate.
+            for pname, i_scale in objective.noise_fisher_point(
+                    sim_data, exp_data, sim_row, rownum, col_name).items():
+                if pname not in index:
+                    raise GradientNotSupported(
+                        "Observable '%s' estimates its noise scale as free parameter '%s', "
+                        "but '%s' is not among the gradient's free parameters (%s)."
+                        % (col_name, pname, pname, ', '.join(index) or '(none)'))
+                j = index[pname]
+                hessian[j, j] += weight * i_scale
 
 
 def _sensitivity(sens, selector, route, sim_row):
@@ -548,6 +648,37 @@ def assemble_constraint_gradient(constraint_sets, sim_data_dict, routings, free_
             grad += constraint.penalty_gradient(sim_data_dict, raw_sens, index, n_param,
                                                 pset_values=pset_values)
     return grad * _sampling_scale_factors(free_params)
+
+
+def assemble_constraint_hessian(constraint_sets, sim_data_dict, routings, free_params):
+    """The Gauss-Newton **Hessian** of the total constraint penalty w.r.t. the free parameters
+    (layer I curvature, #481/#456), in **sampling space** -- the constraint block the EFIM
+    trust-region path (``fit_type = gntr``) adds to :func:`assemble_fisher_hessian`'s data-fit
+    Hessian, the curvature sibling of :func:`assemble_constraint_gradient`.
+
+    Each constraint's penalty is ``P(q(theta))`` for an at-/between-time readout ``q``, so its
+    exact Hessian is ``P''(q) * outer(grad q, grad q) + P'(q) * hess q``; the Gauss-Newton term
+    drops the second-order sensitivity ``hess q`` (as the EFIM drops it for the data fit) and
+    clamps ``P''`` to its positive part, giving the PSD ``max(P''(q), 0) * outer(grad q, grad q)``
+    (:meth:`~pybnf.constraint.Constraint.penalty_curvature`). Reuses
+    :func:`_constraint_sensitivity_accessor` for ``grad q`` exactly as the gradient does, and
+    applies the same native -> sampling ``d theta/d u`` factor on both axes. A **piecewise-linear**
+    (static hinge ``.con``) penalty has ``P'' == 0``, so it contributes no curvature -- correct, a
+    linear penalty has none; its pull rides the gradient. Returns zeros for an empty constraint set;
+    raises :class:`GradientNotSupported` for a penalty whose curvature this cut does not assemble
+    (a clipped smooth penalty, an estimated constraint scale) -> the L-BFGS-B fallback."""
+    names = [p.name for p in free_params]
+    index = {name: j for j, name in enumerate(names)}
+    n_param = len(free_params)
+    pset_values = {p.name: p.value for p in free_params}
+    raw_sens = _constraint_sensitivity_accessor(sim_data_dict, routings, index, n_param)
+    hessian = np.zeros((n_param, n_param))
+    for cset in constraint_sets:
+        for constraint in cset.constraints:
+            hessian += constraint.penalty_curvature(sim_data_dict, raw_sens, index, n_param,
+                                                    pset_values=pset_values)
+    factors = _sampling_scale_factors(free_params)
+    return hessian * np.outer(factors, factors)
 
 
 def _constraint_sensitivity_accessor(sim_data_dict, routings, index, n_param):

--- a/pybnf/noise/base.py
+++ b/pybnf/noise/base.py
@@ -183,6 +183,49 @@ class NoiseModel(ABC):
             f'{type(self).__name__} has no noise-parameter gradient on the gradient path '
             f'(#454/#458)')
 
+    def location_fisher(self, prediction, observation, noise, extra=None):
+        """The expected per-point **Fisher information of the location** ``kappa`` -- the
+        Gauss-Newton curvature the EFIM trust-region path (``fit_type = gntr``, #481)
+        weights ``d(prediction)/d(theta)`` by to build its Hessian ``H = sum_i kappa_i
+        s_i s_i^T``. ``kappa`` is the expected ``E[-d^2 log p / d mu^2]`` carried through
+        the prediction: for a location-scale family additive on a scale it is
+        ``(forward'(pred))**2 * I_additive`` (the unit location Fisher in the additive
+        space times the scale's chain factor squared).
+
+        Only a **non-residual** family in scope overrides it -- Laplace
+        (``(forward'(pred))**2 / b**2``) and the count family (its mean's Fisher, through
+        the location realization). A **residual-bearing** family (Gaussian, Student-t) is
+        never asked: the assembly reads its location curvature straight off the residual
+        Jacobian (``d_residual_d_prediction**2``, which *is* the Fisher there), so it takes
+        that path. The base raises, so an unsupported family/config refuses the EFIM step
+        with a pointer back to the scalar-gradient (L-BFGS-B) path."""
+        from ..gradient.errors import GradientNotSupported
+        raise GradientNotSupported(
+            "%s has no expected location Fisher on the EFIM trust-region path "
+            "(fit_type = gntr, #481)." % type(self).__name__)
+
+    def noise_param_fisher(self, prediction, observation, noise, extra=None):
+        """``{param_name: I_scale}`` -- the expected **Fisher information of each estimated
+        noise parameter**, the diagonal noise block of the EFIM Hessian (``fit_type =
+        gntr``, #481). The assembly reads it only for a parameter whose source is
+        *estimated* (a free parameter), exactly as :meth:`noise_grad_point` emits a column
+        only for an estimated parameter, and accumulates ``w_i * I_scale *
+        outer(e_param, e_param)`` (the free parameter *is* the noise parameter, so the
+        curvature direction is that parameter's own coordinate). The location-scale cross
+        Fisher is 0 for the symmetric families on linear/MEDIAN, so the block is diagonal
+        there -- a family whose estimated scale couples to the location (a MEAN on a log
+        scale) refuses instead.
+
+        Overridden by the families whose estimated-scale block this cut assembles --
+        Gaussian (``{'sigma': 2/sigma**2}``) and Laplace (``{'scale': 1/b**2}``). The base
+        raises, which is exactly the refusal for an out-of-scope estimated scale (the count
+        family's free dispersion, the Student-t 2-parameter block): the fit falls back to
+        the scalar-gradient (L-BFGS-B) path."""
+        from ..gradient.errors import GradientNotSupported
+        raise GradientNotSupported(
+            "%s has no estimated-noise Fisher block on the EFIM trust-region path "
+            "(fit_type = gntr, #481)." % type(self).__name__)
+
     def nll(self, prediction, observation, noise, extra=None):
         """The full per-point negative log-likelihood (data fit + every parameter's
         normalizer)."""

--- a/pybnf/noise/gaussian.py
+++ b/pybnf/noise/gaussian.py
@@ -98,6 +98,26 @@ class Gaussian(NoiseModel):
         return {'sigma': (1. - rho ** 2) / noise
                 - rho * self.location.d_offset_d_noise(self, noise) / noise}
 
+    def noise_param_fisher(self, prediction, observation, noise, extra=None):
+        """``{'sigma': 2/sigma**2}`` -- the expected Fisher information of an estimated
+        Gaussian scale, the noise block of the EFIM Hessian (``fit_type = gntr``, #481).
+        With the per-point loss ``R**2/(2 sigma**2) + log sigma`` (``R`` the additive-space
+        residual), ``d^2/d sigma^2 = 3 R**2/sigma^4 - 1/sigma^2`` and ``E[R**2] = sigma**2``,
+        so ``E[d^2] = 3/sigma^2 - 1/sigma^2 = 2/sigma^2``. Using the *expected* value (not the
+        data-dependent observed second derivative, which can go negative) is what keeps the
+        block positive-definite. The location-scale cross Fisher is 0 by symmetry
+        (``E[d^2/d mu d sigma] = -2 E[R]/sigma^3 = 0``), so the block is diagonal -- **except**
+        a MEAN centered on a log scale, where the moment offset ``mu = forward(pred) -
+        offset(sigma)`` couples location and scale; that corner is refused (its scalar gradient
+        still fits under ``fit_type = lbfgs``)."""
+        if self.location.d_offset_d_noise(self, noise) != 0.0:
+            from ..gradient.errors import GradientNotSupported
+            raise GradientNotSupported(
+                "An estimated Gaussian sigma centering a MEAN on a log scale couples the "
+                "location and scale (a nonzero cross-Fisher), which the EFIM trust-region "
+                "path (fit_type = gntr, #481) does not assemble this cut; use fit_type = lbfgs.")
+        return {'sigma': 2.0 / noise ** 2.}
+
     def log_normalizer(self, noise):
         return np.log(noise)
 

--- a/pybnf/noise/laplace.py
+++ b/pybnf/noise/laplace.py
@@ -133,5 +133,34 @@ class Laplace(NoiseModel):
         return {'scale': -np.sign(residual) * self.location.d_offset_d_noise(self, noise) / noise
                 - abs(residual) / noise ** 2. + 1. / noise}
 
+    def location_fisher(self, prediction, observation, noise, extra=None):
+        """``kappa = (forward'(pred))**2 / b**2`` -- the Laplace location Fisher, the
+        Gauss-Newton curvature the EFIM trust-region path (``fit_type = gntr``, #481) weights
+        ``d(prediction)/d(theta)`` by. The unit Fisher of a Laplace location is ``1/b**2``
+        (``E[(sign(R)/b)**2] = 1/b**2``); the scale's chain factor ``forward'(pred)`` carries
+        it to the prediction (``1`` on the linear scale). Laplace is **not** residual-bearing
+        (its L1 data fit is the cusp ``sqrt|z|``, #459), so the assembly reads its location
+        curvature here rather than off a residual Jacobian. Holds for MEDIAN and MEAN alike --
+        the offset is prediction-independent, so ``d mu/d pred = forward'(pred)`` either way.
+        Note the *observed* second derivative of ``|R|/b`` is 0 almost everywhere; the
+        *expected* Fisher ``1/b**2`` is the well-posed curvature (why an EFIM step, not a plain
+        Newton step, is what makes L1 tractable)."""
+        return (self.additive_on.dforward(prediction) / noise) ** 2.
+
+    def noise_param_fisher(self, prediction, observation, noise, extra=None):
+        """``{'scale': 1/b**2}`` -- the expected Fisher of an estimated Laplace scale, the noise
+        block of the EFIM Hessian (``fit_type = gntr``, #481). With the per-point loss
+        ``|R|/b + log(2 b)``, ``d^2/d b^2 = 2|R|/b^3 - 1/b^2`` and ``E[|R|] = b``, so
+        ``E[d^2] = 2/b^2 - 1/b^2 = 1/b^2``. Diagonal (cross-Fisher 0 by symmetry), except a MEAN
+        on a log scale, refused as for Gaussian (its scalar gradient still fits under
+        ``fit_type = lbfgs``)."""
+        if self.location.d_offset_d_noise(self, noise) != 0.0:
+            from ..gradient.errors import GradientNotSupported
+            raise GradientNotSupported(
+                "An estimated Laplace scale centering a MEAN on a log scale couples the "
+                "location and scale on the EFIM trust-region path (fit_type = gntr, #481); "
+                "use fit_type = lbfgs.")
+        return {'scale': 1.0 / noise ** 2.}
+
     def log_normalizer(self, noise):
         return np.log(2. * noise)

--- a/pybnf/noise/negative_binomial.py
+++ b/pybnf/noise/negative_binomial.py
@@ -208,3 +208,28 @@ class NegBinomial(NoiseModel):
             dG_d_r = _d_betainc_d_a(r, target + 1.0, prob) + beta_pdf * mean / (r + mean) ** 2.
             d_fit_d_r += d_fit_d_mean * (-dG_d_r / dG_d_mean)
         return {'dispersion': d_fit_d_r}
+
+    def location_fisher(self, prediction, observation, noise, extra=None):
+        """``kappa = I_mean = r / (mean (r + mean))`` -- the negative-binomial **mean's** Fisher
+        information, the Gauss-Newton curvature the EFIM trust-region path (``fit_type = gntr``,
+        #481) weights ``d(prediction)/d(theta)`` by. It is the variance of the mean score
+        ``d(-logpmf)/d mean = r (mean - obs) / (mean (r + mean))`` (``Var(obs) = mean (r + mean)/r``,
+        so ``I_mean = [r/(mean(r+mean))]**2 * Var(obs) = r/(mean(r+mean))``).
+
+        * **MEAN**: the prediction *is* the mean (``d mean/d pred = 1``), so ``kappa`` is this
+          directly -- the case this cut supports (``neg_bin`` / ``neg_bin_dynamic`` pinned to MEAN).
+        * **MEDIAN**: the mean sits behind the betainc CDF inversion (``_mean_for_median``), whose
+          ``d mean/d pred`` is the non-elementary implicit derivative; its location Fisher is out of
+          scope for this cut -- refused, pointing at ``fit_type = lbfgs`` (which fits it via the
+          scalar data-fit gradient). A negative observation contributes no curvature (the
+          count-domain guard, mirroring :meth:`data_fit`)."""
+        if self.location is MEDIAN:
+            from ..gradient.errors import GradientNotSupported
+            raise GradientNotSupported(
+                "A MEDIAN-centered negative-binomial has its mean behind a betainc CDF inversion, "
+                "whose location Fisher the EFIM trust-region path (fit_type = gntr, #481) does not "
+                "assemble this cut; use fit_type = lbfgs.")
+        mean = self._mean(prediction, noise)
+        if observation < 0 or mean <= 0.0:
+            return 0.0
+        return noise / (mean * (noise + mean))

--- a/pybnf/objective.py
+++ b/pybnf/objective.py
@@ -334,6 +334,26 @@ class ObjectiveFunction:
             "Objective %s has no differentiable data-fit gradient on the gradient path (#385)."
             % type(self).__name__)
 
+    def location_fisher_point(self, sim_data, exp_data, sim_row, exp_row, col_name):
+        """The expected per-point **Fisher information of the location** ``kappa`` for one scored
+        point -- the Gauss-Newton curvature the EFIM trust-region path (``fit_type = gntr``, #481)
+        weights ``d(prediction)/d(theta)`` by (``H = sum_i w_i * kappa_i * outer(s_i, s_i)``). The
+        twin of :meth:`residual_point` on the curvature side; the base raises
+        :class:`GradientNotSupported`, since only a per-point likelihood defines a location Fisher
+        (a non-likelihood / unsupported objective already refuses at ``residual_point``). Only
+        :class:`LikelihoodObjective` overrides it."""
+        from .gradient.errors import GradientNotSupported
+        raise GradientNotSupported(
+            "Objective %s has no Fisher-information location curvature on the EFIM trust-region "
+            "path (fit_type = gntr, #481)." % type(self).__name__)
+
+    def noise_fisher_point(self, sim_data, exp_data, sim_row, exp_row, col_name):
+        """The per-point expected **Fisher information of each estimated free noise parameter** --
+        ``{free_param: I_scale}`` (the diagonal noise block of the EFIM Hessian, #481). The twin
+        of :meth:`noise_grad_point` on the curvature side. Empty on the base (a non-likelihood
+        objective estimates no noise parameter); only :class:`LikelihoodObjective` overrides it."""
+        return {}
+
 
 class SummationObjective(ObjectiveFunction):
     """
@@ -1146,6 +1166,49 @@ class LikelihoodObjective(SummationObjective):
         observation = exp_data.data[exp_row, exp_data.cols[col_name]]
         primary, extra = self._noise_values(family, sources, self, exp_data, exp_row, col_name)
         return family.d_data_fit_d_prediction(prediction, observation, primary, extra)
+
+    def location_fisher_point(self, sim_data, exp_data, sim_row, exp_row, col_name):
+        """The expected per-point **Fisher information of the location** ``kappa`` -- the
+        Gauss-Newton curvature the EFIM trust-region Hessian weights ``d(prediction)/d(theta)``
+        by (``fit_type = gntr``, #481). Read through the same ``_prediction`` / ``_noise_values``
+        seams as ``residual_point`` / ``data_fit_grad_point``, so it is the curvature of exactly
+        the loss PyBNF scores.
+
+        A **residual-bearing** family (Gaussian, Student-t) has ``kappa == (d rho/d pred)**2``
+        identically -- the assembly's residual-Jacobian already carries it -- so this returns that
+        square directly (no new family math). A **non-residual** family (Laplace, count) delegates
+        to the family's :meth:`~pybnf.noise.base.NoiseModel.location_fisher`. Any configuration the
+        family refuses (a MEDIAN-centered count, ...) raises :class:`GradientNotSupported`, so the
+        fit falls back to the scalar-gradient (L-BFGS-B) path."""
+        family, sources = self._spec_for(col_name)
+        self._require_gradient_supported(col_name, family, sources)
+        prediction = self._prediction(sim_data, sim_row, col_name, exp_data, exp_row)
+        observation = exp_data.data[exp_row, exp_data.cols[col_name]]
+        primary, extra = self._noise_values(family, sources, self, exp_data, exp_row, col_name)
+        if self.has_least_squares_residual(col_name):
+            drho = family.d_residual_d_prediction(prediction, observation, primary, extra)
+            return drho * drho
+        return family.location_fisher(prediction, observation, primary, extra)
+
+    def noise_fisher_point(self, sim_data, exp_data, sim_row, exp_row, col_name):
+        """The per-point expected **Fisher information of each estimated free noise parameter** --
+        ``{free_param_name: I_scale}`` (the diagonal noise block of the EFIM Hessian, #481). The
+        curvature twin of :meth:`noise_grad_point`: empty for a fixed-noise point, else each
+        estimated noise parameter's :meth:`~pybnf.noise.base.NoiseModel.noise_param_fisher` entry,
+        keyed by the source's free-parameter name (the free parameter *is* the noise parameter, so
+        the curvature lands on that parameter's own coordinate). A coupled corner the family refuses
+        (a MEAN-on-log estimated scale, the count family's free dispersion) raises
+        :class:`GradientNotSupported` -> the L-BFGS-B fallback."""
+        family, sources = self._spec_for(col_name)
+        estimated = {name: src for name, src in sources.items() if src.estimated}
+        if not estimated:
+            return {}
+        self._require_gradient_supported(col_name, family, sources)
+        prediction = self._prediction(sim_data, sim_row, col_name, exp_data, exp_row)
+        observation = exp_data.data[exp_row, exp_data.cols[col_name]]
+        primary, extra = self._noise_values(family, sources, self, exp_data, exp_row, col_name)
+        per_param = family.noise_param_fisher(prediction, observation, primary, extra)
+        return {src.required_free_param(): per_param[name] for name, src in estimated.items()}
 
     def has_least_squares_residual(self, col_name):
         """Whether this observable contributes an **exact** least-squares residual/Jacobian

--- a/pybnf/parse.py
+++ b/pybnf/parse.py
@@ -44,10 +44,11 @@ numkeys_int = ['verbosity', 'parallel_count', 'delete_old_files', 'population_si
                # cross-parameter parallel-track cap (#467).
                'profile_likelihood_max_iterations', 'profile_likelihood_max_points',
                'profile_likelihood_reopt_max_iterations', 'profile_likelihood_max_parallel',
-               # gradient optimizers (fit_type = trf / lbfgs, #386): the int-valued
-               # tunables -- L-BFGS-B's curvature-history depth and the two cycle
-               # budgets (runtime-guarded RUNTIME_KEYS, defaulting to max_iterations).
+               # gradient optimizers (fit_type = trf / lbfgs / gntr, #386/#481): the
+               # int-valued tunables -- L-BFGS-B's curvature-history depth and the three
+               # cycle budgets (runtime-guarded RUNTIME_KEYS, defaulting to max_iterations).
                'lbfgs_history', 'trf_max_iterations', 'lbfgs_max_iterations',
+               'gntr_max_iterations',
                # DREAM multi-try count (ADR-0067 Stage 2, #357): candidate proposals
                # per chain per generation (n_try = 1 is the classic single-try engine).
                'n_try']
@@ -60,11 +61,13 @@ numkeys_float = ['min_objective', 'cognitive', 'social', 'particle_weight',
                  'rhat_threshold', 'snooker_prob',
                  'powell_step', 'powell_line_tol', 'powell_stop_tol',
                  'cmaes_sigma0', 'cmaes_stop_tol',
-                 # gradient optimizers (fit_type = trf / lbfgs, #386): the float-valued
-                 # tunables -- the trust-region-reflective / L-BFGS-B optimality +
-                 # step tolerances and L-BFGS-B's Armijo constant / backtrack factor.
+                 # gradient optimizers (fit_type = trf / lbfgs / gntr, #386/#481): the
+                 # float-valued tunables -- the trust-region-reflective / L-BFGS-B / EFIM
+                 # optimality + step tolerances, L-BFGS-B's Armijo constant / backtrack
+                 # factor, and GNTR's relative Levenberg ridge on the Fisher Hessian.
                  'trf_grad_tol', 'trf_step_tol', 'lbfgs_grad_tol', 'lbfgs_step_tol',
                  'lbfgs_c1', 'lbfgs_backtrack',
+                 'gntr_grad_tol', 'gntr_step_tol', 'gntr_ridge',
                  # HMC (job_type = hmc, ADR-0059): NUTS dual-averaging target acceptance.
                  'target_accept',
                  # profile likelihood (job_type = profile_likelihood, #446/#466): confidence

--- a/tests/recovery_harness.py
+++ b/tests/recovery_harness.py
@@ -49,6 +49,7 @@ _ALGORITHMS = {
     'am': algorithms.Adaptive_MCMC,
     'trf': algorithms.TRFAlgorithm,   # gradient-based least-squares optimizer (#386)
     'lbfgs': algorithms.LBFGSAlgorithm,   # gradient-based scalar quasi-Newton fallback (#386)
+    'gntr': algorithms.GNTRAlgorithm,   # general-objective Fisher/Gauss-Newton trust region (#481)
     'profile_likelihood': algorithms.ProfileLikelihoodAlgorithm,   # PL identifiability (#446/#466)
 }
 

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -325,15 +325,16 @@ class TestRegistrySchemaSeam:
         # Stage (b) migrates one method/family per step: pso (Step 1), de+ade
         # (Step 2), ss (Step 3), sim (Step 4), the whole MCMC family (Step 5).
         # powell + cmaes land co-located with their own schemas (#403/ADR-0015).
-        # The gradient-based optimizers (#386) land with their own schemas: trf
-        # (trust-region least-squares) with TRFConfig and lbfgs (L-BFGS-B) with
-        # LBFGSConfig. profile_likelihood (#446/#466) lands with ProfileLikelihoodConfig.
+        # The gradient-based optimizers (#386/#481) land with their own schemas: trf
+        # (trust-region least-squares) with TRFConfig, lbfgs (L-BFGS-B) with LBFGSConfig,
+        # and gntr (general-objective Fisher/Gauss-Newton trust region) with GNTRConfig.
+        # profile_likelihood (#446/#466) lands with ProfileLikelihoodConfig.
         # Only 'check' remains unmigrated. Each step extends this set -- a ratchet.
         from pybnf.registry import FIT_TYPE_REGISTRY
         migrated = {c for c, e in FIT_TYPE_REGISTRY.items() if e.schema is not None}
         assert migrated == {'pso', 'de', 'ade', 'ss', 'sim', 'powell', 'cmaes',
                             'mh', 'pt', 'sa', 'am', 'dream', 'p_dream', 'hmc', 'trf', 'lbfgs',
-                            'profile_likelihood'}
+                            'gntr', 'profile_likelihood'}
         assert FIT_TYPE_REGISTRY['check'].schema is None
 
 

--- a/tests/test_gradient_assembly.py
+++ b/tests/test_gradient_assembly.py
@@ -27,7 +27,8 @@ import pytest
 
 from pybnf.data import Data, OutputSensitivities
 from pybnf.gradient import (
-    assemble_constraint_gradient, assemble_gaussian_gradient, GradientNotSupported,
+    assemble_constraint_gradient, assemble_constraint_hessian, assemble_fisher_hessian,
+    assemble_gaussian_gradient, GradientNotSupported,
     PARAM, IC, NONE, ExperimentRouting, ParamRoute, route_experiment,
 )
 from pybnf.gradient.assembly import _sampling_scale_factors
@@ -2905,3 +2906,198 @@ def test_fd_acceptance_gate_dose_response(k_type):
     # Fixed sigma, all-Gaussian: the residual/Jacobian is the whole objective.
     assert res.least_squares_exact is True
     np.testing.assert_allclose(res.gradient, grad_fd, rtol=1e-4, atol=1e-4)
+
+
+# ================================================== EFIM / Fisher Hessian (#481) ===
+# assemble_fisher_hessian assembles the expected-Fisher / Gauss-Newton Hessian the EFIM
+# trust-region optimizer (fit_type = gntr) consumes. Because it is the *expected* Fisher
+# (not the observed second derivative), a finite difference of the assembled gradient does
+# NOT equal it in general (they agree only in expectation for the noise/Laplace/count
+# blocks); these checks are closed-form, plus the headline J^T J consistency that proves
+# the Gaussian case reduces to trf's curvature.
+
+def test_fisher_hessian_gaussian_equals_jtj():
+    """The Fisher/Gauss-Newton Hessian of a fixed-sigma Gaussian fit is exactly the residual
+    Jacobian's ``J^T J`` -- the same Gauss-Newton curvature ``trf`` uses (``kappa ==
+    (d rho/d pred)^2`` for a residual-bearing family). Two parameters + a per-condition factor
+    exercise the outer products; the result is symmetric PSD."""
+    pred = np.array([120.0, 80.0, 53.0, 36.0])
+    obs = np.array([118.0, 82.0, 50.0, 38.0])
+    sigma = 4.0
+    dk = np.array([0.0, -80.0, -106.0, -108.0])
+    ds0 = np.array([1.0, 0.66, 0.44, 0.30])
+    obj = ChiSquareObjective()
+    sim = _sim_with_sensitivities(pred, d_param=dk, d_ic=ds0)
+    exp = _exp(obs, sigma)
+    routing = ExperimentRouting(routes={
+        'k': ParamRoute('k', PARAM, 'k', 4.0), 'S0': ParamRoute('S0', IC, 'S()', 1.0)})
+    free = _free(('k', 'uniform_var', 0.0, 10.0, 0.3), ('S0', 'uniform_var', 0.0, 500.0, 120.0))
+
+    res = assemble_gaussian_gradient(obj, [(sim, exp, routing)], free)
+    H = assemble_fisher_hessian(obj, [(sim, exp, routing)], free)
+
+    np.testing.assert_allclose(H, res.jacobian.T @ res.jacobian)
+    np.testing.assert_allclose(H, H.T)                       # symmetric
+    assert np.all(np.linalg.eigvalsh(H) >= -1e-9)            # PSD
+
+
+def test_fisher_hessian_sums_across_experiments():
+    """The Hessian is summed across experiments -- assembling two together equals adding the
+    two single-experiment Hessians (the outer-product sum is linear over points)."""
+    obj = ChiSquareObjective()
+    free = _free(('k', 'uniform_var', 0.0, 10.0, 0.3))
+    sim1 = _sim_with_sensitivities([100, 74, 55, 41], d_param=[0, -74, -110, -123])
+    exp1 = _exp([100, 70, 60, 40], 5.0)
+    r1 = ExperimentRouting(routes={'k': ParamRoute('k', PARAM, 'k', 1.0)})
+    sim2 = _sim_with_sensitivities([100, 55, 30, 17], d_param=[0, -110, -120, -100])
+    exp2 = _exp([100, 58, 28, 20], 3.0)
+    r2 = ExperimentRouting(routes={'k': ParamRoute('k', PARAM, 'k', 4.0)})
+
+    both = assemble_fisher_hessian(obj, [(sim1, exp1, r1), (sim2, exp2, r2)], free)
+    h1 = assemble_fisher_hessian(obj, [(sim1, exp1, r1)], free)
+    h2 = assemble_fisher_hessian(obj, [(sim2, exp2, r2)], free)
+    np.testing.assert_allclose(both, h1 + h2)
+
+
+def test_fisher_hessian_estimated_sigma_adds_diagonal_noise_block():
+    """An estimated free sigma (``chi_sq_dynamic``) adds the expected-Fisher noise block
+    ``sum_i 2/sigma^2`` on the sigma coordinate, block-diagonal (no location-scale cross term),
+    while the model-parameter block stays the data-fit ``J^T J``. The sigma column of the
+    residual-Jacobian is zero, so the noise curvature exists only on the Hessian's own block."""
+    pred = np.array([100.0, 74.0, 55.0, 41.0])
+    obs = np.array([100.0, 70.0, 60.0, 40.0])
+    sigma = 5.0
+    dk = np.array([0.0, -74.0, -110.0, -123.0])
+    obj = _free_sigma_objective('noise_sd')
+    sim = _sim_with_sensitivities(pred, d_param=dk)
+    exp = _exp_dyn(obs)
+    routing = ExperimentRouting(routes={
+        'k': ParamRoute('k', PARAM, 'k', 1.0),
+        'noise_sd': ParamRoute('noise_sd', NONE, None, 1.0)})
+    free = _free(('k', 'uniform_var', 0.0, 10.0, 0.3),
+                 ('noise_sd', 'uniform_var', 0.01, 100.0, sigma))
+
+    H = assemble_fisher_hessian(obj, [(sim, exp, routing)], free)
+
+    np.testing.assert_allclose(H[0, 0], np.sum((dk / sigma) ** 2))      # data-fit block
+    np.testing.assert_allclose(H[1, 1], len(obs) * 2.0 / sigma ** 2)    # sigma Fisher 2/sigma^2
+    np.testing.assert_allclose(H[0, 1], 0.0)                           # block-diagonal
+    np.testing.assert_allclose(H[1, 0], 0.0)
+
+
+def test_fisher_hessian_laplace_location_block():
+    """A fixed-scale Laplace fit's Fisher Hessian is the location block ``sum_i (1/b^2)
+    outer(s_i, s_i)`` -- Laplace's expected location Fisher ``1/b^2`` (its observed second
+    derivative is 0, so the expected Fisher is what makes an L1 Newton step well-posed)."""
+    pred = np.array([100.0, 74.0, 55.0, 41.0])
+    obs = np.array([100.0, 70.0, 60.0, 40.0])
+    b = 3.0
+    dk = np.array([0.0, -74.0, -110.0, -123.0])
+    obj = _laplace_objective()                 # fixed _SD column scale
+    sim = _sim_with_sensitivities(pred, d_param=dk)
+    exp = _exp(obs, b)                          # Stot_SD column == b
+    routing = ExperimentRouting(routes={'k': ParamRoute('k', PARAM, 'k', 1.0)})
+    free = _free(('k', 'uniform_var', 0.0, 10.0, 0.3))
+
+    H = assemble_fisher_hessian(obj, [(sim, exp, routing)], free)
+    np.testing.assert_allclose(H[0, 0], np.sum((1.0 / b ** 2) * dk ** 2))
+
+
+def test_fisher_hessian_neg_bin_mean_location_block():
+    """A fixed-dispersion negative-binomial (MEAN) fit's Fisher Hessian is the location block
+    ``sum_i kappa_i outer(s_i, s_i)`` with ``kappa_i = r/(mean(r+mean))`` the mean's Fisher
+    (``mean == prediction`` for MEAN)."""
+    pred = np.array([50.0, 40.0, 30.0, 22.0])
+    obs = np.array([48.0, 42.0, 28.0, 24.0])
+    r = 6.0
+    dk = np.array([0.0, -8.0, -12.0, -11.0])
+    obj = _neg_bin_objective(location=MEAN, dispersion=r)
+    sim = _sim_with_sensitivities(pred, d_param=dk)
+    exp = _exp_dyn(obs)                          # self-normalizing PMF, no _SD column
+    routing = ExperimentRouting(routes={'k': ParamRoute('k', PARAM, 'k', 1.0)})
+    free = _free(('k', 'uniform_var', 0.0, 100.0, 0.3))
+
+    H = assemble_fisher_hessian(obj, [(sim, exp, routing)], free)
+    kappa = r / (pred * (r + pred))
+    np.testing.assert_allclose(H[0, 0], np.sum(kappa * dk ** 2))
+
+
+def test_fisher_hessian_refuses_median_negative_binomial():
+    """A MEDIAN-centered count family has its mean behind the betainc CDF inversion, whose
+    location Fisher this cut does not assemble -- refused with GradientNotSupported (-> lbfgs)."""
+    obj = _neg_bin_objective(location=MEDIAN, dispersion=6.0)
+    sim = _sim_with_sensitivities([50.0, 40.0, 30.0, 22.0], d_param=[0.0, -8.0, -12.0, -11.0])
+    exp = _exp_dyn([48.0, 42.0, 28.0, 24.0])
+    routing = ExperimentRouting(routes={'k': ParamRoute('k', PARAM, 'k', 1.0)})
+    free = _free(('k', 'uniform_var', 0.0, 100.0, 0.3))
+    with pytest.raises(GradientNotSupported):
+        assemble_fisher_hessian(obj, [(sim, exp, routing)], free)
+
+
+def test_fisher_hessian_refuses_mean_on_log_estimated_scale():
+    """An estimated sigma centering a MEAN on a log scale couples location and scale (a nonzero
+    cross-Fisher this cut does not assemble) -- refused with GradientNotSupported (-> lbfgs)."""
+    obj = LikelihoodObjective(noise=Gaussian(additive_on=LOG10, location=MEAN),
+                              sigma_sources={'sigma': FreeParameterSigma('noise_sd')})
+    sim = _sim_with_sensitivities([100.0, 74.0, 55.0, 41.0], d_param=[0.0, -74.0, -110.0, -123.0])
+    exp = _exp_dyn([100.0, 70.0, 60.0, 40.0])
+    routing = ExperimentRouting(routes={
+        'k': ParamRoute('k', PARAM, 'k', 1.0),
+        'noise_sd': ParamRoute('noise_sd', NONE, None, 1.0)})
+    free = _free(('k', 'uniform_var', 0.0, 10.0, 0.3),
+                 ('noise_sd', 'uniform_var', 0.01, 100.0, 0.2))
+    with pytest.raises(GradientNotSupported):
+        assemble_fisher_hessian(obj, [(sim, exp, routing)], free)
+
+
+def test_constraint_hessian_static_is_zero():
+    """A static (piecewise-linear hinge) constraint penalty has zero curvature -- a linear
+    penalty contributes no Gauss-Newton Hessian (its pull rides the gradient, and the data-fit
+    Fisher + ridge supply the step's curvature)."""
+    sdd, routings, free = _constraint_sim(_C_STOT, _C_DK, _C_DS0)
+    c = AtConstraint('Stot', '>', 90.0, 'm', 'tc', weight=2.0, atvar=None, atval=2.0)
+    cset = ConstraintSet('m', 'tc'); cset.constraints = [c]
+    H = assemble_constraint_hessian([cset], sdd, routings, free)
+    np.testing.assert_allclose(H, 0.0)
+
+
+def test_constraint_hessian_logit_matches_closed_form():
+    """The logit softplus penalty's Gauss-Newton curvature is ``sigma(x)(1-sigma(x))/s^2 *
+    outer(grad q, grad q)`` (``P'' `` of ``ln(1+e^{d/s})``, ``x = difference/s``), at the
+    achieving row -- symmetric PSD."""
+    from pybnf.constraint import _sigmoid
+    sdd, routings, free = _constraint_sim(_C_STOT, _C_DK, _C_DS0)
+    s = 12.0
+    c = AtConstraint('Stot', '>', 90.0, 'm', 'tc', weight=None, atvar=None, atval=2.0, scale=s)
+    cset = ConstraintSet('m', 'tc'); cset.constraints = [c]
+    H = assemble_constraint_hessian([cset], sdd, routings, free)
+    x = (90.0 - _C_STOT[2]) / s
+    pp = _sigmoid(x) * (1.0 - _sigmoid(x)) / s ** 2
+    grad_q = np.array([-_C_DK[2], -_C_DS0[2]])       # d(90 - Stot)/d theta at row 2
+    np.testing.assert_allclose(H, pp * np.outer(grad_q, grad_q), rtol=1e-5)
+    np.testing.assert_allclose(H, H.T)
+    assert np.all(np.linalg.eigvalsh(H) >= -1e-12)
+
+
+def test_constraint_hessian_satisfied_is_zero():
+    """A satisfied smooth-penalty constraint far from its boundary contributes negligible
+    curvature (the softplus is nearly flat there), and a satisfied static one exactly zero."""
+    sdd, routings, free = _constraint_sim(_C_STOT, _C_DK, _C_DS0)
+    c = AtConstraint('Stot', '<', 90.0, 'm', 'tc', weight=2.0, atvar=None, atval=2.0)  # 55 < 90 ok
+    cset = ConstraintSet('m', 'tc'); cset.constraints = [c]
+    H = assemble_constraint_hessian([cset], sdd, routings, free)
+    np.testing.assert_allclose(H, 0.0)
+
+
+def test_constraint_hessian_refuses_estimated_scale():
+    """A constraint with an estimated (free-parameter-tied) scale couples the readout and scale
+    (an off-diagonal Fisher block this cut does not assemble) -- refused (-> lbfgs). Its gradient
+    column still fits under ``fit_type = lbfgs``."""
+    sdd, routings, _ = _constraint_sim(_C_STOT, _C_DK, _C_DS0)
+    c = AtConstraint('Stot', '>', 90.0, 'm', 'tc', weight=None, atvar=None, atval=2.0, scale=12.0)
+    c.bind_scale_param('s_q')
+    cset = ConstraintSet('m', 'tc'); cset.constraints = [c]
+    free = _free(('k', 'uniform_var', 0.0, 100.0, 0.4), ('S0', 'uniform_var', 0.0, 1000.0, 120.0),
+                 ('s_q', 'uniform_var', 0.1, 1000.0, 12.0))
+    with pytest.raises(GradientNotSupported):
+        assemble_constraint_hessian([cset], sdd, routings, free)

--- a/tests/test_gradient_optimizer.py
+++ b/tests/test_gradient_optimizer.py
@@ -493,6 +493,118 @@ def test_lbfgs_refuses_legacy_edition_before_building_models(tmp_path):
 
 
 # --------------------------------------------------------------------------- #
+# GNTR -- the general-objective Fisher/Gauss-Newton trust region (#481)
+# --------------------------------------------------------------------------- #
+# The missing cell: a trust-region step with TRF's Gauss-Newton/EFIM Hessian, extended
+# to the general-NLL objectives TRF refuses (estimated noise scale, Laplace/count,
+# constraints) and LBFGS handles only with a history Hessian. These prove (a) it recovers
+# a fixed-scale fit like TRF/LBFGS, (b) the distinguishing case -- an *estimated* noise
+# scale (chi_sq_dynamic), which TRF rejects but GNTR now fits with a trust-region EFIM
+# step, and (c) picklability + the edition gate (offline).
+
+
+@pytest.mark.recovery
+@pytest.mark.skipif(not BNGSIM_HAS_OUTPUT_SENS,
+                    reason='needs a bngsim build with the output_sensitivities feature')
+def test_gntr_recovers_decay_rate_and_initial_condition(tmp_path, monkeypatch):
+    """``fit_type = gntr`` recovers both the rate ``k`` and the initial amount ``S0`` of an
+    exponential decay from the box center, through the real bngsim forward-sensitivity path --
+    on a fixed-scale (exact least-squares) fit its EFIM Hessian is ``J^T J``, so it drives the
+    async trust-region loop to the optimum exactly as TRF does (the sibling of the TRF/LBFGS
+    recovery tests on the same model)."""
+    H.require_bng2pl()
+    H.install(monkeypatch)
+    model = _decay_model(tmp_path)
+    exp = _write_decay_exp(tmp_path / 'decay.exp')
+    conf = H.make_newera_config(
+        tmp_path, model, exp,
+        {'k': ('uniform_var', 1e-2, 3.0), 'S0': ('uniform_var', 20.0, 400.0)},
+        'decay', 'gntr', objective='chi_sq', random_seed=1234,
+        population_size=1, max_iterations=100)
+
+    alg = H.build(conf, 'gntr')
+    H.drive(alg)
+
+    rec = H.best_params(alg, ('k', 'S0'))
+    assert abs(rec['k'] - TRUE_K) / TRUE_K < 0.02, \
+        'k recovered %g, expected ~%g' % (rec['k'], TRUE_K)
+    assert abs(rec['S0'] - TRUE_S0) / TRUE_S0 < 0.02, \
+        'S0 recovered %g, expected ~%g' % (rec['S0'], TRUE_S0)
+    assert alg.trajectory.best_score() < 1e-3, \
+        'best objective %g not ~0' % alg.trajectory.best_score()
+
+
+@pytest.mark.recovery
+@pytest.mark.skipif(not BNGSIM_HAS_OUTPUT_SENS,
+                    reason='needs a bngsim build with the output_sensitivities feature')
+def test_gntr_fits_estimated_noise_scale_that_trf_refuses(tmp_path, monkeypatch):
+    """The distinguishing case, and the reason ``gntr`` exists. With an **estimated** noise
+    scale (``chi_sq_dynamic``'s free ``sigma__FREE``), the objective keeps a ``+log σ``
+    normalizer that is not a square, so ``least_squares_exact`` is ``False`` and TRF refuses the
+    fit (``test_trf_refuses_non_least_squares_objective_pointing_at_lbfgs``). ``gntr`` builds the
+    EFIM Hessian instead -- the data-fit ``J^T J`` plus the estimated-σ Fisher block ``2/σ²`` --
+    and fits the same objective LBFGS does, but with a *trust-region* step rather than a
+    limited-memory quasi-Newton one, still recovering the rate / initial condition."""
+    H.require_bng2pl()
+    H.install(monkeypatch)
+    model = _decay_model(tmp_path)
+    # No _SD column: chi_sq_dynamic reads its sigma from the free parameter, not the data.
+    exp = _write_decay_exp(tmp_path / 'decay.exp', with_sd=False)
+    conf = H.make_newera_config(
+        tmp_path, model, exp,
+        {'k': ('uniform_var', 1e-2, 3.0), 'S0': ('uniform_var', 20.0, 400.0),
+         'sigma__FREE': ('uniform_var', 0.1, 50.0)},
+        'decay', 'gntr', objective='chi_sq_dynamic', random_seed=1234,
+        population_size=1, max_iterations=250)
+
+    alg = H.build(conf, 'gntr')
+    H.drive(alg)   # must NOT raise -- this is the path TRF refuses and GNTR now fits
+
+    rec = H.best_params(alg, ('k', 'S0'))
+    assert abs(rec['k'] - TRUE_K) / TRUE_K < 0.03, \
+        'k recovered %g, expected ~%g' % (rec['k'], TRUE_K)
+    assert abs(rec['S0'] - TRUE_S0) / TRUE_S0 < 0.03, \
+        'S0 recovered %g, expected ~%g' % (rec['S0'], TRUE_S0)
+
+
+@pytest.mark.recovery
+@pytest.mark.skipif(not BNGSIM_HAS_OUTPUT_SENS,
+                    reason='needs a bngsim build with the output_sensitivities feature')
+def test_gntr_is_picklable_across_a_run(tmp_path, monkeypatch):
+    """``Algorithm.backup`` pickles the optimizer mid-run, so the GNTR state machine must
+    round-trip both before and after a run -- all state is plain numpy/float (inherited from
+    the TRF runner: the point, the pseudo residual model, the trust radius + cached SVD),
+    exactly like Powell / CMA-ES / TRF / L-BFGS (ADR-0007)."""
+    import pickle
+    H.require_bng2pl()
+    H.install(monkeypatch)
+    model = _decay_model(tmp_path)
+    exp = _write_decay_exp(tmp_path / 'decay.exp', with_sd=False)
+    conf = H.make_newera_config(
+        tmp_path, model, exp,
+        {'k': ('uniform_var', 1e-2, 3.0), 'S0': ('uniform_var', 20.0, 400.0),
+         'sigma__FREE': ('uniform_var', 0.1, 50.0)},
+        'decay', 'gntr', objective='chi_sq_dynamic', random_seed=1234,
+        population_size=1, max_iterations=10)
+    alg = H.build(conf, 'gntr')
+    pickle.loads(pickle.dumps(alg))     # constructed state round-trips
+    H.drive(alg)
+    pickle.loads(pickle.dumps(alg))     # state after a completed run round-trips
+
+
+def test_gntr_refuses_legacy_edition_before_building_models(tmp_path):
+    """A GNTR fit on a legacy (edition-1) config is refused at construction with a clear,
+    actionable message -- the edition gate is inherited from GradientOptimizer and fires before
+    any model is built, so no BNG2.pl / bngsim is needed here (mirrors the TRF / LBFGS gate
+    tests)."""
+    from pybnf.algorithms.optimizers.gntr import GNTRAlgorithm
+    import types
+    conf = types.SimpleNamespace(config={'edition': None})
+    with pytest.raises(PybnfError, match='(?i)edition'):
+        GNTRAlgorithm(conf)
+
+
+# --------------------------------------------------------------------------- #
 # Local multi-start (#386 follow-up)
 # --------------------------------------------------------------------------- #
 # A gradient method is purely local -- it descends into whatever basin its single start

--- a/tests/test_gradient_runner.py
+++ b/tests/test_gradient_runner.py
@@ -28,6 +28,7 @@ import numpy as np
 from scipy.optimize import least_squares, minimize
 
 from pybnf.algorithms.optimizers.gradient_base import DONE
+from pybnf.algorithms.optimizers.gntr import _GNTRRunner
 from pybnf.algorithms.optimizers.lbfgs import _LBFGSRunner
 from pybnf.algorithms.optimizers.trf import _TRFRunner
 
@@ -35,13 +36,15 @@ from pybnf.algorithms.optimizers.trf import _TRFRunner
 class _Grad:
     """Stand-in for an assembled GradientResult: carries exactly what each runner reads
     off it (``gradient`` for L-BFGS-B; ``residual`` / ``jacobian`` /
-    ``least_squares_exact`` for TRF)."""
+    ``least_squares_exact`` for TRF; ``gradient`` / ``hessian`` for GNTR)."""
 
-    def __init__(self, gradient, residual=None, jacobian=None, least_squares_exact=True):
+    def __init__(self, gradient, residual=None, jacobian=None, least_squares_exact=True,
+                 hessian=None):
         self.gradient = gradient
         self.residual = residual
         self.jacobian = jacobian
         self.least_squares_exact = least_squares_exact
+        self.hessian = hessian
 
 
 def _drive_scalar(runner, f_and_grad, max_evals=4000):
@@ -67,6 +70,20 @@ def _drive_least_squares(runner, r_and_jac, max_evals=4000):
         score = 0.5 * float(r @ r)
         nxt = runner.got(u, score, _Grad(jac.T @ r, residual=r, jacobian=jac,
                                          least_squares_exact=True))
+        if nxt is DONE:
+            return runner
+        u = nxt
+    raise AssertionError('runner did not terminate within %d evaluations' % max_evals)
+
+
+def _drive_efim(runner, f_g_h, max_evals=4000):
+    """Drive the GNTR (Fisher/Gauss-Newton trust-region) runner from an analytic
+    ``f_g_h(u) -> (score, gradient, hessian)`` -- the general-objective EFIM it consumes: a
+    scalar gradient + a PSD curvature Hessian, not a least-squares residual model."""
+    u = runner.start()
+    for _ in range(max_evals):
+        score, grad, hess = f_g_h(u)
+        nxt = runner.got(u, score, _Grad(grad, hessian=hess, least_squares_exact=False))
         if nxt is DONE:
             return runner
         u = nxt
@@ -129,6 +146,127 @@ def test_trf_runner_matches_scipy_with_several_bounds_active():
     assert np.allclose(runner.point, [3.0, -3.0, 3.0], atol=1e-6)   # the box corner
     assert np.allclose(runner.point, oracle.x, atol=1e-5)
     assert 'gradient is flat' in runner.stop_reason
+
+
+# --------------------------------------------------------------------------- #
+# GNTR (general-objective Fisher/Gauss-Newton trust region, #481). On a Gaussian
+# least-squares problem its EFIM Hessian is H = J^T J and gradient g = J^T r, so the
+# pseudo-Jacobian reduction reproduces trf's / scipy's step exactly. On a genuinely
+# non-least-squares NLL (a curvature H that is not any J^T J) it takes a real trust-region
+# Newton step, converging to the same minimum scipy.minimize finds.
+# --------------------------------------------------------------------------- #
+def _ls_efim(ustar):
+    """The Gaussian least-squares EFIM: H = A = D^T D (= J^T J), g = A(u-ustar), the score
+    the same 0.5||D(u-ustar)||^2 the residual form reports."""
+    A = _D.T @ _D
+
+    def f_g_h(u):
+        d = u - ustar
+        return 0.5 * float(d @ (A @ d)), A @ d, A
+
+    return f_g_h
+
+
+def test_gntr_runner_matches_trf_and_scipy_on_an_interior_least_squares_minimum():
+    """On a Gaussian least-squares fit the EFIM Hessian is exactly ``J^T J``, so the GNTR runner
+    -- built by feeding ``(g, H)`` through the pseudo-Jacobian into trf's Coleman-Li machinery --
+    takes the SAME step as ``_TRFRunner`` and ``scipy.least_squares`` and reaches the same interior
+    minimum. This is the reduction that anchors ``gntr`` to ``trf``'s step quality."""
+    ustar = np.array([1.0, -0.5, 2.0])
+    runner = _drive_efim(
+        _GNTRRunner(_U0, _LOWER, _UPPER, 200, grad_tol=1e-10, step_tol=1e-12, ridge=1e-10),
+        _ls_efim(ustar))
+    oracle = least_squares(lambda u: _D @ (u - ustar), _U0, jac=lambda u: _D,
+                           bounds=(_LOWER, _UPPER))
+    assert np.allclose(runner.point, ustar, atol=1e-5)
+    assert np.allclose(runner.point, oracle.x, atol=1e-5)
+    assert 'gradient is flat' in runner.stop_reason
+
+
+def test_gntr_runner_matches_scipy_with_several_bounds_active():
+    """The bound-active corner (every coordinate's unconstrained optimum is outside the box): the
+    inherited Coleman-Li reflective transformation slides the iterate cleanly onto the box corner,
+    matching ``scipy.optimize.least_squares(method='trf')`` -- the same offline oracle ``trf`` uses,
+    now reached through the EFIM ``(g, H)`` seam."""
+    ustar = np.array([10.0, -8.0, 9.0])
+    runner = _drive_efim(
+        _GNTRRunner(_U0, _LOWER, _UPPER, 500, grad_tol=1e-10, step_tol=1e-12, ridge=1e-10),
+        _ls_efim(ustar))
+    oracle = least_squares(lambda u: _D @ (u - ustar), _U0, jac=lambda u: _D,
+                           bounds=(_LOWER, _UPPER))
+    assert np.allclose(runner.point, [3.0, -3.0, 3.0], atol=1e-6)   # the box corner
+    assert np.allclose(runner.point, oracle.x, atol=1e-5)
+    assert 'gradient is flat' in runner.stop_reason
+
+
+def test_gntr_runner_converges_on_a_general_non_least_squares_nll():
+    """The case ``gntr`` exists for: a genuinely non-least-squares objective whose Hessian is not
+    any ``J^T J`` (a quadratic bowl plus an exponential ridge). The EFIM trust-region step drives
+    it to the same interior minimum ``scipy.optimize.minimize`` finds -- the general-NLL trust
+    region ``trf`` cannot do and ``lbfgs`` does only with a history Hessian."""
+    A = np.diag([2.0, 1.0])
+    a = np.array([0.5, -0.3])
+    c = np.array([0.4, 0.2])
+    lower, upper, u0 = np.array([-5.0, -5.0]), np.array([5.0, 5.0]), np.array([2.0, 2.0])
+
+    def f_g_h(u):
+        e = np.exp(c @ u)
+        return (float(0.5 * (u - a) @ (A @ (u - a)) + e),
+                A @ (u - a) + e * c,
+                A + e * np.outer(c, c))     # a true PSD Hessian, != any J^T J
+
+    runner = _drive_efim(
+        _GNTRRunner(u0, lower, upper, 500, grad_tol=1e-11, step_tol=1e-13, ridge=1e-10), f_g_h)
+    oracle = minimize(lambda u: f_g_h(u)[0], u0, jac=lambda u: f_g_h(u)[1],
+                      method='L-BFGS-B', bounds=list(zip(lower, upper)),
+                      options={'ftol': 1e-15, 'gtol': 1e-12})
+    assert np.allclose(runner.point, oracle.x, atol=1e-5)
+
+
+def test_gntr_runner_pickles_midway_through_a_search():
+    """The GNTR runner is pure float/ndarray (inherited from ``_TRFRunner`` -- the point, the
+    pseudo residual model, the trust radius + cached SVD), so it round-trips through pickle
+    mid-search and resumes identically (the backup/resume contract, ADR-0007)."""
+    ustar = np.array([1.0, -0.5, 2.0])
+    f_g_h = _ls_efim(ustar)
+    runner = _GNTRRunner(_U0, _LOWER, _UPPER, 200, grad_tol=1e-10, step_tol=1e-12, ridge=1e-10)
+    u = runner.start()
+    for _ in range(4):
+        score, grad, hess = f_g_h(u)
+        u = runner.got(u, score, _Grad(grad, hessian=hess, least_squares_exact=False))
+        assert u is not DONE, 'expected the search to still be running here'
+    revived = pickle.loads(pickle.dumps(runner))
+    assert revived.iteration == runner.iteration
+    assert revived.phase == runner.phase
+    assert np.allclose(revived.point, runner.point)
+    while u is not DONE:
+        score, grad, hess = f_g_h(u)
+        u = revived.got(u, score, _Grad(grad, hessian=hess, least_squares_exact=False))
+    assert np.allclose(revived.point, ustar, atol=1e-4)
+
+
+def test_gntr_refusal_points_at_lbfgs_not_a_metaheuristic():
+    """A corner whose EFIM Hessian ``gntr`` cannot assemble (a MEDIAN count, a MEAN-on-log
+    estimated scale, an estimated constraint scale) must refuse toward ``lbfgs`` -- which
+    consumes the scalar gradient and fits it -- not toward a metaheuristic (the base's default
+    hint). The leaf overrides ``_unsupported_gradient_error`` to redirect the pointer."""
+    from pybnf.algorithms.optimizers.gntr import GNTRAlgorithm
+    from pybnf.gradient import GradientNotSupported
+    from pybnf.printing import PybnfError
+    err = GNTRAlgorithm._unsupported_gradient_error(
+        object(), GradientNotSupported('a MEDIAN-centered negative-binomial ...'))
+    assert isinstance(err, PybnfError)
+    assert 'lbfgs' in str(err).lower()
+
+
+def test_gntr_runner_accepts_any_objective_the_hessian_covers():
+    """The GNTR runner overrides ``trf``'s exact-least-squares gate to a no-op: the curvature is
+    the EFIM Hessian, not a residual, so a non-least-squares gradient (``least_squares_exact ==
+    False``) is accepted (the real gate -- whether the Fisher Hessian could be assembled -- fired
+    upstream). ``_require_exact`` returns the grad unchanged."""
+    runner = _GNTRRunner(_U0, _LOWER, _UPPER, 10, grad_tol=1e-8, step_tol=1e-8, ridge=1e-10)
+    grad = _Grad(np.zeros(3), hessian=np.eye(3), least_squares_exact=False)
+    assert runner._require_exact(grad) is grad
 
 
 def test_lbfgs_runner_matches_scipy_on_an_interior_minimum():

--- a/tests/test_gradient_runner.py
+++ b/tests/test_gradient_runner.py
@@ -25,6 +25,7 @@ recovery tier in ``test_gradient_optimizer.py``.
 import pickle
 
 import numpy as np
+import pytest
 from scipy.optimize import least_squares, minimize
 
 from pybnf.algorithms.optimizers.gradient_base import DONE
@@ -257,6 +258,18 @@ def test_gntr_refusal_points_at_lbfgs_not_a_metaheuristic():
         object(), GradientNotSupported('a MEDIAN-centered negative-binomial ...'))
     assert isinstance(err, PybnfError)
     assert 'lbfgs' in str(err).lower()
+
+
+def test_gntr_runner_fails_fast_without_an_attached_hessian():
+    """The GNTR runner needs an assembled EFIM Hessian (GNTRAlgorithm attaches it in
+    _attach_curvature before the runner sees the gradient). If it is ever driven off the
+    residual-form path with no hessian, it raises a clear PybnfError naming the wiring error
+    rather than an opaque numpy failure deep in the eigen-factorisation."""
+    from pybnf.printing import PybnfError
+    runner = _GNTRRunner(_U0, _LOWER, _UPPER, 10, grad_tol=1e-8, step_tol=1e-8, ridge=1e-10)
+    u = runner.start()
+    with pytest.raises(PybnfError, match='(?i)hessian'):
+        runner.got(u, 1.0, _Grad(np.zeros(3)))   # _Grad defaults hessian=None
 
 
 def test_gntr_runner_accepts_any_objective_the_hessian_covers():

--- a/tests/test_pybnf_main_helpers.py
+++ b/tests/test_pybnf_main_helpers.py
@@ -53,6 +53,7 @@ _DISPATCH = [
     ('cmaes', 'CMAESAlgorithm'),
     ('trf', 'TRFAlgorithm'),
     ('lbfgs', 'LBFGSAlgorithm'),
+    ('gntr', 'GNTRAlgorithm'),
     ('profile_likelihood', 'ProfileLikelihoodAlgorithm'),
     ('ade', 'AsynchronousDifferentialEvolution'),
     ('dream', 'DreamAlgorithm'),
@@ -92,7 +93,7 @@ def test_only_mh_and_sa_are_deprecated():
 
 def test_families_partition_the_codes():
     fam = {code: e.family for code, e in FIT_TYPE_REGISTRY.items()}
-    assert {c for c, f in fam.items() if f == 'optimizer'} == {'pso', 'de', 'ade', 'ss', 'sim', 'sa', 'powell', 'cmaes', 'trf', 'lbfgs', 'profile_likelihood'}
+    assert {c for c, f in fam.items() if f == 'optimizer'} == {'pso', 'de', 'ade', 'ss', 'sim', 'sa', 'powell', 'cmaes', 'trf', 'lbfgs', 'gntr', 'profile_likelihood'}
     assert {c for c, f in fam.items() if f == 'sampler'} == {'mh', 'pt', 'am', 'dream', 'p_dream', 'hmc'}
     assert {c for c, f in fam.items() if f == 'checker'} == {'check'}
 
@@ -100,19 +101,20 @@ def test_families_partition_the_codes():
 def test_refiners_are_the_start_point_optimizers():
     """The ``refiner`` flag (refine_method targets, #403/ADR-0015) marks the
     start-point local optimizers: Simplex, Powell, CMA-ES, and the gradient-based
-    methods (#386) -- TRF (trust-region least-squares) and L-BFGS-B (scalar quasi-Newton)."""
-    assert {c for c, e in FIT_TYPE_REGISTRY.items() if e.refiner} == {'sim', 'powell', 'cmaes', 'trf', 'lbfgs'}
+    methods (#386/#481) -- TRF (trust-region least-squares), L-BFGS-B (scalar quasi-Newton),
+    and GNTR (general-objective Fisher/Gauss-Newton trust region)."""
+    assert {c for c, e in FIT_TYPE_REGISTRY.items() if e.refiner} == {'sim', 'powell', 'cmaes', 'trf', 'lbfgs', 'gntr'}
 
 
 def test_box_start_optimizers_are_a_subset_of_refiners():
     """The ``start_from_box`` flag (#404/ADR-0017) marks the start-point optimizers
     that may *also* run as a standalone search over a bounded-prior box: CMA-ES (the
-    global derivative-free search) and the bounded gradient methods (#386) -- TRF and
-    L-BFGS-B, whose box IS the parameter bounds they project/reflect into. It is a strict
-    subset of the refiners: a box optimizer is a refiner that learned a second start mode."""
+    global derivative-free search) and the bounded gradient methods (#386/#481) -- TRF,
+    L-BFGS-B, and GNTR, whose box IS the parameter bounds they project/reflect into. It is a
+    strict subset of the refiners: a box optimizer is a refiner that learned a second start mode."""
     box = {c for c, e in FIT_TYPE_REGISTRY.items() if e.start_from_box}
     refiners = {c for c, e in FIT_TYPE_REGISTRY.items() if e.refiner}
-    assert box == {'cmaes', 'trf', 'lbfgs'}
+    assert box == {'cmaes', 'trf', 'lbfgs', 'gntr'}
     assert box <= refiners
 
 


### PR DESCRIPTION
Closes #481.

## Summary

Fills the last empty cell of the gradient-fitting (objective × curvature-model) matrix with a new `fit_type = gntr` — a native trust-region optimizer whose Hessian is the **expected-Fisher / Gauss–Newton information**, extending `trf`'s step quality to the general-NLL objectives `trf` refuses.

| | least-squares (`chi_sq`) | general NLL (estimated σ, Laplace/count, constrained) |
|---|---|---|
| **trust-region, EFIM `JᵀJ` Hessian** | `trf` ✅ | **`gntr` ✅ (this PR)** |
| **quasi-Newton** | (`trf` preferred) | `lbfgs` ✅ |

Before this, the moment an objective stopped being a pure sum of squares (an estimated noise scale, a Laplace/count likelihood, or an active constraint), the gradient path dropped from `trf`'s well-conditioned trust-region step to `lbfgs`'s history-built quasi-Newton Hessian. `gntr` recovers `trf`'s step quality for exactly those objectives.

## How it works

- **Curvature model** — the EFIM `H = Σ κᵢ sᵢsᵢᵀ` (+ estimated-noise and constraint blocks), built from the same #385 forward sensitivities `sᵢ = ∂predᵢ/∂θ` `trf`/`lbfgs` already consume, plus small analytic per-family curvature factors. No second-order sensitivities. It consumes the **same scalar gradient** as `lbfgs`; only the curvature differs.
- **Reuses `trf`'s Coleman–Li core unchanged** — feeds `(g, H)` through a ridge-regularised pseudo-Jacobian (`H = QΛQᵀ → J = √Λ Qᵀ`, `r = Λ⁻¹ᐟ² Qᵀg`), so `_GNTRRunner` is a ~20-line fork of `_TRFRunner`. On a Gaussian least-squares fit it reduces to `trf`'s step **exactly**.
- **Native & picklable** — driven by `GradientOptimizer` inside the run-loop contract (no `run()` override, ADR-0007); backup/resume and concurrent `N`-start multi-start work like every other `fit_type`. Registered as a box-start refiner.

## Scope (tractable subset + clean refusals)

Supports an estimated-σ Gaussian (`chi_sq_dynamic`), a fixed-scale Laplace, a fixed-dispersion mean-centered negative-binomial, and a Gaussian fit with static-hinge constraints. The coupled corners it cannot yet build the Fisher Hessian for (mean-on-log estimated scale, free-dispersion/median count, estimated Student-t df, estimated constraint scale) refuse with a `PybnfError` pointing at `lbfgs`, which fits them — mirroring how the #385 epic layered its support.

## Validation

- **Step-math oracle** — `gntr` runner matches `_TRFRunner` and `scipy.optimize.least_squares` exactly on a Gaussian LS problem (interior + all-bounds-active), and converges to `scipy.optimize.minimize` on a genuine non-least-squares NLL.
- **Assembly** — 11 closed-form / `JᵀJ`-consistency tests for the Fisher Hessian and constraint curvature.
- **End-to-end recovery** — `gntr` recovers a decay model under `chi_sq_dynamic` (the estimated-σ case `trf` refuses) through the real bngsim forward-sensitivity backend, plus fixed-σ recovery and mid-run pickle.
- **Full suite green** — 3028 passed, 0 failed (recovery tier included); `trf`/`lbfgs` byte-identical (they never form the Hessian).

New config keys `gntr_grad_tol` (1e-8), `gntr_step_tol` (1e-8), `gntr_ridge` (1e-10), and runtime-guarded `gntr_max_iterations`. Design recorded in **ADR-0068**; docs in `gradient_fitting.rst` / `algorithms.rst`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)