### PR TITLE
fix(petab): import problem.yaml with column-0 YAML lists (petab1to2 output)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,6 +164,16 @@ All notable changes to PyBNF are documented below. This project adheres to
   steady-state); any method may opt into a fixed-time equilibration with the field.
 
 ### Fixed
+- **PEtab import now reads a `problem.yaml` whose table-file lists are unindented (a column-0
+  `- item`), the shape the official `petab.v2.petab1to2` converter emits (#407).** An externally
+  authored v2 problem — e.g. any `Benchmark-Models-PEtab` problem converted from v1 — imported as
+  `problem.yaml ... has no parameter_files`, because `read_problem_yaml`'s dependency-free
+  hand-rolled scan treated a column-0 list item as a new top-level key and dropped it; only the
+  two-space-indented list shape our own exporter writes was read. The section reset is now guarded
+  on `not stripped.startswith('-')`, so a column-0 `- item` appends to the current section — making
+  the reader a strict superset of both list shapes (our indented output and petab's unindented
+  output parse identically). Two regression tests cover the `petab1to2` shape and the two-shape
+  equivalence.
 - **Adaptive MCMC (`am`) with `output_trajectory` no longer crashes on edition-2 one-model +
   `condition:` jobs (`KeyError` on `<action><mutant>` suffixes) (#483).** An `am` job that saves
   posterior-predictive trajectories (`output_trajectory`) over an edition-2 model with `condition:`

--- a/pybnf/petab/import_.py
+++ b/pybnf/petab/import_.py
@@ -1095,8 +1095,10 @@ def read_problem_yaml(path):
     surfaced as ``model_file`` / ``model_id`` / ``model_language``. Dependency-free (no YAML
     library): the writer emits a flat ``key:`` + ``  - item`` list shape and a two-level
     ``model_files`` block, which a small indentation-aware scan reads exactly. The scan is
-    **order-independent**, so a real v2 ``problem.yaml`` that lists ``model_files`` first
-    (our writer emits it last) reads identically.
+    **order-independent** (a real v2 ``problem.yaml`` that lists ``model_files`` first, where
+    our writer emits it last, reads identically) **and list-indent-independent**: a
+    column-0 ``- item`` list -- YAML-legal, and what the official ``petab.v2.petab1to2``
+    converter emits -- reads the same as our own two-space-indented items.
 
     This is a pure *reader*: it records each model's ``language`` but does not enforce a
     policy on it. The supported-language scope (BNGL or SBML, ADR-0036) is enforced by the
@@ -1115,7 +1117,12 @@ def read_problem_yaml(path):
             continue
         indent = len(raw) - len(raw.lstrip())
         stripped = raw.strip()
-        if indent == 0:
+        # A column-0 list item (`- item`) is YAML-legal and is exactly what the official
+        # petab v1->v2 converter emits (`petab.v2.petab1to2`); it belongs to the *current*
+        # section, not a new key, so it must not reset the scan. Only a non-list line at
+        # column 0 opens/closes a section -- our own writer indents its list items, so
+        # honoring the unindented shape too makes the reader a strict superset of both.
+        if indent == 0 and not stripped.startswith('-'):
             section, in_model, current = None, False, None
             if stripped.endswith(':') and stripped[:-1] in files:
                 section = stripped[:-1]

--- a/tests/test_petab_import.py
+++ b/tests/test_petab_import.py
@@ -1205,6 +1205,56 @@ class TestProblemYamlReader:
         assert problem['model_file'] == DEMO_MODEL
         assert problem['condition_files'] == [] and problem['experiment_files'] == []
 
+    def test_reads_petab1to2_column0_list_shape(self, tmp_path):
+        # The official petab.v2.petab1to2 converter emits table-file lists at column 0
+        # (`- item`, YAML-legal) rather than the two-space-indented items our own writer
+        # emits. A column-0 list item must be read as belonging to the current section,
+        # not treated as a new top-level key -- the latter silently dropped every table
+        # file, so the whole problem imported as "has no parameter_files". Regression for
+        # the petab1to2 import path (an externally-authored v2 problem.yaml).
+        yaml_path = tmp_path / 'problem.yaml'
+        yaml_path.write_text(
+            'format_version: 2.0.0\n'
+            'parameter_files:\n'
+            '- parameters.tsv\n'
+            'model_files:\n'
+            '  model:\n'
+            '    location: model.xml\n'
+            '    language: sbml\n'
+            'measurement_files:\n'
+            '- measurements.tsv\n'
+            'condition_files:\n'
+            '- conditions.tsv\n'
+            'experiment_files: []\n'
+            'observable_files:\n'
+            '- observables.tsv\n'
+            'mapping_files: []\n'
+            'extensions: {}\n'
+        )
+        problem = read_problem_yaml(yaml_path)
+        assert problem['parameter_files'] == ['parameters.tsv']
+        assert problem['observable_files'] == ['observables.tsv']
+        assert problem['measurement_files'] == ['measurements.tsv']
+        assert problem['condition_files'] == ['conditions.tsv']
+        assert problem['experiment_files'] == []
+        assert problem['model_file'] == 'model.xml'
+        assert problem['model_id'] == 'model'
+        assert problem['model_language'] == 'sbml'
+
+    def test_column0_and_indented_lists_read_identically(self, tmp_path):
+        # The reader is a strict superset of both list shapes: the same problem written
+        # with column-0 (petab1to2) and two-space-indented (our writer) list items parses
+        # to the same result. Guards against a future scan change that re-honors only one.
+        head = ('format_version: 2.0.0\n'
+                'model_files:\n  m:\n    location: m.xml\n    language: sbml\n')
+        keys = ('parameter_files', 'observable_files', 'measurement_files')
+        col0 = head + ''.join(f'{k}:\n- {k[:1]}.tsv\n' for k in keys)
+        indented = head + ''.join(f'{k}:\n  - {k[:1]}.tsv\n' for k in keys)
+        (tmp_path / 'col0.yaml').write_text(col0)
+        (tmp_path / 'indented.yaml').write_text(indented)
+        assert (read_problem_yaml(tmp_path / 'col0.yaml')
+                == read_problem_yaml(tmp_path / 'indented.yaml'))
+
 
 class TestBoundaries:
 


### PR DESCRIPTION
## What

`read_problem_yaml` could not parse a `problem.yaml` whose table-file lists are written at
column 0 (`- item`) — the shape the official `petab.v2.petab1to2` converter emits. Such a
problem imported as `problem.yaml ... has no parameter_files`, even though it is valid PEtab v2.

## Why

The reader is a dependency-free, hand-rolled indentation scan tuned to the shape our own
exporter writes (two-space-indented list items). At column 0 it reset the current section and
tried to read the line as a new top-level key, so a column-0 `- item` was silently dropped and
every table-file list came back empty.

## Fix

Guard the section reset on `not stripped.startswith('-')`, so a column-0 list item is appended
to the current section instead of resetting the scan. The reader is now a strict superset of
both list shapes — our indented output and petab's unindented output parse identically. One-line
behavior change; the exporter round-trip is unaffected.

## Tests

Two regression tests in `TestProblemYamlReader` (both fail on the pre-fix reader with
`PybnfError: ... has no parameter_files`):

- `test_reads_petab1to2_column0_list_shape` — reads the exact `petab1to2` column-0 `problem.yaml`.
- `test_column0_and_indented_lists_read_identically` — the two list shapes parse to the same result.

Full `tests/test_petab_import.py` suite passes (`BNGPATH` set).

## Context

Found while importing externally-authored PEtab v2 problems (converted from v1 with `petab1to2`);
a prerequisite for importing the `Benchmark-Models-PEtab` collection. Encountered on the repro
path for #482.
