### PR TITLE
ci: give the recovery tier a home in integration.yml; restore Boehm to per-push

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,14 +1,18 @@
 name: integration
 
-# Manual only. The slow tier is the 4 statistical-recovery tests against
-# analytical targets (AnalyticalModel) -- bngsim-free and BNG2.pl-free, ~8 min.
+# The home for the test tiers too slow for the per-push gate. Two jobs:
+#
+#   slow     -- the 4 statistical-recovery tests against analytical targets
+#               (AnalyticalModel), bngsim-free and BNG2.pl-free, ~8 min. Runs
+#               nightly AND on manual dispatch.
+#   recovery -- the `recovery` tier: ~130 real parameter-recovery fits through
+#               the bngsim backend (over an hour on a dev machine, unmeasured on
+#               a 2-core hosted runner). DISPATCH-ONLY for now (see the job's
+#               `if:`), so it can be sized and given a flake policy before it
+#               goes on the nightly schedule (#517).
 #
 # NOTE: the fast bngsim *simulation* suites (true NFsim/RuleMonkey/SBML runs)
-# DO run in hosted CI -- tests.yml installs bngsim from public PyPI (#514). Not
-# covered anywhere hosted yet: the `recovery` tier (real parameter-recovery fits
-# through the backend, over an hour), which still runs on a dev machine.
-#
-# Runs nightly and on manual dispatch.
+# DO run in hosted CI -- tests.yml installs bngsim from public PyPI (#514).
 on:
   workflow_dispatch:
   schedule:
@@ -36,3 +40,39 @@ jobs:
         env:
           PYBNF_NO_BNGSIM: '1'
         run: uv run --no-sync pytest -m slow -n auto
+
+  recovery:
+    runs-on: ubuntu-latest
+    name: recovery tier (bngsim fits)
+    # Dispatch-only for now, NOT on the nightly cron. The `slow` job above runs
+    # on both triggers; this one is gated to manual dispatch so a maintainer can
+    # run it once to measure the wall-clock on a 2-core runner (over an hour on a
+    # dev machine) and decide a flake policy for these stochastic fits BEFORE it
+    # is committed to a schedule -- an unmeasured hour-plus job that reds nightly
+    # for tolerance reasons gets ignored, which is worse than not having it
+    # (#517). To put it on the 08:00 nightly, delete this `if:` (the `on:` block
+    # already schedules the workflow); to make it non-blocking instead, add
+    # `continue-on-error: true` here.
+    if: github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ./.github/actions/setup-pybnf
+        with:
+          python-version: '3.12'
+          # The whole point of this tier: real fits through the simulation
+          # backend, so bngsim must be present (and PYBNF_NO_BNGSIM stays unset).
+          bngsim: 'true'
+          # Also a 3.12 setup-pybnf run; give it its own uv-cache namespace so it
+          # does not race the `slow` job's save on a dispatch (both run then).
+          cache-suffix: pybnf-recovery
+
+      - name: Run the recovery tier
+        # -m recovery: the ~130 synthetic-data parameter-recovery fits through
+        # the backend (test_recovery.py, the tutorial suites, profile-likelihood,
+        # the gradient/SBML fits, ...). -n auto parallelizes across the runner's
+        # cores -- fewer here than on a dev box, so expect this to be the slow leg.
+        #
+        # --no-sync: the composite action already populated .venv; do not let
+        # `uv run` re-resolve it from pyproject.toml.
+        run: uv run --no-sync pytest -m recovery -n auto

--- a/tests/test_petab_sbml_layer.py
+++ b/tests/test_petab_sbml_layer.py
@@ -799,15 +799,21 @@ class TestDualBackendLayer:
 
 
 # ---------------------------------------------------------------------------
-# 5. The real-world Boehm problem reproduces its published data (-m recovery)
+# 5. The real-world Boehm problem reproduces its published data
 #
 # The crafted decay model above isolates the layer with an analytic oracle; this closes
 # the loop on the HEADLINE milestone -- the externally-authored Boehm v2 problem imported
 # end to end (ADR-0037). Simulated at the published optimum (the SBML's embedded parameter
 # values) on RoadRunner, the imported measurement layer's materialized observable columns
 # track the published measurement table (the fit IS the optimum), and agree across
