### PR TITLE
DREAM(KZS): Kalman-inspired proposal (ADR-0067 Stage 3, #358)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,23 @@ All notable changes to PyBNF are documented below. This project adheres to
   Hessian for (a mean-on-log estimated scale, a free-dispersion / median count family, an estimated
   Student-t df, or an estimated constraint scale) refuse with a pointer to `lbfgs`, which fits them.
   `trf` / `lbfgs` are byte-identical (they never form the Hessian).
+- **Kalman-inspired DREAM proposal: `proposal = kalman` (ADR-0067, Stage 3; DREAM(KZS), #358).**
+  The third proposal operator on the unified DREAM engine (Zhang, Vrugt et al. 2020). During a
+  burn-in window each proposal is steered toward the data by a Kalman gain `K = C_ZY (C_YY + R)⁻¹`
+  built from the archive's parameter↔model-output cross-covariance, with the innovation `d - f(xᵢ) +
+  ε` taken at the chain's current state (`ε ~ N(0, R)`), which accelerates burn-in on informative,
+  mildly non-linear problems; after the window the chain reverts to `de` for a reversible sampling
+  phase (the Kalman jump breaks detailed balance by design, so its samples are burn-in and
+  discarded). The gain reads each archive entry's *model output vector* `f(Z)` — surfaced by the new
+  `LikelihoodObjective.aligned_prediction_data` seam and carried in an output-augmented archive that
+  turns on only for this proposal (the "implied axis 2b"; dormant and byte-identical for `de` /
+  `whitened`). `kalman` requires a linear-scale Gaussian likelihood (`chi_sq` / `chi_sq_dynamic`,
+  the source of `R = diag(σ²)`) and `n_try = 1`, and refuses any other objective or `n_try > 1`
+  *before the run starts*. The internal ensemble size is fixed (`M = 20`, clamped to the available
+  archive, falling back to `de` before enough outputs accrue — no new user key); one new
+  proposal-scoped key `kalman_burnin_frac` (default `0.3`) sets the window as a fraction of
+  `burn_in`. Validated end-to-end against a closed-form linear-Gaussian posterior (`f(x) = A x`
+  scored by real `chi_sq`), plus pinned gain-math and burn-in-switch unit tests.
 - **Multi-Try DREAM: the `n_try` count (ADR-0067, Stage 2; MT-DREAM(ZS), #357).** A new integer
   `n_try` config key turns each chain-generation into a multiple-try step (Liu, Liang & Wong 2000;
   Laloy & Vrugt 2012): with `n_try = k > 1` a chain draws `k` candidate proposals, selects one in

--- a/docs/adr/0067-dream-is-one-engine-with-two-orthogonal-axes-a-proposal-operator-and-an-evaluation-protocol-so-its-variants-are-config-points-not-subclasses.md
+++ b/docs/adr/0067-dream-is-one-engine-with-two-orthogonal-axes-a-proposal-operator-and-an-evaluation-protocol-so-its-variants-are-config-points-not-subclasses.md
@@ -1,8 +1,12 @@
 # DREAM is one engine with two orthogonal extension axes — a proposal operator and an evaluation protocol — so its variants are config points, not subclasses (issues #357, #358)
 
-**Status: Accepted (2026-07-16); Stages 1–2 implemented (2026-07-17).** Design accepted;
-Stage 1 (proposal Strategy / P-DREAM fold-in) and Stage 2 (`n_try`, Multi-Try DREAM) are
-shipped, Stage 3 (`kalman`) remains the build plan below. The scheduler-contract risk that
+**Status: Accepted (2026-07-16); Stages 1–2 implemented (2026-07-17); Stage 3a in
+progress (2026-07-17, branch `feat/358-dream-kzs-kalman`).** Design accepted; Stage 1
+(proposal Strategy / P-DREAM fold-in) and Stage 2 (`n_try`, Multi-Try DREAM) are shipped.
+Stage 3 (`kalman`) is being landed in two commits — **3a, the output-augmented archive
+plumbing (implied axis 2b), is committed on the branch above** (inert at defaults,
+byte-identical); **3b, the Kalman proposal itself, remains** — see *Stage 3 — confirmed
+algorithm and build decisions* below. The scheduler-contract risk that
 gated acceptance was pressure-tested and resolved — see *Principal risk*. Reframes the DREAM
 family so that DREAM(ZS),
 Preconditioned DREAM, the requested Multi-Try DREAM (#357), and the requested
@@ -161,7 +165,19 @@ the two axes touch the engine at architecturally different depths.
      hides at the usual `k = 5`. Correctness validated by moment recovery on a Gaussian target with
      the snooker update active (`tests/test_multitry_dream.py`).
   3. **`kalman` (#358).** Add the Kalman proposal + the output-augmented archive
-     (implied) + the burn-in switch, on the clean base.
+     (implied) + the burn-in switch, on the clean base. Landed in two commits:
+     - **3a — output-augmented archive plumbing. — DONE (2026-07-17, branch
+       `feat/358-dream-kzs-kalman`).** The objective seam
+       `LikelihoodObjective.aligned_prediction_data` (aligned prediction `f(θ)` /
+       observation `d` / variance `σ²`, `None` for a non-Gaussian/`direct_pass`
+       objective), a parallel `archive_outputs` list index-aligned with `archive`
+       (initial random draws seeded `None`), and the accepted state's `f(x)` cached per
+       chain (`current_output_vec`, mirroring `current_pointwise_loglik`) at all three
+       accept sites and appended at archive growth — all gated on
+       `_archive_stores_outputs`, `False` for `de`/`whitened` (byte-identical). BNG-free
+       extractor unit tests in `tests/test_kalman_dream.py`.
+     - **3b — the `kalman` proposal + burn-in switch + oracle. — TODO.** See the
+       confirmed algorithm and build decisions below.
 
 ### Principal risk — pressure-tested, resolved (2026-07-16)
 
@@ -210,6 +226,62 @@ needed**. This settles the *scheduler-contract* question only — the correctnes
 Multi-Try acceptance math itself (the reference-set Metropolis ratio and the detailed
 balance of the ∝-posterior selection, which reduces to standard MH at `k = 1`; Laloy &
 Vrugt 2012) remains Stage 2's own validation against a stationary-distribution oracle.
+
+## Stage 3 — confirmed algorithm and build decisions (`kalman`, #358)
+
+The DREAM(KZS) proposal math was pinned against the primary source (Zhang, Vrugt et al.
+2020, arXiv:1707.05431 — the open-access WRR manuscript with all equations) **and** Vrugt's
+own reference implementation (DREAM-Suite `dream_kzs`: `Calc_proposal.m`,
+`Calc_likelihood.m`, `DREAM_Suite.m`). The confirmed update, per chain `i`, per proposal,
+during the Kalman window:
+
+```
+Draw an M-member ensemble {Z_K, f(Z_K)} at random (no replacement) from archive entries WITH outputs
+C_ZY = Cov(Z_K, f(Z_K))        # k×n, mean-subtracted, ÷(M−1)      (paper Eq. 14)
+C_YY = Cov(f(Z_K), f(Z_K))     # n×n
+K    = C_ZY · (C_YY + R)^(−1)  # k×n — SOLVE, do not invert; R keeps it PD (jitter if needed)  (Eq. 7)
+ε    ~ N(0, R)
+x_p  = x_i + (1+λ)·K·( d − f(x_i) + ε ) + ζ                        (Eq. 6/11–12)
+```
+
+Load-bearing details (several are easy to get wrong, and the paper and reference code
+diverge on some — decisions recorded here):
+
+- **Innovation uses the *current* chain state's residual** `d − f(x_i)` (not an archived
+  member's), plus a fresh perturbed-observations draw `ε ~ N(0, R)`. Dropping `ε` makes the
+  proposal degenerate — keep it.
+- **Sign:** use the paper's `(d − f)`. The DREAM-Suite literal reads the opposite because of
+  its `E = Y − FX` residual convention; the deterministic jump must *reduce* ‖d − f‖, which a
+  unit test asserts.
+- **No Hastings correction; plain Metropolis accept.** Detailed balance is intentionally
+  broken in the window (α = 1 for the Kalman jump), and those samples are burn-in and
+  discarded. After the window the chain reverts to `de`+snooker (reversible), so the sampled
+  posterior is correct. This is *why* it is burn-in-only.
+- **Gain rebuilt fresh per proposal** (stochastic). Ensemble size **`M = 20` internal
+  constant** (clamped to available), matching DREAM-Suite's default — **no new user key**
+  (keeps the minimal surface). Fall back to `de` when too few archive entries carry outputs,
+  mirroring how `whitened` falls back before its preconditioner warms up.
+- **`R` = `diag(σ²)`** from the Gaussian likelihood, so `kalman` **requires an ordinary
+  additive-error (linear-scale) Gaussian per-point likelihood** (`chi_sq`/`chi_sq_dynamic`)
+  and errors clearly for `direct_pass`/`sos`/log-scale/non-Gaussian families (no residual/σ
+  ⇒ no gain). Stage 3a's `aligned_prediction_data` is the gate (returns `None` otherwise).
+- **`kalman_burnin_frac`** (the one new key, default **0.3**) is a fraction of **`burn_in`**
+  (PyBNF's natural knob), not of the whole run. Paper uses `T_K = 0.3·T` from gen 0;
+  DREAM-Suite uses `[0.1·T, 0.25·T)`. PyBNF pins fraction-of-`burn_in` = 0.3.
+- **Renormalization on switch-off** is automatic in PyBNF's binary split: snooker still
+  fires at `snooker_prob`, and the non-snooker branch swaps `kalman → de` after the window
+  (DREAM-Suite's snooker-fixed scheme, not the paper's proportional one).
+- **Scope:** `kalman` targets the canonical DREAM(KZS) = `(kalman, n_try = 1)`. `kalman` +
+  `n_try > 1` raises a clear "not yet supported" error (burn-in-only Kalman inside a
+  multi-try reference set is deferrable; the axes stay *expressible* for later).
+
+**Build decisions (confirmed with the requester):** land Stage 3 in **two commits** (3a
+plumbing — done — then 3b proposal); validate 3b with a **test-only linear-Gaussian forward
+model** `f(x) = A x` (added to `tests/integration_harness.py`, emitting observable columns
+paired with a generated multi-row `.exp`, scored by the real `chi_sq`), whose posterior
+`x | d ~ N(μ_post, Σ_post)` is closed-form — the honest end-to-end oracle the `direct_pass`
+analytical menu (scalar score only) cannot provide. 3b also carries pinned-RNG unit tests of
+the gain/innovation/sign, the `de` fallback, and the burn-in switch.
 
 ## Considered Options
 

--- a/docs/adr/0067-dream-is-one-engine-with-two-orthogonal-axes-a-proposal-operator-and-an-evaluation-protocol-so-its-variants-are-config-points-not-subclasses.md
+++ b/docs/adr/0067-dream-is-one-engine-with-two-orthogonal-axes-a-proposal-operator-and-an-evaluation-protocol-so-its-variants-are-config-points-not-subclasses.md
@@ -1,12 +1,13 @@
 # DREAM is one engine with two orthogonal extension axes — a proposal operator and an evaluation protocol — so its variants are config points, not subclasses (issues #357, #358)
 
-**Status: Accepted (2026-07-16); Stages 1–2 implemented (2026-07-17); Stage 3a in
-progress (2026-07-17, branch `feat/358-dream-kzs-kalman`).** Design accepted; Stage 1
-(proposal Strategy / P-DREAM fold-in) and Stage 2 (`n_try`, Multi-Try DREAM) are shipped.
-Stage 3 (`kalman`) is being landed in two commits — **3a, the output-augmented archive
-plumbing (implied axis 2b), is committed on the branch above** (inert at defaults,
-byte-identical); **3b, the Kalman proposal itself, remains** — see *Stage 3 — confirmed
-algorithm and build decisions* below. The scheduler-contract risk that
+**Status: Accepted (2026-07-16); Stages 1–3 implemented (2026-07-17..18, branch
+`feat/358-dream-kzs-kalman`).** Design accepted; Stage 1 (proposal Strategy / P-DREAM
+fold-in), Stage 2 (`n_try`, Multi-Try DREAM), and Stage 3 (`kalman`, DREAM(KZS)) are all
+shipped. Stage 3 landed in two commits — **3a, the output-augmented archive plumbing
+(implied axis 2b)** (inert at defaults, byte-identical), then **3b, the Kalman proposal
+itself, the `kalman_burnin_frac` key, the burn-in switch, and the closed-form
+linear-Gaussian posterior-recovery oracle** — both per *Stage 3 — confirmed algorithm and
+build decisions* below. The scheduler-contract risk that
 gated acceptance was pressure-tested and resolved — see *Principal risk*. Reframes the DREAM
 family so that DREAM(ZS),
 Preconditioned DREAM, the requested Multi-Try DREAM (#357), and the requested
@@ -176,8 +177,17 @@ the two axes touch the engine at architecturally different depths.
        accept sites and appended at archive growth — all gated on
        `_archive_stores_outputs`, `False` for `de`/`whitened` (byte-identical). BNG-free
        extractor unit tests in `tests/test_kalman_dream.py`.
-     - **3b — the `kalman` proposal + burn-in switch + oracle. — TODO.** See the
-       confirmed algorithm and build decisions below.
+     - **3b — the `kalman` proposal + burn-in switch + oracle. — DONE (2026-07-18).** The
+       `_calculate_kalman_pset` gain (`K = C_ZY (C_YY + R)^-1`, solved with PD jitter; the
+       internal `M = 20` ensemble clamped to available, `de` fallback below the minimum),
+       the current-state innovation `d - f(x_i) + ε` (paper sign), the `is_linear_gaussian`
+       config gate + `(kalman, n_try = 1)` scope check (both error before the run starts),
+       the `kalman_burnin_frac` key (default 0.3 of `burn_in`) and the `_kalman_active`
+       burn-in switch in the proposal dispatch (reverting to `de`, no Hastings correction).
+       Validated by the closed-form linear-Gaussian oracle (`f(x) = A x` scored by real
+       `chi_sq`, `tests/integration_harness.py:LinearGaussianModel`) recovering
+       `N([2,-1], (1/3) I)`, plus pinned gain-math / sign / fallback / window unit tests
+       (`tests/test_kalman_dream.py`).
 
 ### Principal risk — pressure-tested, resolved (2026-07-16)
 

--- a/docs/config_keys.rst
+++ b/docs/config_keys.rst
@@ -1849,13 +1849,26 @@ For DREAM
   differential-evolution proposal. ``whitened`` computes the proposal in an online
   covariance-whitened space for better sampling of correlated posteriors — this is what the
   ``p_dream`` job type selects (``p_dream`` is simply ``dream`` with ``proposal = whitened``
-  pinned), and it can also be requested explicitly on a ``dream`` run. Default: ``de``
+  pinned), and it can also be requested explicitly on a ``dream`` run. ``kalman`` is the
+  Kalman-inspired proposal (DREAM(KZS); Zhang, Vrugt et al. 2020): during a burn-in window it
+  steers each proposal toward the data using a Kalman gain built from the archive's
+  parameter↔model-output cross-covariance, which accelerates burn-in on informative, mildly
+  non-linear problems, then reverts to ``de`` for the sampling phase. ``kalman`` requires a
+  linear-scale Gaussian likelihood (``objfunc = chi_sq`` or ``chi_sq_dynamic`` — the source of the
+  measurement covariance ``R = diag(σ²)``) and ``n_try = 1``. Default: ``de``
 
 ``precondition_adapt = int``
   Used only by the ``whitened`` proposal (the ``p_dream`` job type, or ``dream`` with
   ``proposal = whitened``). The iteration at which the sampler switches to proposing in its learned
   covariance-whitened space; until then the online covariance is still being estimated and plain
   DREAM proposals are used. Default: half of ``burn_in``.
+
+``kalman_burnin_frac = float``
+  Used only by the ``kalman`` proposal. The fraction of ``burn_in`` over which the Kalman-inspired
+  proposal is active before the chain reverts to the ``de`` proposal. The Kalman jump deliberately
+  breaks detailed balance (there is no Hastings correction), so its samples are burn-in and
+  discarded; it must switch off before the sampling phase, so this must be between 0 and 1.
+  Default: ``0.3`` (matching Zhang et al. 2020's ``T_K = 0.3 T``, here a fraction of ``burn_in``).
 
 ``n_try = int``
   Number of candidate proposals drawn per chain per generation — the Multi-Try DREAM
@@ -1864,8 +1877,8 @@ For DREAM
   its posterior importance weight, and accepts it over the current state with a multiple-try
   Metropolis ratio evaluated against a reference set (``2k - 1`` evaluations per chain per
   generation). Multiple tries per generation raise the per-generation acceptance rate and help
-  parameter-rich or strongly correlated posteriors mix. Composes with every ``proposal`` value
-  (``de``, ``whitened``) and with the snooker update. Default: ``1``
+  parameter-rich or strongly correlated posteriors mix. Composes with the ``de`` and ``whitened``
+  proposals and with the snooker update; ``proposal = kalman`` requires ``n_try = 1``. Default: ``1``
   If set to a positive value, the algorithm stops automatically once all parameters have
   :math:`\hat{R}` below this threshold (checked after burn-in). Set to 0 to disable. A common
   threshold is 1.05. Default: 0 (disabled)

--- a/pybnf/algorithms/samplers/dream.py
+++ b/pybnf/algorithms/samplers/dream.py
@@ -113,6 +113,20 @@ class DreamAlgorithm(BayesianAlgorithm):
         self.archive_thin_rate = config.config['archive_thin_rate']
         self.archive = []  # list of PSet objects
 
+        # Output-augmented archive (ADR-0067 Stage 3, axis 2b -- "implied"). When a
+        # proposal declares it needs model outputs (the 'kalman' proposal; see
+        # _archive_stores_outputs, set after the proposal is resolved below), each
+        # archive entry also carries the model's output vector f(Z), stored in
+        # archive_outputs in lockstep with archive. The accepted state's output is
+        # cached per chain at accept time (current_output_vec, mirroring
+        # current_pointwise_loglik) and appended at archive growth. Both stay dormant
+        # for the 'de'/'whitened' proposals (the gate is False), so a plain run stores
+        # only PSets exactly as before -- carrying output vectors for a proposal that
+        # never reads them would spend memory/bandwidth for nothing.
+        self.archive_outputs = []                        # f(Z) per archive entry (or None)
+        self.current_output_vec = [None] * self.num_parallel  # accepted f(x) per chain
+        self._archive_stores_outputs = False             # set True for 'kalman' below
+
         # Snooker update
         self.snooker_prob = config.config['snooker_prob']
         self.gen_log_snooker_correction = [0.0] * self.num_parallel
@@ -171,6 +185,11 @@ class DreamAlgorithm(BayesianAlgorithm):
         first_psets = super().start_run(setup_samples)
         # Initialize the ZS archive with m0 random draws from the prior
         self.archive = [self.random_pset() for _ in range(self.archive_m0)]
+        # The initial archive is random prior draws with no evaluated model output, so
+        # their output slots are None (ADR-0067 Stage 3). Kept index-aligned with archive;
+        # the output-augmented proposals (kalman) draw their ensemble only from entries
+        # whose output is not None (the grown, accepted states).
+        self.archive_outputs = [None] * self.archive_m0
         logger.info('Initialized ZS archive with %d entries (d=%d)' % (self.archive_m0, self.n_dim))
         return first_psets
 
@@ -191,6 +210,33 @@ class DreamAlgorithm(BayesianAlgorithm):
             return self._pset_from_u(xp_vec, reflect=False)
         except OutOfBoundsException:
             return None
+
+    def record_accepted_output(self, res, index):
+        """Cache the just-accepted state's model output vector f(x) for chain ``index``
+        (ADR-0067 Stage 3), mirroring :meth:`record_pointwise_loglik`: computed here,
+        where the accepted pset's simulation data is in hand, and consumed later at
+        archive growth (:meth:`_advance_generation`) and by the Kalman proposal.
+
+        A no-op unless the proposal declared it needs archived outputs
+        (``_archive_stores_outputs``; the 'kalman' proposal). Reads the simdata through
+        :meth:`_result_simdata` so it works whether the objective was scored worker-side
+        or master-side (lanl/PyBNF#480), and extracts the aligned output vector via the
+        objective's :meth:`~pybnf.objective.ObjectiveFunction.aligned_prediction_data`
+        seam. Any failure is logged, never fatal -- the proposal falls back to ``de``
+        when a chain lacks a cached output."""
+        if not self._archive_stores_outputs:
+            return
+        try:
+            aligned = self.objective.aligned_prediction_data(
+                self._result_simdata(res), self.exp_data, res.pset)
+        except Exception:
+            logger.debug('Could not extract model output vector for chain %d',
+                         index, exc_info=True)
+            return
+        if aligned is None:
+            return
+        prediction, _observation, _variance = aligned
+        self.current_output_vec[index] = prediction
 
     def _snooker_propose(self, idx, x0_vec):
         """Core snooker geometry (ter Braak & Vrugt, 2008), proposing a jump
@@ -371,6 +417,7 @@ class DreamAlgorithm(BayesianAlgorithm):
             self.acceptances[index] += 1
             self.evaluate_constraints(self._result_simdata(res), index)
             self.record_pointwise_loglik(res, index)
+            self.record_accepted_output(res, index)
 
         # Store chain history (after accept/reject, so it reflects the kept state)
         self.chain_history[index].append(self._param_vec(self.current_pset[index]))
@@ -488,6 +535,12 @@ class DreamAlgorithm(BayesianAlgorithm):
         if self.iteration[index] % self.archive_thin_rate == 0:
             for i in range(self.num_parallel):
                 self.archive.append(copy.deepcopy(self.current_pset[i]))
+                # Output-augmented archive (ADR-0067 Stage 3): append the accepted
+                # state's cached output vector in lockstep, so archive_outputs stays
+                # index-aligned with archive. Dormant (no-op storage of None slots) for
+                # the 'de'/'whitened' proposals that never read outputs.
+                if self._archive_stores_outputs:
+                    self.archive_outputs.append(self.current_output_vec[i])
             logger.debug('Archive grown to %d entries at iteration %d'
                         % (len(self.archive), self.iteration[index]))
 
@@ -589,6 +642,7 @@ class DreamAlgorithm(BayesianAlgorithm):
             self.acceptances[index] += 1
             self.evaluate_constraints(self._result_simdata(res), index)
             self.record_pointwise_loglik(res, index)
+            self.record_accepted_output(res, index)
         self.chain_history[index].append(self._param_vec(self.current_pset[index]))
         self.ln_posterior_history[index].append(self.ln_current_P[index])
         self.wait_for_sync[index] = True
@@ -693,6 +747,7 @@ class DreamAlgorithm(BayesianAlgorithm):
             self.acceptances[index] += 1
             self.evaluate_constraints(self._result_simdata(sel['res']), index)
             self.record_pointwise_loglik(sel['res'], index)
+            self.record_accepted_output(sel['res'], index)
 
         # Store chain history (after accept/reject, so it reflects the kept state)
         self.chain_history[index].append(self._param_vec(self.current_pset[index]))

--- a/pybnf/algorithms/samplers/dream.py
+++ b/pybnf/algorithms/samplers/dream.py
@@ -27,6 +27,16 @@ from scipy.special import logsumexp
 # 'pybnf.algorithms' channel.
 logger = logging.getLogger('pybnf.algorithms')
 
+# Kalman-inspired proposal (DREAM(KZS); Zhang, Vrugt et al. 2020) -- ADR-0067 Stage 3.
+# The gain is built from an internal M-member ensemble drawn from the output-augmented
+# archive; M = 20 matches DREAM-Suite's default and is an internal constant, not a user
+# key (the config surface stays minimal). Clamped to the number of archive entries that
+# carry an output; below _KALMAN_MIN_ENSEMBLE such entries the proposal falls back to 'de'
+# (mirroring how 'whitened' falls back before its preconditioner warms up) -- two points
+# are the minimum for a mean-subtracted cross-covariance (the /(M-1) divisor).
+_KALMAN_ENSEMBLE_SIZE = 20
+_KALMAN_MIN_ENSEMBLE = 2
+
 
 class DreamConfig(MCMCFamilyConfig):
     """Config for DREAM(ZS) (dream), co-located with the method (ADR-0006). Adds the
@@ -49,9 +59,16 @@ class DreamConfig(MCMCFamilyConfig):
     outlier_method: str = 'iqr'
     # Proposal operator (ADR-0067 axis 1). 'de' is the classic DREAM(ZS)
     # parallel-direction proposal; 'whitened' is the covariance-preconditioned
-    # proposal (the p_dream default, pinned by ``PDreamConfig``). Additional
-    # operators (e.g. 'kalman') arrive in later ADR-0067 stages.
+    # proposal (the p_dream default, pinned by ``PDreamConfig``); 'kalman' is the
+    # Kalman-inspired proposal (DREAM(KZS); Zhang, Vrugt et al. 2020, ADR-0067
+    # Stage 3), active only during a burn-in window.
     proposal: str = 'de'
+    # Proposal-scoped: the fraction of ``burn_in`` over which the 'kalman' proposal
+    # is active before the chain reverts to 'de' (ADR-0067 Stage 3). Ignored by the
+    # 'de'/'whitened' proposals. The Kalman jump breaks detailed balance, so it must
+    # switch off before the sampling phase; 0.3 matches Zhang et al. (2020)'s T_K =
+    # 0.3 T on PyBNF's natural knob (a fraction of burn_in, not of the whole run).
+    kalman_burnin_frac: float = 0.3
     # Multi-try evaluation protocol (ADR-0067 axis 2, MT-DREAM(ZS); Laloy &
     # Vrugt 2012). n_try = 1 is the classic single-try engine (byte-identical to
     # before this key). n_try = k > 1 draws k candidate proposals per chain per
@@ -125,6 +142,14 @@ class DreamAlgorithm(BayesianAlgorithm):
         # never reads them would spend memory/bandwidth for nothing.
         self.archive_outputs = []                        # f(Z) per archive entry (or None)
         self.current_output_vec = [None] * self.num_parallel  # accepted f(x) per chain
+        # The current state's observation vector d and measurement variance R = diag(var)
+        # per chain, cached alongside f(x) at accept time (ADR-0067 Stage 3b). The Kalman
+        # innovation is d - f(x_i) and its perturbation is drawn from N(0, R); both are
+        # properties of the *current* chain state (R follows an estimated sigma), so they
+        # travel with current_output_vec rather than with each archive entry (which needs
+        # only f(Z) for the cross-covariance). Dormant unless proposal = 'kalman'.
+        self.current_output_obs = [None] * self.num_parallel  # observation d per chain
+        self.current_output_var = [None] * self.num_parallel  # R diagonal (sigma**2) per chain
         self._archive_stores_outputs = False             # set True for 'kalman' below
 
         # Snooker update
@@ -143,9 +168,43 @@ class DreamAlgorithm(BayesianAlgorithm):
         # (guarded everywhere by ``self.proposal == 'whitened'``), so a plain
         # ``dream`` run is byte-identical to before this fold-in.
         self.proposal = config.config['proposal']
-        if self.proposal not in ('de', 'whitened'):
+        if self.proposal not in ('de', 'whitened', 'kalman'):
             raise PybnfError("Invalid proposal '%s'" % self.proposal,
-                             "Config key 'proposal' must be 'de' or 'whitened'.")
+                             "Config key 'proposal' must be 'de', 'whitened', or 'kalman'.")
+
+        # Kalman-inspired proposal (DREAM(KZS); Zhang, Vrugt et al. 2020) -- ADR-0067
+        # Stage 3. Turns on the output-augmented archive (axis 2b) and pins the burn-in
+        # window; the gain math lives in _calculate_kalman_pset. Two hard preconditions,
+        # checked here so the run refuses to start rather than silently degenerating:
+        # (1) the objective must be a linear-scale Gaussian likelihood -- the Kalman
+        #     R = diag(sigma**2) is the Gaussian measurement covariance, so a
+        #     least-squares / distance / log-scale / non-Gaussian objfunc has no R.
+        # (2) n_try must be 1 -- the canonical DREAM(KZS) is (kalman, n_try=1); a
+        #     burn-in-only Kalman jump inside a multi-try reference set is deferred (the
+        #     axes stay expressible, just not this combination yet).
+        self.kalman_window_end = 0
+        if self.proposal == 'kalman':
+            self._archive_stores_outputs = True
+            if not self.objective.is_linear_gaussian():
+                raise PybnfError(
+                    "proposal = 'kalman' requires a linear-scale Gaussian likelihood",
+                    "The Kalman-inspired DREAM proposal (DREAM(KZS)) builds its gain from "
+                    "R = diag(sigma**2), the Gaussian measurement covariance, so it needs an "
+                    "ordinary additive-error Gaussian objfunc (chi_sq or chi_sq_dynamic). "
+                    "The configured objective is not a linear-scale Gaussian likelihood "
+                    "(a least-squares / distance / pass-through objective, or a log-scale / "
+                    "non-Gaussian family such as lognormal / laplace / neg_bin, has no R).")
+            frac = config.config['kalman_burnin_frac']
+            if not (0.0 <= frac <= 1.0):
+                raise PybnfError(
+                    "Invalid kalman_burnin_frac '%s'" % frac,
+                    "Config key 'kalman_burnin_frac' is the fraction of burn_in over which "
+                    "the Kalman proposal is active; it must be between 0 and 1. The Kalman "
+                    "jump breaks detailed balance, so it must switch off within burn_in.")
+            # The Kalman jump is active while iteration < kalman_window_end, then the
+            # non-snooker branch reverts to 'de' (the binary split renormalizes
+            # automatically; DREAM-Suite's snooker-fixed scheme).
+            self.kalman_window_end = int(round(frac * self.burn_in))
 
         # Multi-try count (ADR-0067 axis 2). n_try == 1 is the classic engine;
         # n_try > 1 activates the multiple-try (MT-DREAM(ZS)) barrier in
@@ -155,6 +214,13 @@ class DreamAlgorithm(BayesianAlgorithm):
         if not isinstance(self.n_try, int) or self.n_try < 1:
             raise PybnfError("Invalid n_try '%s'" % self.n_try,
                              "Config key 'n_try' must be an integer >= 1.")
+        if self.proposal == 'kalman' and self.n_try != 1:
+            raise PybnfError(
+                "proposal = 'kalman' does not support n_try > 1",
+                "The canonical DREAM(KZS) is (kalman, n_try = 1); a burn-in-only Kalman "
+                "jump inside a multi-try reference set is not yet supported (ADR-0067 "
+                "Stage 3). Use n_try = 1 with proposal = 'kalman', or an n_try > 1 "
+                "multi-try run with proposal = 'de' or 'whitened'.")
         # Per-chain two-phase multi-try state (dormant unless n_try > 1). A
         # generation for chain i runs TRIALS (k candidates from x) -> select the
         # winner Y in proportion to its importance weight -> REFERENCE (k-1 draws
@@ -235,8 +301,13 @@ class DreamAlgorithm(BayesianAlgorithm):
             return
         if aligned is None:
             return
-        prediction, _observation, _variance = aligned
+        prediction, observation, variance = aligned
         self.current_output_vec[index] = prediction
+        # Cache d and R = diag(variance) for the current state too (ADR-0067 Stage 3b):
+        # the Kalman innovation d - f(x_i) and its perturbation N(0, R) are the current
+        # chain state's, so they ride with f(x_i) rather than with each archive entry.
+        self.current_output_obs[index] = observation
+        self.current_output_var[index] = variance
 
     def _snooker_propose(self, idx, x0_vec):
         """Core snooker geometry (ter Braak & Vrugt, 2008), proposing a jump
@@ -812,21 +883,36 @@ class DreamAlgorithm(BayesianAlgorithm):
         Uses differential evolution-like update to calculate new PSet.
         Returns (PSet, cr_idx) or (None, cr_idx) if the proposal is out of bounds.
 
-        Dispatches on the configured proposal operator (ADR-0067 axis 1): the
-        'whitened' proposal runs once its preconditioner has warmed up, otherwise
-        (and always for 'de') the classic parallel-direction DE proposal below.
+        Dispatches on the configured proposal operator (ADR-0067 axis 1):
+
+        * 'whitened' runs once its preconditioner has warmed up (else falls through
+          to 'de'), and
+        * 'kalman' runs during the burn-in window (:meth:`_kalman_active`, else falls
+          through to 'de'), returning ``cr_idx = None`` since it uses no crossover;
+
+        otherwise (and always for 'de') the classic parallel-direction DE proposal.
 
         ``base`` overrides the point the jump is applied to (default: the current
         chain state). Multi-try (ADR-0067 Stage 2) passes the selected candidate
         Y as ``base`` to draw the reference set from ``T(Y, .)``; with the default
         ``base=None`` this is byte-identical to the classic single-try proposal.
+        ('kalman' is single-try only, so it never receives a ``base``.)
 
         :param idx: Index of PSet to update
-        :return: tuple of (PSet or None, int)
+        :return: tuple of (PSet or None, int or None)
         """
         if self.proposal == 'whitened' and self._preconditioned:
             return self._calculate_whitened_pset(idx, base)
+        if self._kalman_active(idx):
+            return self._calculate_kalman_pset(idx, base)
+        return self._calculate_de_pset(idx, base)
 
+    def _calculate_de_pset(self, idx, base=None):
+        """The classic DREAM(ZS) parallel-direction differential-evolution proposal
+        (the 'de' operator; also the warm-up / out-of-window fallback for 'whitened'
+        and 'kalman'). Returns ``(PSet or None, cr_idx)``. Byte-identical to the body
+        that lived inline in :meth:`calculate_new_pset` before the ADR-0067 Stage 3
+        proposal dispatch was extracted."""
         x0 = self.current_pset[idx] if base is None else base
 
         # Draw 2*delta donor states from the ZS archive (without replacement)
@@ -875,6 +961,115 @@ class DreamAlgorithm(BayesianAlgorithm):
                 return None, cr_idx
 
         return PSet(new_vars), cr_idx
+
+    # ------------------------------------------------------------------ #
+    # Kalman-inspired ('kalman') proposal — DREAM(KZS); Zhang, Vrugt     #
+    # et al. 2020 (arXiv:1707.05431). ADR-0067 Stage 3. Active only      #
+    # during the burn-in window (_kalman_active); the jump breaks        #
+    # detailed balance (no Hastings correction), so its samples are      #
+    # burn-in and discarded, after which the chain reverts to 'de'.      #
+    # ------------------------------------------------------------------ #
+    def _kalman_active(self, idx):
+        """Whether chain ``idx`` should propose with the Kalman operator now: the
+        proposal is 'kalman' and the chain is still inside its burn-in window
+        (``iteration < kalman_window_end``). After the window the non-snooker branch
+        reverts to 'de' -- PyBNF's binary snooker/non-snooker split renormalizes
+        automatically (DREAM-Suite's snooker-fixed scheme, not the paper's
+        proportional one). Always ``False`` for 'de'/'whitened' (kalman_window_end
+        is 0), so those paths are untouched."""
+        return self.proposal == 'kalman' and self.iteration[idx] < self.kalman_window_end
+
+    @staticmethod
+    def _kalman_gain(c_zy, s_yy):
+        """The Kalman gain ``K = C_ZY (C_YY + R)^-1`` (paper Eq. 7), solved rather than
+        inverted, with a PD jitter retry.
+
+        ``c_zy`` is the parameter/output cross-covariance (d_param x d_out) and ``s_yy``
+        the innovation covariance ``C_YY + R`` (d_out x d_out, symmetric). Computes
+        ``K = (S^-1 C_ZY^T)^T`` via :func:`numpy.linalg.solve` (never an explicit inverse).
+        ``S`` is PD whenever every measurement variance is positive (``R`` is then PD), so
+        the solve normally succeeds on the first try; a zero-variance point can make ``S``
+        singular, so a trace-scaled diagonal jitter is added and the solve retried. Returns
+        the gain ``K``, or ``None`` if it stays singular (the caller then falls back to
+        'de')."""
+        d_out = s_yy.shape[0]
+        scale = np.trace(s_yy) / d_out if d_out else 1.0
+        jitter = 0.0
+        for attempt in range(4):
+            try:
+                x = np.linalg.solve(s_yy + jitter * np.eye(d_out), c_zy.T)
+                return x.T
+            except np.linalg.LinAlgError:
+                jitter = max(scale, 1e-12) * 1e-8 * (10 ** attempt)
+        return None
+
+    def _calculate_kalman_pset(self, idx, base=None):
+        """Kalman-inspired proposal (DREAM(KZS); Zhang, Vrugt et al. 2020), ADR-0067
+        Stage 3. Returns ``(PSet or None, None)`` -- the trailing ``None`` is the crossover
+        index, which the Kalman jump does not use (so CR adaptation skips this move).
+
+        Per chain ``i``, during the burn-in window (Eqs. 6/7/11-14)::
+
+            {Z_K, f(Z_K)} : an M-member ensemble drawn without replacement from the
+                            archive entries that carry an output vector
+            C_ZY = Cov(Z_K, f(Z_K))          # d_param x d_out, mean-subtracted, /(M-1)
+            C_YY = Cov(f(Z_K), f(Z_K))        # d_out  x d_out
+            K    = C_ZY (C_YY + R)^-1          # d_param x d_out  (_kalman_gain: solve, PD jitter)
+            eps  ~ N(0, R)
+            x_p  = x_i + (1 + lambda) K (d - f(x_i) + eps) + zeta
+
+        Load-bearing details (ADR-0067 "Stage 3 -- confirmed algorithm"):
+
+        * the innovation uses the **current** chain state's residual ``d - f(x_i)`` (the
+          paper sign, so the deterministic part reduces ``||d - f||``) plus a fresh
+          perturbed-observations draw ``eps`` (dropping it degenerates the proposal);
+        * ``(1 + lambda)`` and ``zeta`` are DREAM's standard e-randomization and small
+          perturbation, drawn exactly as the DE proposal draws them, so the operator
+          composes with the rest of the engine;
+        * ``R = diag(var)`` and ``d`` are the current state's cached measurement variance
+          and observation (:meth:`record_accepted_output`).
+
+        Falls back to the DE proposal when the current state has no cached output/variance
+        yet (early burn-in, before the first accept seeds it) or too few archive entries
+        carry outputs -- mirroring how 'whitened' falls back before its preconditioner
+        warms up. The parameter vectors live in sampling space ``u`` (as for the snooker /
+        whitened proposals), so the gain maps native output residuals to ``u``-space jumps
+        and :meth:`_proposal_pset` materializes / bounds-rejects the result."""
+        f_x = self.current_output_vec[idx]
+        d = self.current_output_obs[idx]
+        r_diag = self.current_output_var[idx]
+        pool = [j for j, o in enumerate(self.archive_outputs) if o is not None]
+        if f_x is None or d is None or r_diag is None or len(pool) < _KALMAN_MIN_ENSEMBLE:
+            return self._calculate_de_pset(idx, base)
+
+        m = min(_KALMAN_ENSEMBLE_SIZE, len(pool))
+        sel = self.chain_rngs[idx].choice(pool, m, replace=False)
+        z = np.array([self._param_vec(self.archive[s]) for s in sel])   # M x d_param (u-space)
+        try:
+            f = np.array([self.archive_outputs[s] for s in sel], dtype=float)  # M x d_out
+        except ValueError:
+            # A ragged output stack (an entry cached a different-length f(Z), e.g. a sim
+            # that scored a shorter observation set) cannot form an aligned gain -> DE.
+            return self._calculate_de_pset(idx, base)
+        if f.ndim != 2 or f.shape[1] != len(d) or len(f_x) != len(d):
+            return self._calculate_de_pset(idx, base)
+
+        zc = z - z.mean(axis=0)
+        fc = f - f.mean(axis=0)
+        c_zy = (zc.T @ fc) / (m - 1)                    # d_param x d_out
+        c_yy = (fc.T @ fc) / (m - 1)                    # d_out  x d_out
+        k_gain = self._kalman_gain(c_zy, c_yy + np.diag(r_diag))
+        if k_gain is None:
+            return self._calculate_de_pset(idx, base)
+
+        x0 = self.current_pset[idx] if base is None else base
+        x0_vec = self._param_vec(x0)
+        eps = self.chain_rngs[idx].normal(0.0, 1.0, size=len(d)) * np.sqrt(np.maximum(r_diag, 0.0))
+        innovation = d - f_x + eps                       # paper sign: reduces ||d - f||
+        lamb = self.chain_rngs[idx].uniform(-self.config.config['lambda'], self.config.config['lambda'])
+        zeta = self.chain_rngs[idx].normal(0, self.config.config['zeta'], size=self.n_dim)
+        xp_vec = x0_vec + (1.0 + lamb) * (k_gain @ innovation) + zeta
+        return self._proposal_pset(xp_vec), None
 
     # ------------------------------------------------------------------ #
     # Whitened ('whitened') proposal — folded in from PDreamAlgorithm    #

--- a/pybnf/objective.py
+++ b/pybnf/objective.py
@@ -288,6 +288,18 @@ class ObjectiveFunction:
         variance ``R``); ``LikelihoodObjective`` overrides it for the Gaussian family."""
         return None
 
+    def is_linear_gaussian(self):
+        """Whether every observable this objective scores uses a linear-scale Gaussian
+        noise family -- the config-time precondition for the Kalman-inspired DREAM
+        proposal (ADR-0067 Stage 3, DREAM(KZS)), which forms ``R = diag(sigma**2)`` from a
+        Gaussian measurement covariance and so has no ``R`` for a least-squares / distance
+        / pass-through objective or a non-Gaussian / log-scale likelihood. The base is
+        ``False`` (only a linear-Gaussian ``LikelihoodObjective`` overrides it); it lets
+        ``proposal = kalman`` reject an unsupported objfunc *before the run starts*, rather
+        than silently degenerating to ``de`` because :meth:`aligned_prediction_data` returns
+        ``None`` at every accept."""
+        return False
+
     def residual_point(self, sim_data, exp_data, sim_row, exp_row, col_name):
         """The standardized residual ``rho`` and its derivative ``d rho/d prediction``
         for one scored point -- the per-point seam the gradient path differentiates
@@ -1095,6 +1107,24 @@ class LikelihoodObjective(SummationObjective):
                 obs.append(observation)
                 var.append(primary ** 2)
         return True
+
+    def is_linear_gaussian(self):
+        """True iff the default family and every per-observable override are a
+        linear-scale Gaussian (ADR-0067 Stage 3; overrides
+        :meth:`ObjectiveFunction.is_linear_gaussian`).
+
+        The config-time twin of :meth:`aligned_prediction_data`'s per-point gate
+        (``isinstance(family, Gaussian) and family.additive_on.ln_base == 0.0``), checked
+        against the *declared* families rather than a walked point set so
+        ``proposal = kalman`` can reject a non-Gaussian objfunc before the run starts. Both
+        ``chi_sq`` (fixed ``_SD`` sigma) and ``chi_sq_dynamic`` (an estimated free sigma)
+        pass -- the family is Gaussian either way, and the Kalman ``R = diag(sigma**2)`` is
+        formed per accept from the current state's sourced sigma. A log-scale (``lognormal``)
+        or non-Gaussian (``laplace`` / ``student_t`` / ``neg_bin``) default or override makes
+        it ``False``."""
+        families = [self.noise] + [fam for fam, _sources in self.overrides.values()]
+        return all(isinstance(f, Gaussian) and f.additive_on.ln_base == 0.0
+                   for f in families)
 
     def eval_point(self, sim_data, exp_data, sim_row, exp_row, col_name):
         family, sources = self._spec_for(col_name)

--- a/pybnf/objective.py
+++ b/pybnf/objective.py
@@ -274,6 +274,20 @@ class ObjectiveFunction:
         overrides it (and flips ``supports_pointwise_log_likelihood``)."""
         return None
 
+    def aligned_prediction_data(self, sim_data_dict, exp_data_dict, pset):
+        """The aligned ``(prediction, observation, variance)`` vectors for one parameter
+        set -- the raw per-point model output ``f(theta)``, the matching observed data
+        ``d``, and the Gaussian measurement variance ``sigma**2`` -- or ``None`` when the
+        objective is not a per-point Gaussian likelihood (ADR-0067 Stage 3, DREAM(KZS)).
+
+        This is the seam the Kalman-inspired proposal reads: it needs the model *output
+        vector* (not the scalar score) to build the parameter/output cross-covariance, plus
+        the observed data and the measurement covariance ``R = diag(variance)`` for the
+        Kalman gain. The base is a no-op (a least-squares / distance / pass-through
+        objective has no residual/output vector, and a non-Gaussian likelihood has no
+        variance ``R``); ``LikelihoodObjective`` overrides it for the Gaussian family."""
+        return None
+
     def residual_point(self, sim_data, exp_data, sim_row, exp_row, col_name):
         """The standardized residual ``rho`` and its derivative ``d rho/d prediction``
         for one scored point -- the per-point seam the gradient path differentiates
@@ -1022,6 +1036,65 @@ class LikelihoodObjective(SummationObjective):
                 primary, extra = self._noise_values(family, sources, self, exp_data, rownum, col_name)
                 values.append(family.log_density(prediction, observation, primary, extra))
                 ids.append('%s/%s@%s=%g' % (prefix, col_name, indvar, indvar_val))
+
+    def aligned_prediction_data(self, sim_data_dict, exp_data_dict, pset):
+        """Aligned ``(prediction, observation, variance)`` for the Kalman proposal
+        (ADR-0067 Stage 3; overrides :meth:`ObjectiveFunction.aligned_prediction_data`).
+
+        Walks the same scored points as :meth:`evaluate_pointwise` in the same
+        deterministic order (``_pointwise_suffix``'s model -> suffix -> row ->
+        ``sorted(compare_cols)`` walk, skipping only NaN observations), so ``prediction``
+        (the model output ``f(theta)``), ``observation`` (the data ``d``), and
+        ``variance`` (the Gaussian ``sigma**2``, the ``R`` diagonal) are index-aligned and
+        stable across draws. Returns three ``np.ndarray`` s, or ``None`` unless **every**
+        scored point is an ordinary additive-error **Gaussian** observable (linear scale):
+        the Kalman gain's ``R = diag(variance)`` is the Gaussian measurement covariance, so
+        a log-scale (lognormal) or non-Gaussian (Laplace / Student-t / count) family has no
+        ``R`` to form and the proposal is unsupported for that objective."""
+        self._pset_values = {p.name: p.value for p in pset}
+        preds, obs, var = [], [], []
+        with np.errstate(all='ignore'):
+            if self.measurement:
+                self.measurement.apply(sim_data_dict, self._pset_values)
+            for model in sim_data_dict:
+                for suffix in sim_data_dict[model]:
+                    if suffix in exp_data_dict[model]:
+                        if not self._aligned_prediction_suffix(
+                                sim_data_dict[model][suffix], exp_data_dict[model][suffix],
+                                preds, obs, var, data_key=suffix):
+                            return None
+        if not preds:
+            return None
+        return np.array(preds, dtype=float), np.array(obs, dtype=float), np.array(var, dtype=float)
+
+    def _aligned_prediction_suffix(self, sim_data, exp_data, preds, obs, var, data_key=None):
+        """Append aligned ``(prediction, observation, sigma**2)`` for every scored point of
+        one model/suffix -- the Kalman twin of :meth:`_pointwise_suffix`, same row-matching
+        and scaling seams. Returns ``False`` (and stops) if any scored observable is not a
+        linear-scale Gaussian, for which ``sigma**2`` is the measurement variance ``R``."""
+        indvar = min(exp_data.cols, key=exp_data.cols.get)
+        comparable = set(sim_data.cols) | set(self._per_measurement_models)
+        compare_cols = set(exp_data.cols).intersection(comparable)
+        compare_cols.discard(indvar)
+        self._scale_factors = self._analytic_scale_factors(sim_data, exp_data, indvar, compare_cols, data_key)
+        for rownum in range(exp_data.data.shape[0]):
+            sim_row = self._sim_row_for(sim_data, exp_data, indvar, rownum, show_warnings=False)
+            for col_name in sorted(compare_cols):
+                observation = exp_data.data[rownum, exp_data.cols[col_name]]
+                if np.isnan(observation):
+                    continue
+                family, sources = self._spec_for(col_name)
+                # Kalman's R = diag(sigma**2) is the Gaussian measurement covariance, so
+                # only an ordinary additive-error Gaussian (linear scale) has a well-defined
+                # variance here; a log-scale or non-Gaussian family has no such R.
+                if not (isinstance(family, Gaussian) and family.additive_on.ln_base == 0.0):
+                    return False
+                prediction = self._prediction(sim_data, sim_row, col_name, exp_data, rownum)
+                primary, _extra = self._noise_values(family, sources, self, exp_data, rownum, col_name)
+                preds.append(prediction)
+                obs.append(observation)
+                var.append(primary ** 2)
+        return True
 
     def eval_point(self, sim_data, exp_data, sim_row, exp_row, col_name):
         family, sources = self._spec_for(col_name)

--- a/pybnf/parse.py
+++ b/pybnf/parse.py
@@ -58,7 +58,7 @@ numkeys_float = ['min_objective', 'cognitive', 'social', 'particle_weight',
                  'simplex_reflection', 'simplex_expansion', 'simplex_contraction', 'simplex_shrink', 'cooling',
                  'beta_max', 'bootstrap_max_obj', 'simplex_stop_tol', 'v_stop', 'gamma_prob', 'zeta', 'lambda',
                  'constraint_scale', 'neg_bin_r', 'stablizingCov',
-                 'rhat_threshold', 'snooker_prob',
+                 'rhat_threshold', 'snooker_prob', 'kalman_burnin_frac',
                  'powell_step', 'powell_line_tol', 'powell_stop_tol',
                  'cmaes_sigma0', 'cmaes_stop_tol',
                  # gradient optimizers (fit_type = trf / lbfgs / gntr, #386/#481): the

--- a/tests/golden_configs/effective_config_golden.json
+++ b/tests/golden_configs/effective_config_golden.json
@@ -557,6 +557,10 @@
     null
    ],
    [
+    "kalman_burnin_frac",
+    0.3
+   ],
+   [
     "lambda",
     0.1
    ],
@@ -985,6 +989,10 @@
    [
     "job_type",
     null
+   ],
+   [
+    "kalman_burnin_frac",
+    0.3
    ],
    [
     "lambda",
@@ -1923,6 +1931,10 @@
     null
    ],
    [
+    "kalman_burnin_frac",
+    0.3
+   ],
+   [
     "lambda",
     0.1
    ],
@@ -2463,6 +2475,10 @@
    [
     "job_type",
     null
+   ],
+   [
+    "kalman_burnin_frac",
+    0.3
    ],
    [
     "lambda",
@@ -3395,6 +3411,10 @@
     null
    ],
    [
+    "kalman_burnin_frac",
+    0.3
+   ],
+   [
     "lambda",
     0.1
    ],
@@ -3823,6 +3843,10 @@
    [
     "job_type",
     null
+   ],
+   [
+    "kalman_burnin_frac",
+    0.3
    ],
    [
     "lambda",

--- a/tests/integration_harness.py
+++ b/tests/integration_harness.py
@@ -41,6 +41,7 @@ stream per-step output to disk), so:
     ``ground_truth`` with statistical tolerances. Run occasionally / before
     landing the critical algorithm patches.
 """
+import copy
 import json
 import os
 
@@ -48,6 +49,8 @@ import numpy as np
 
 from pybnf import algorithms, config
 from pybnf.algorithms import Result
+from pybnf.data import Data
+from pybnf.pset import Model
 
 
 # --------------------------------------------------------------------------- #
@@ -122,6 +125,95 @@ def install(monkeypatch):
     monkeypatch.setattr(algorithms.core, 'as_completed', FakeAsCompleted)
     monkeypatch.setattr(algorithms.core, 'run_job', slim_run_job)
     monkeypatch.setattr('pybnf.analytical_model.time.sleep', lambda *a, **k: None)
+
+
+# --------------------------------------------------------------------------- #
+# Linear-Gaussian forward model — the closed-form DREAM(KZS) oracle (ADR-0067
+# Stage 3). Unlike the AnalyticalModel targets (which emit a scalar `score`
+# column for `direct_pass`), this emits observable output columns f(x) = A x
+# scored by the *real* chi_sq likelihood — the shape the Kalman proposal needs
+# (it reads the model output vector, not just the score). With a linear forward
+# map, a Gaussian likelihood, and a flat prior, the posterior is Gaussian in
+# closed form (`linear_gaussian_posterior`): the honest end-to-end oracle.
+# --------------------------------------------------------------------------- #
+class LinearGaussianModel(Model):
+    """Test-only forward model ``f(x) = A x``: emits one observable row per output
+    (``index``, ``y``) scored by chi_sq against a matching ``.exp`` (``index``, ``y``,
+    ``y_SD``). Parameters bind by name ``p1..pD`` (``D = A.shape[1]``), matching
+    :func:`make_config`; the ``target`` suffix matches the generated ``target.exp``."""
+
+    def __init__(self, A, name='g', pset=None):
+        self.A = np.asarray(A, dtype=float)   # n_out x n_params
+        self.name = name
+        self.file_path = name
+        self.suffixes = ['target']
+        self.stochastic = False
+        self.has_observables = True
+        self.param_names = set()              # params come from the config, not the model
+        self._pset = pset
+
+    def copy_with_param_set(self, pset):
+        m = copy.copy(self)
+        m._pset = pset
+        return m
+
+    def save(self, file_prefix, **kwargs):
+        pass
+
+    def get_suffixes(self):
+        return self.suffixes
+
+    def execute(self, folder, filename, timeout):
+        if self._pset is None:
+            raise ValueError('LinearGaussianModel has no parameter set')
+        x = np.array([self._pset['p%d' % (i + 1)] for i in range(self.A.shape[1])])
+        y = self.A @ x                        # n_out forward outputs
+        arr = np.column_stack([np.arange(len(y), dtype=float), y])
+        d = Data(arr=arr)
+        d.cols = {'index': 0, 'y': 1}
+        d.headers = {0: 'index', 1: 'y'}
+        return {'target': d}
+
+
+def linear_gaussian_posterior(A, d, sigma):
+    """Closed-form posterior ``x | d ~ N(mu_post, Sigma_post)`` for the linear-Gaussian
+    model with a flat prior: ``Sigma_post = (A^T R^-1 A)^-1``, ``mu_post = Sigma_post A^T
+    R^-1 d`` with ``R = diag(sigma**2)``. Returns ``(mu_post, Sigma_post)``."""
+    A = np.asarray(A, dtype=float)
+    d = np.asarray(d, dtype=float)
+    r_inv = np.diag(1.0 / np.asarray(sigma, dtype=float) ** 2)
+    prec = A.T @ r_inv @ A
+    cov = np.linalg.inv(prec)
+    return cov @ A.T @ r_inv @ d, cov
+
+
+def make_linear_gaussian_config(tmp_path, A, d, sigma, bounds=(-20.0, 20.0), **overrides):
+    """A real ``objfunc = chi_sq`` DREAM fit over the linear-Gaussian forward model
+    ``f(x) = A x`` scored against ``d`` with per-observation ``sigma``.
+
+    Writes a matching ``target.exp`` (``index``, ``y``, ``y_SD``) and a placeholder
+    ``.target`` so the Configuration loader builds a model named ``g`` with suffix
+    ``target``; then swaps in :class:`LinearGaussianModel` (keeping name+suffix so the
+    loaded exp_data keys still resolve). Parameters are ``p1..pD`` over ``bounds``
+    (a wide flat prior, so the Gaussian posterior sits well inside the box)."""
+    A = np.asarray(A, dtype=float)
+    d = np.asarray(d, dtype=float)
+    sigma = np.asarray(sigma, dtype=float)
+    n_out, n_params = A.shape
+    tgt = tmp_path / 'g.target'
+    tgt.write_text(json.dumps(gaussian_spec([0.0] * n_params, [1.0] * n_params)))
+    exp = tmp_path / 'target.exp'
+    rows = ['# index\ty\ty_SD']
+    rows += ['%d\t%.17g\t%.17g' % (i, d[i], sigma[i]) for i in range(n_out)]
+    exp.write_text('\n'.join(rows) + '\n')
+    # Sampler defaults so callers that only exercise construction/validation need not
+    # restate the required keys; any is overridable via ``overrides``.
+    kw = dict(population_size=5, max_iterations=100, burn_in=50)
+    kw.update(overrides)
+    conf = make_config(tmp_path, 'dream', str(tgt), str(exp), n_params,
+                       bounds=bounds, objfunc='chi_sq', **kw)
+    conf.models['g'] = LinearGaussianModel(A, name='g')
+    return conf
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_benchmark_harness.py
+++ b/tests/test_benchmark_harness.py
@@ -63,14 +63,17 @@ import run_benchmark as rb  # noqa: E402  (path-dependent import of the harness 
 # These always carry no-op defaults here, so excluding them keeps the oracle an
 # independent *pre-migration* witness without regenerating it for keys the original confs
 # could not have carried.
-# classic whitened), and n_try (ADR-0067 Stage 2; the Multi-Try DREAM count -- defaults to
+# classic whitened), n_try (ADR-0067 Stage 2; the Multi-Try DREAM count -- defaults to
 # 1 == the classic single-try engine, byte-identical to pre-migration, so these confs never
-# carried it and it is a no-op here).
+# carried it and it is a no-op here), and kalman_burnin_frac (ADR-0067 Stage 3; the
+# proposal-scoped Kalman burn-in window -- defaults to 0.3, meaningful only for the
+# kalman proposal these pre-migration de/whitened confs never selected, so a no-op here).
 _EXCLUDE = frozenset({
     'bng_command', 'output_dir', 'refine_method', 'noise_location',
     'initialization_distribution', 'edition', 'objective', 'profile_objective',
     'job_type', 'embed_best_fit_data', 'smooth_plot_points', 'output_inference_data',
     'qualitative_loss', 'qualitative_scale', 'generate_network', 'proposal', 'n_try',
+    'kalman_burnin_frac',
 })
 
 

--- a/tests/test_kalman_dream.py
+++ b/tests/test_kalman_dream.py
@@ -7,15 +7,59 @@ Gaussian measurement variance ``R`` -- surfaced by the objective seam
 ``LikelihoodObjective.aligned_prediction_data`` (Stage 3a, the output-augmented
 archive plumbing).
 
-This file starts with the Stage 3a extractor unit tests (BNG-free: they exercise
-``aligned_prediction_data`` directly on hand-built Data). The Kalman proposal's
-own gain-math unit tests and the closed-form linear-Gaussian posterior-recovery
-oracle land with Stage 3b.
+This file has two parts:
+
+* the Stage 3a extractor unit tests (BNG-free: they exercise
+  ``aligned_prediction_data`` directly on hand-built Data), and
+* the Stage 3b tests -- the ``is_linear_gaussian`` config gate, pinned gain-math
+  unit tests (``_kalman_gain`` and the deterministic-jump sign / residual
+  reduction), the ``de`` fallback and burn-in window switch, and the end-to-end
+  closed-form **linear-Gaussian posterior-recovery oracle** (``f(x) = A x`` scored
+  by real ``chi_sq``; the honest oracle the scalar ``direct_pass`` menu cannot give).
 """
 import numpy as np
+import pytest
 
 from pybnf import objective, data
+from pybnf.algorithms import DreamAlgorithm
+from pybnf.printing import PybnfError
 from pybnf.pset import PSet, FreeParameter
+
+from . import integration_harness as H
+
+
+@pytest.fixture(autouse=True)
+def _fakes(monkeypatch):
+    """Patch the dask / simulation-folder / sleep layers for the driving tests. Inert
+    for the pure-extractor tests, which touch neither the scheduler nor a model."""
+    H.install(monkeypatch)
+
+
+# A 2-parameter, 4-observation linear-Gaussian oracle: A is full column rank, the data
+# is noiseless (d = A x_true), so the closed-form posterior is N(x_true, (A^T A)^-1) =
+# N([2, -1], (1/3) I) for sigma = 1 (A^T A = 3 I). Shared by the gain and oracle tests.
+_A = np.array([[1., 0.], [0., 1.], [1., 1.], [1., -1.]])
+_X_TRUE = np.array([2.0, -1.0])
+_D = _A @ _X_TRUE
+_SIGMA = np.ones(4)
+
+
+class _ZeroRNG:
+    """Deterministic RNG stand-in for the sign test: ``choice`` returns the first
+    ``size`` of the pool, ``normal`` returns zeros (killing the Kalman eps and the zeta
+    perturbation), and ``uniform(a, b)`` returns the midpoint (so the lambda draw over
+    ``(-l, l)`` is 0). The Kalman jump is then exactly ``K (d - f(x))`` -- deterministic
+    and comparable to a closed-form reference."""
+
+    def choice(self, pool, size, replace=True):
+        return np.asarray(pool)[:size]
+
+    def normal(self, loc=0.0, scale=1.0, size=None):
+        return np.zeros(size) if size is not None else 0.0
+
+    def uniform(self, a=0.0, b=1.0, size=None):
+        mid = (a + b) / 2.0
+        return mid if size is None else np.full(size, mid)
 
 
 def _data(arr, cols):
@@ -85,3 +129,229 @@ def test_lognormal_returns_none():
     exp = _data([[0.0, 2.5, 0.5], [1.0, 3.5, 0.5]], {'time': 0, 'y': 1, 'y_SD': 2})
     out = obj.aligned_prediction_data({'m': {'s': sim}}, {'m': {'s': exp}}, _pset())
     assert out is None
+
+
+# --------------------------------------------------------------------------- #
+# Stage 3b: the is_linear_gaussian config gate
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize('obj_cls, expected', [
+    (objective.ChiSquareObjective, True),            # Gaussian, fixed _SD sigma
+    (objective.ChiSquareObjective_Dynamic, True),    # Gaussian, estimated free sigma
+    (objective.LogNormalObjective, False),           # Gaussian on the log10 scale -> no linear R
+    (objective.LaplaceObjective, False),             # non-Gaussian family
+    (objective.SumOfSquaresObjective, False),        # not a likelihood
+    (objective.DirectPassObjective, False),          # pass-through analytical score
+])
+def test_is_linear_gaussian_gate(obj_cls, expected):
+    """The config-time gate proposal = kalman uses: only a linear-scale Gaussian
+    likelihood (chi_sq / chi_sq_dynamic) forms the Kalman R = diag(sigma**2)."""
+    assert obj_cls().is_linear_gaussian() is expected
+
+
+def test_is_linear_gaussian_false_on_lognormal_override():
+    """A single log-scale per-observable override taints the whole objective: the
+    gate is all-observables (every point must have a linear R)."""
+    from pybnf.noise import Gaussian, LOG10, MEDIAN, DataColumnSigma
+    obj = objective.ChiSquareObjective()
+    obj.overrides = {'y': (Gaussian(additive_on=LOG10, location=MEDIAN),
+                           {'sigma': DataColumnSigma()})}
+    assert obj.is_linear_gaussian() is False
+
+
+# --------------------------------------------------------------------------- #
+# Stage 3b: the Kalman gain math (K = C_ZY (C_YY + R)^-1)
+# --------------------------------------------------------------------------- #
+def test_kalman_gain_matches_inverse():
+    """_kalman_gain solves rather than inverts, but must equal C_ZY (C_YY+R)^-1."""
+    c_zy = np.array([[1., 2., 3.], [4., 5., 6.]])            # 2 x 3
+    s = np.array([[2., 0.5, 0.], [0.5, 3., 1.], [0., 1., 4.]])   # 3 x 3 SPD
+    k = DreamAlgorithm._kalman_gain(c_zy, s)
+    assert np.allclose(k, c_zy @ np.linalg.inv(s))
+
+
+def test_kalman_gain_jitters_singular_innovation_cov():
+    """A singular innovation covariance (a zero-variance point can make C_YY + R
+    singular) is rescued by the PD jitter, not returned as NaN."""
+    c_zy = np.array([[1., 2.], [3., 4.]])
+    s = np.array([[1., 1.], [1., 1.]])                       # rank-1 singular
+    k = DreamAlgorithm._kalman_gain(c_zy, s)
+    assert k is not None and np.all(np.isfinite(k))
+
+
+def _kalman_alg(tmp_path, **overrides):
+    """A constructed (undriven) kalman DreamAlgorithm over the linear-Gaussian oracle,
+    with a fresh empty current_pset list ready for hand-set state."""
+    kw = dict(population_size=3, burn_in=50, max_iterations=60, rhat_threshold=0)
+    kw.update(overrides)
+    conf = H.make_linear_gaussian_config(tmp_path, _A, _D, _SIGMA, proposal='kalman', **kw)
+    alg = DreamAlgorithm(conf)
+    alg.current_pset = [None] * alg.num_parallel
+    return alg
+
+
+def test_kalman_deterministic_jump_reduces_residual(tmp_path):
+    """The deterministic Kalman jump x + K(d - f(x)) reduces ||d - f(x)||: with a
+    well-spread ensemble over a linear f(x) = A x, K is the ensemble Kalman gain and
+    the innovation d - f(x) (paper sign) pulls the state toward the data manifold."""
+    alg = _kalman_alg(tmp_path)
+    rng = np.random.default_rng(0)
+    z = rng.normal(0.0, 3.0, size=(20, 2))                  # ensemble in u = param space
+    alg.archive = [alg._pset_from_u(zi) for zi in z]
+    alg.archive_outputs = [_A @ zi for zi in z]
+    idx = 0
+    x = np.array([-1.0, 4.0])                               # off the mode [2, -1]
+    alg.current_pset[idx] = alg._pset_from_u(x)
+    alg.current_output_vec[idx] = _A @ x
+    alg.current_output_obs[idx] = _D
+    alg.current_output_var[idx] = _SIGMA ** 2
+    alg.chain_rngs[idx] = _ZeroRNG()
+
+    proposal, cr_idx = alg._calculate_kalman_pset(idx)
+    assert cr_idx is None                                   # kalman uses no crossover
+    xp = alg._param_vec(proposal)
+    assert np.linalg.norm(_D - _A @ xp) < np.linalg.norm(_D - _A @ x)
+
+
+def test_kalman_falls_back_to_de_with_too_few_outputs(tmp_path, monkeypatch):
+    """No archive entry carries an output yet (early burn-in): the proposal must fall
+    back to the DE proposal rather than build a gain from nothing."""
+    alg = _kalman_alg(tmp_path)
+    alg.current_pset[0] = alg._pset_from_u(np.zeros(2))
+    alg.archive = [alg._pset_from_u(np.zeros(2))]
+    alg.archive_outputs = [None]                            # 0 entries with outputs
+    alg.current_output_vec[0] = _A @ np.zeros(2)
+    alg.current_output_obs[0] = _D
+    alg.current_output_var[0] = _SIGMA ** 2
+    sentinel = ('DE_PSET', 7)
+    monkeypatch.setattr(alg, '_calculate_de_pset', lambda idx, base=None: sentinel)
+    assert alg._calculate_kalman_pset(0) is sentinel
+
+
+def test_kalman_falls_back_to_de_without_current_output(tmp_path, monkeypatch):
+    """The current state has no cached output (never accepted yet): fall back to DE
+    even when the archive is full of outputs."""
+    alg = _kalman_alg(tmp_path)
+    alg.current_pset[0] = alg._pset_from_u(np.zeros(2))
+    z = np.random.default_rng(1).normal(0, 3, size=(20, 2))
+    alg.archive = [alg._pset_from_u(zi) for zi in z]
+    alg.archive_outputs = [_A @ zi for zi in z]
+    alg.current_output_vec[0] = None                        # not seeded
+    alg.current_output_obs[0] = _D
+    alg.current_output_var[0] = _SIGMA ** 2
+    sentinel = ('DE_PSET', 3)
+    monkeypatch.setattr(alg, '_calculate_de_pset', lambda idx, base=None: sentinel)
+    assert alg._calculate_kalman_pset(0) is sentinel
+
+
+# --------------------------------------------------------------------------- #
+# Stage 3b: the burn-in window switch
+# --------------------------------------------------------------------------- #
+def test_kalman_window_end_is_fraction_of_burn_in(tmp_path):
+    alg = _kalman_alg(tmp_path, burn_in=100, kalman_burnin_frac=0.3)
+    assert alg.kalman_window_end == 30                      # round(0.3 * 100)
+
+
+def test_kalman_active_only_inside_window(tmp_path):
+    alg = _kalman_alg(tmp_path, burn_in=100)                # window_end = 30
+    alg.iteration[0] = 0
+    assert alg._kalman_active(0) is True
+    alg.iteration[0] = 29
+    assert alg._kalman_active(0) is True
+    alg.iteration[0] = 30                                   # boundary is exclusive
+    assert alg._kalman_active(0) is False
+    alg.iteration[0] = 80
+    assert alg._kalman_active(0) is False
+
+
+def test_dispatch_reverts_to_de_after_window(tmp_path, monkeypatch):
+    """calculate_new_pset routes to the Kalman operator inside the window and to DE
+    after it -- the burn-in switch (the binary snooker/non-snooker split renormalizes
+    automatically)."""
+    alg = _kalman_alg(tmp_path, burn_in=100)                # window_end = 30
+    monkeypatch.setattr(alg, '_calculate_kalman_pset', lambda i, base=None: ('KALMAN', None))
+    monkeypatch.setattr(alg, '_calculate_de_pset', lambda i, base=None: ('DE', 1))
+    alg.iteration[0] = 10
+    assert alg.calculate_new_pset(0)[0] == 'KALMAN'
+    alg.iteration[0] = 60
+    assert alg.calculate_new_pset(0)[0] == 'DE'
+
+
+def test_de_proposal_never_activates_kalman(tmp_path):
+    """A plain 'de' run stores no outputs and is never kalman-active -- the axis-2b
+    plumbing stays dormant (byte-identical to before Stage 3)."""
+    conf = H.make_linear_gaussian_config(tmp_path, _A, _D, _SIGMA)   # proposal defaults to 'de'
+    alg = DreamAlgorithm(conf)
+    assert alg._archive_stores_outputs is False
+    assert alg.kalman_window_end == 0
+    alg.iteration[0] = 0
+    assert alg._kalman_active(0) is False
+
+
+# --------------------------------------------------------------------------- #
+# Stage 3b: config validation (errors clearly, before the run starts)
+# --------------------------------------------------------------------------- #
+def test_kalman_rejects_non_gaussian_objective(tmp_path):
+    """proposal = kalman with a direct_pass (analytical) objective has no R and must
+    error at construction, not silently degenerate to de."""
+    tgt, exp = H.write_target(tmp_path, H.gaussian_spec([0.0, 0.0], [1.0, 1.0]))
+    conf = H.make_config(tmp_path, 'dream', tgt, exp, 2, proposal='kalman',   # direct_pass
+                         population_size=5, max_iterations=100, burn_in=50)
+    with pytest.raises(PybnfError, match='linear-scale Gaussian'):
+        DreamAlgorithm(conf)
+
+
+def test_kalman_rejects_n_try_gt_1(tmp_path):
+    conf = H.make_linear_gaussian_config(tmp_path, _A, _D, _SIGMA, proposal='kalman', n_try=3)
+    with pytest.raises(PybnfError, match='n_try'):
+        DreamAlgorithm(conf)
+
+
+def test_kalman_rejects_out_of_range_burnin_frac(tmp_path):
+    conf = H.make_linear_gaussian_config(tmp_path, _A, _D, _SIGMA,
+                                         proposal='kalman', kalman_burnin_frac=1.5)
+    with pytest.raises(PybnfError, match='kalman_burnin_frac'):
+        DreamAlgorithm(conf)
+
+
+# --------------------------------------------------------------------------- #
+# Stage 3b: the closed-form linear-Gaussian posterior-recovery oracle
+# --------------------------------------------------------------------------- #
+def test_kalman_moves_to_mode(tmp_path):
+    """FAST: a short kalman run leaves the flat prior and concentrates near the
+    closed-form posterior mode [2, -1]; samples are finite and the chain moves."""
+    conf = H.make_linear_gaussian_config(
+        tmp_path, _A, _D, _SIGMA, proposal='kalman',
+        population_size=6, burn_in=120, max_iterations=350, rhat_threshold=0,
+        sample_every=2, output_hist_every=10 ** 9, hist_bins=10,
+        diagnostics_every=10 ** 9, random_seed=7)
+    alg = DreamAlgorithm(conf)
+    H.drive(alg)
+
+    samples = H.read_samples(conf.config['output_dir'], 2)
+    assert len(samples) > 0, 'no samples written'
+    assert np.all(np.isfinite(samples)), 'non-finite samples'
+    mu, _cov = H.linear_gaussian_posterior(_A, _D, _SIGMA)
+    assert np.allclose(samples.mean(axis=0), mu, atol=0.5), \
+        'kalman chain mean %s not near posterior mode %s' % (samples.mean(axis=0), mu)
+    assert H.acceptance_rate(samples) > 0.1, 'chain not moving'
+
+
+@pytest.mark.slow
+def test_kalman_recovers_linear_gaussian_posterior(tmp_path):
+    """SLOW: full moment recovery against the closed-form posterior N([2,-1], (1/3) I) --
+    the correctness proof that (kalman during burn-in, de after) samples the target."""
+    conf = H.make_linear_gaussian_config(
+        tmp_path, _A, _D, _SIGMA, proposal='kalman',
+        population_size=6, burn_in=350, max_iterations=900, rhat_threshold=0,
+        sample_every=2, output_hist_every=10 ** 9, hist_bins=10,
+        diagnostics_every=10 ** 9, random_seed=21)
+    alg = DreamAlgorithm(conf)
+    H.drive(alg)
+
+    samples = H.read_samples(conf.config['output_dir'], 2)
+    assert len(samples) > 200, 'too few samples for moment recovery'
+    mu, cov = H.linear_gaussian_posterior(_A, _D, _SIGMA)
+    assert np.allclose(samples.mean(axis=0), mu, atol=0.15), \
+        'posterior mean %s off target %s' % (samples.mean(axis=0), mu)
+    assert np.allclose(np.var(samples, axis=0), np.diag(cov), rtol=0.4), \
+        'posterior variance %s off target %s' % (np.var(samples, axis=0), np.diag(cov))

--- a/tests/test_kalman_dream.py
+++ b/tests/test_kalman_dream.py
@@ -288,39 +288,56 @@ def test_de_proposal_never_activates_kalman(tmp_path):
 
 
 # --------------------------------------------------------------------------- #
-# Stage 3b: config validation (errors clearly, before the run starts)
+# Stage 3b: config validation matrix (every unsupported point errors clearly, at
+# construction, before the run starts -- the "config points, not subclasses"
+# surface must reject the inexpressible combinations up front rather than fail or
+# silently degenerate mid-run).
 # --------------------------------------------------------------------------- #
-def test_kalman_rejects_non_gaussian_objective(tmp_path):
-    """proposal = kalman with a direct_pass (analytical) objective has no R and must
-    error at construction, not silently degenerate to de."""
+def _direct_pass_kalman_conf(tmp_path):
+    """A proposal = kalman config over a direct_pass (analytical, non-Gaussian)
+    objective -- no measurement R, so kalman must refuse it."""
     tgt, exp = H.write_target(tmp_path, H.gaussian_spec([0.0, 0.0], [1.0, 1.0]))
-    conf = H.make_config(tmp_path, 'dream', tgt, exp, 2, proposal='kalman',   # direct_pass
+    return H.make_config(tmp_path, 'dream', tgt, exp, 2, proposal='kalman',
                          population_size=5, max_iterations=100, burn_in=50)
-    with pytest.raises(PybnfError, match='linear-scale Gaussian'):
-        DreamAlgorithm(conf)
 
 
-def test_kalman_rejects_n_try_gt_1(tmp_path):
-    conf = H.make_linear_gaussian_config(tmp_path, _A, _D, _SIGMA, proposal='kalman', n_try=3)
-    with pytest.raises(PybnfError, match='n_try'):
-        DreamAlgorithm(conf)
-
-
-def test_kalman_rejects_out_of_range_burnin_frac(tmp_path):
-    conf = H.make_linear_gaussian_config(tmp_path, _A, _D, _SIGMA,
-                                         proposal='kalman', kalman_burnin_frac=1.5)
-    with pytest.raises(PybnfError, match='kalman_burnin_frac'):
-        DreamAlgorithm(conf)
+@pytest.mark.parametrize('build_conf, match', [
+    # invalid proposal enum value (caught before the kalman-specific checks)
+    (lambda t: H.make_linear_gaussian_config(t, _A, _D, _SIGMA, proposal='banana'),
+     'Invalid proposal'),
+    # kalman requires a linear-scale Gaussian likelihood (direct_pass has no R)
+    (_direct_pass_kalman_conf, 'linear-scale Gaussian'),
+    # kalman is single-try only
+    (lambda t: H.make_linear_gaussian_config(t, _A, _D, _SIGMA, proposal='kalman', n_try=3),
+     'n_try'),
+    # kalman_burnin_frac must be in [0, 1] -- above and below
+    (lambda t: H.make_linear_gaussian_config(t, _A, _D, _SIGMA, proposal='kalman',
+                                             kalman_burnin_frac=1.5), 'kalman_burnin_frac'),
+    (lambda t: H.make_linear_gaussian_config(t, _A, _D, _SIGMA, proposal='kalman',
+                                             kalman_burnin_frac=-0.1), 'kalman_burnin_frac'),
+], ids=['invalid-proposal', 'kalman+non-gaussian', 'kalman+n_try>1',
+        'burnin-frac-too-high', 'burnin-frac-negative'])
+def test_dream_config_rejection_matrix(tmp_path, build_conf, match):
+    with pytest.raises(PybnfError, match=match):
+        DreamAlgorithm(build_conf(tmp_path))
 
 
 # --------------------------------------------------------------------------- #
 # Stage 3b: the closed-form linear-Gaussian posterior-recovery oracle
 # --------------------------------------------------------------------------- #
-def test_kalman_moves_to_mode(tmp_path):
+@pytest.mark.parametrize('snooker_prob', [0.1, 0.5],
+                         ids=['default-snooker', 'snooker-heavy'])
+def test_kalman_moves_to_mode(tmp_path, snooker_prob):
     """FAST: a short kalman run leaves the flat prior and concentrates near the
-    closed-form posterior mode [2, -1]; samples are finite and the chain moves."""
+    closed-form posterior mode [2, -1]; samples are finite and the chain moves.
+
+    Parametrized over ``snooker_prob`` because the Kalman jump is the *non-snooker*
+    branch of DREAM's binary split: the ``snooker-heavy`` case (snooker fires half the
+    time) is the composition check that ``proposal = kalman`` co-exists with the snooker
+    mix-in (the ADR-0067 "orthogonal to proposal" claim) and still recovers the mode --
+    the analogue of the multi-try ``snooker-heavy-k3`` case."""
     conf = H.make_linear_gaussian_config(
-        tmp_path, _A, _D, _SIGMA, proposal='kalman',
+        tmp_path, _A, _D, _SIGMA, proposal='kalman', snooker_prob=snooker_prob,
         population_size=6, burn_in=120, max_iterations=350, rhat_threshold=0,
         sample_every=2, output_hist_every=10 ** 9, hist_bins=10,
         diagnostics_every=10 ** 9, random_seed=7)

--- a/tests/test_kalman_dream.py
+++ b/tests/test_kalman_dream.py
@@ -1,0 +1,87 @@
+"""Kalman-inspired DREAM (DREAM(KZS); ADR-0067 Stage 3, issue #358) tests.
+
+Stage 3 adds the ``proposal = kalman`` operator, whose gain is built from the
+archive's parameter<->output cross-covariance. That needs the *model output
+vector* ``f(theta)`` (not just the scalar score), the observed data ``d``, and the
+Gaussian measurement variance ``R`` -- surfaced by the objective seam
+``LikelihoodObjective.aligned_prediction_data`` (Stage 3a, the output-augmented
+archive plumbing).
+
+This file starts with the Stage 3a extractor unit tests (BNG-free: they exercise
+``aligned_prediction_data`` directly on hand-built Data). The Kalman proposal's
+own gain-math unit tests and the closed-form linear-Gaussian posterior-recovery
+oracle land with Stage 3b.
+"""
+import numpy as np
+
+from pybnf import objective, data
+from pybnf.pset import PSet, FreeParameter
+
+
+def _data(arr, cols):
+    d = data.Data()
+    d.data = np.array(arr, dtype=float)
+    d.cols = dict(cols)
+    d.headers = {v: k for k, v in cols.items()}
+    return d
+
+
+def _pset():
+    return PSet([FreeParameter('p1', 'uniform_var', 0.0, 1.0, value=0.5)])
+
+
+# --------------------------------------------------------------------------- #
+# Stage 3a: LikelihoodObjective.aligned_prediction_data
+# --------------------------------------------------------------------------- #
+def test_gaussian_extractor_aligns_prediction_observation_variance():
+    """chi_sq (a linear-scale Gaussian likelihood) returns the raw model output
+    f(theta), the observed data d, and sigma**2 -- index-aligned over the walk
+    row -> sorted(observable columns)."""
+    obj = objective.ChiSquareObjective()
+    sim = _data([[0.0, 2.0], [1.0, 4.0]], {'time': 0, 'y': 1})
+    exp = _data([[0.0, 2.5, 0.5], [1.0, 3.5, 0.25]], {'time': 0, 'y': 1, 'y_SD': 2})
+    out = obj.aligned_prediction_data({'m': {'s': sim}}, {'m': {'s': exp}}, _pset())
+    assert out is not None
+    prediction, observation, variance = out
+    assert np.allclose(prediction, [2.0, 4.0])
+    assert np.allclose(observation, [2.5, 3.5])
+    assert np.allclose(variance, [0.25, 0.0625])   # sigma**2 from the _SD column
+
+
+def test_extractor_alignment_matches_pointwise_order():
+    """The extractor walks the same points in the same order as evaluate_pointwise,
+    so its observation vector equals the data the pointwise log-likelihoods score --
+    the guarantee the Kalman innovation d - f(x) relies on for correspondence."""
+    obj = objective.ChiSquareObjective()
+    # Two observables (x, y) over two rows -> sorted columns give x before y per row.
+    sim = _data([[0.0, 1.0, 10.0], [1.0, 2.0, 20.0]], {'time': 0, 'x': 1, 'y': 2})
+    exp = _data([[0.0, 1.1, 10.1, 1.0, 1.0], [1.0, 2.1, 20.1, 1.0, 1.0]],
+                {'time': 0, 'x': 1, 'y': 2, 'x_SD': 3, 'y_SD': 4})
+    sd, ed = {'m': {'s': sim}}, {'m': {'s': exp}}
+    prediction, observation, _var = obj.aligned_prediction_data(sd, ed, _pset())
+    ids, _vals = obj.evaluate_pointwise(sd, ed, _pset())
+    assert len(prediction) == len(ids) == 4
+    # row0: x,y  then row1: x,y  -> predictions in that exact order
+    assert np.allclose(prediction, [1.0, 10.0, 2.0, 20.0])
+    assert np.allclose(observation, [1.1, 10.1, 2.1, 20.1])
+
+
+def test_direct_pass_returns_none():
+    """A non-likelihood objective (analytical direct_pass) has no output/residual
+    vector, so the extractor is a no-op -- the gate that makes proposal = kalman
+    error clearly on an analytical target."""
+    sim = _data([[0.0, 1.23]], {'index': 0, 'score': 1})
+    exp = _data([[0.0, 0.0]], {'index': 0, 'score': 1})
+    out = objective.DirectPassObjective().aligned_prediction_data(
+        {'m': {'s': sim}}, {'m': {'s': exp}}, _pset())
+    assert out is None
+
+
+def test_lognormal_returns_none():
+    """A log-scale Gaussian (lognormal) has no linear-space measurement variance R,
+    so the Kalman extractor declines it (returns None) rather than mis-forming R."""
+    obj = objective.LogNormalObjective()
+    sim = _data([[0.0, 2.0], [1.0, 4.0]], {'time': 0, 'y': 1})
+    exp = _data([[0.0, 2.5, 0.5], [1.0, 3.5, 0.5]], {'time': 0, 'y': 1, 'y_SD': 2})
+    out = obj.aligned_prediction_data({'m': {'s': sim}}, {'m': {'s': exp}}, _pset())
+    assert out is None


### PR DESCRIPTION
Implements ADR-0067 Stage 3 — the `kalman` proposal (DREAM(KZS); Zhang, Vrugt et al. 2020), the last piece of unifying the DREAM family into one engine with two orthogonal axes. Closes #358 when complete.

**Draft:** landing in two commits. **3a (the output-augmented archive plumbing) is here; 3b (the Kalman proposal itself) is still TODO.**

## Done — Commit 3a: output-augmented archive plumbing (the "implied axis 2b")

The Kalman gain is built from the archive's parameter↔output cross-covariance, so each archive entry must carry the model **output vector** `f(Z)`, not just the PSet + scalar score. This lands that data plumbing, **inert by default**.

- **objective:** `LikelihoodObjective.aligned_prediction_data(sim, exp, pset)` returns the aligned `(prediction f(θ), observation d, variance σ²)` vectors, walking the same scored points in the same order as `evaluate_pointwise`. Returns `None` unless every point is an ordinary additive-error (linear-scale) Gaussian — the Kalman `R = diag(variance)` is the Gaussian measurement covariance, so a log-scale/non-Gaussian family has no `R`. Base `ObjectiveFunction` returns `None` (the `direct_pass`/non-likelihood gate).
- **dream:** a parallel `archive_outputs` list index-aligned with `archive` (initial random draws seeded `None`), the accepted state's `f(x)` cached per chain (`current_output_vec`, mirroring `current_pointwise_loglik`) at all three accept sites, appended at archive growth. All gated on `_archive_stores_outputs` (`False` for `de`/`whitened`, `True` for `kalman` in 3b), so a plain run stores only PSets exactly as before.
- **tests:** BNG-free extractor unit tests in `tests/test_kalman_dream.py` (Gaussian aligned vectors, pointwise-order alignment, `direct_pass`/`lognormal` → `None`).

Byte-identical at defaults (gate off); no regressions vs. a clean tree.

## TODO — Commit 3b: the `kalman` proposal + burn-in switch + oracle

The confirmed DREAM(KZS) algorithm and all build decisions are recorded in **ADR-0067 → *"Stage 3 — confirmed algorithm and build decisions"*** (pinned against arXiv:1707.05431 + Vrugt's DREAM-Suite `dream_kzs`):

- `DreamConfig.kalman_burnin_frac` (default 0.3, a fraction of `burn_in`) + `proposal = 'kalman'` validation.
- `_calculate_kalman_pset`: `K = C_ZY (C_YY + R)^-1` (solve, jitter for PD), current-state innovation `d − f(x_i) + ε`, paper sign, `de` fallback on a small archive, internal `M = 20` ensemble (no new user key).
- Burn-in switch in the generation builders; requires a Gaussian linear likelihood + `n_try == 1`.
- A test-only linear-Gaussian forward model `f(x) = A x` in `tests/integration_harness.py` as the closed-form posterior oracle, plus pinned-RNG gain-math unit tests.
- Docs (`config_keys.rst`), CHANGELOG, and the ADR Stage-3 status flip.