-# RoadRunner and bngsim. Opt-in (-m recovery): a real stiff-ODE simulation of the full
-# model, not a unit-scale crafted one.
+# RoadRunner and bngsim.
+#
+# Tier split (mirrors the module docstring's rule): the RoadRunner leg is a core-dependency
+# path and runs in the DEFAULT tier (~3s -- a real stiff-ODE sim of the full model, but a
+# single one, cheap enough for the per-push gate), so it is unmarked. The bngsim cross-check
+# is the expensive one and stays opt-in (-m recovery + @pytest.mark.bngsim). Keeping the
+# RoadRunner leg in the default tier is what restores the one end-to-end real-backend signal
+# that #515 dropped from per-push CI (#517).
 # ---------------------------------------------------------------------------
 
 _BOEHM_DIR = Path(__file__).resolve().parent / 'petab_fixtures' / 'boehm_v2'
@@ -851,7 +857,6 @@ def _simulate_boehm(model_cls, out_dir):
     return ds[next(iter(ds))]
 
 
-@pytest.mark.recovery
 class TestBoehmRecovery:
 
     def test_roadrunner_reproduces_published_data(self, tmp_path):
@@ -866,6 +871,7 @@ class TestBoehmRecovery:
             assert np.corrcoef(pred, y)[0, 1] > 0.9
             assert np.sqrt(np.mean((pred - y) ** 2)) < 0.15 * (y.max() - y.min())
 
+    @pytest.mark.recovery
     @pytest.mark.bngsim
     def test_layer_agrees_across_roadrunner_and_bngsim_on_boehm(self, tmp_path):
         """Neither backend exposes Boehm's computed observables; the measurement layer


### PR DESCRIPTION
Closes #517.

The `recovery` tier — ~130 real parameter-recovery fits through the bngsim backend, over an hour — had no automated home: deselected from per-push CI (#515), absent from the pre-push hook (deliberately, a multi-minute hook gets the push reaped), and not part of `integration.yml`'s nightly `slow` job (that's the 4 analytical statistical tests, `bngsim: 'false'`). So the fitting loop's only end-to-end verification against a real engine happened when a maintainer typed `pytest -m recovery` by hand.

## Changes

**1. `integration.yml` — new `recovery` job.**
`setup-pybnf` with `bngsim: 'true'`, running `pytest -m recovery -n auto`, with its own `cache-suffix: pybnf-recovery` so it doesn't race the `slow` job's uv-cache save on a dispatch.

It is **dispatch-only for now** (`if: github.event_name == 'workflow_dispatch'`) — deliberately off the nightly cron. The two open questions from the issue are exactly what a first dispatch answers:

1. **Runtime is unmeasured** on a 2-core hosted runner (over an hour on a dev box, and `-n auto` buys less there).
2. **Flake policy** — these are stochastic fits with recovery tolerances; a nightly that reds every third run for tolerance reasons gets ignored, which is worse than not having it.

Escalating once it's sized is a one-liner, documented on the job: delete the `if:` to put it on the 08:00 nightly (the `on:` block already schedules the workflow), or add `continue-on-error: true` to make it non-blocking.

**2. `test_petab_sbml_layer.py` — fix the small live regression.**
`TestBoehmRecovery::test_roadrunner_reproduces_published_data` is roadrunner-backed (bngsim-free, ~3s) but was `recovery`-marked at the class level, so after #515 it ran nowhere automatic — it was the one recovery test actually running in CI before #515. Moved the class-level `recovery` marker down onto just the bngsim cross-check:

- `test_roadrunner_reproduces_published_data` → **default per-push tier** (restores the end-to-end real-backend signal #515 dropped)
- `test_layer_agrees_across_roadrunner_and_bngsim_on_boehm` → keeps `@pytest.mark.recovery @pytest.mark.bngsim`

This also aligns the code with the module docstring's own stated rule ("RoadRunner legs run in the normal tier; the bngsim leg is gated `-m recovery`"), which the class-level marker had contradicted.

## Verification (local)

- `integration.yml` parses as valid YAML.
- Marker split confirmed by collection: default tier picks up the roadrunner test, `-m recovery` picks up the bngsim one; recovery collection 128 → 127.
- Restored test **passes** in the default tier (~2.5s); full default tier of the file: 21 passed / 2 deselected.
- `ruff@0.15.14 check` passes.