### PR TITLE
ci: install jax on the recovery job so the gradient-path fits run

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -63,6 +63,15 @@ jobs:
           # The whole point of this tier: real fits through the simulation
           # backend, so bngsim must be present (and PYBNF_NO_BNGSIM stays unset).
           bngsim: 'true'
+          # The recovery tier includes gradient-path fits (test_gradient_*,
+          # and the Rijal-2025 real-world cases in test_real_world_examples.py)
+          # whose LOG-SCALED parameters route the gradient into sampling space
+          # via jax -- without the extra those tests raise PybnfError rather than
+          # skip, so a recovery run without jax fails deterministically (2 hard
+          # failures the first dispatch, #517). A complete recovery environment
+          # provisions jax; install it here (as the pytest-jax job in tests.yml
+          # does for the same gradient path).
+          jax: 'true'
           # Also a 3.12 setup-pybnf run; give it its own uv-cache namespace so it
           # does not race the `slow` job's save on a dispatch (both run then).
           cache-suffix: pybnf-recovery


### PR DESCRIPTION
Follow-up to #518 / #517.

The recovery job added in #518 was dispatched for the first time to size it (the point of shipping it dispatch-only). It came back **`failure` at ~11.7 min: 125 passed, 2 failed** — and the two failures were a config gap in the job, not a stochastic tolerance flake:

```
FAILED tests/test_real_world_examples.py::test_real_world_runs_through_bngsim[Rijal-2025/lacud5_ode]
FAILED tests/test_real_world_examples.py::test_real_world_runs_through_bngsim[Rijal-2025/five_dl1_ode]
  PybnfError: Gradient assembly needs jax to transform a log-scaled parameter's
  gradient into sampling space ... the optional 'jax' extra.
```

Those two real-world cases fit **log-scaled** parameters through jax-backed gradient assembly, and they *raise* rather than skip when jax is absent. The recovery job was built with `setup-pybnf`'s default `jax: 'false'`, so it failed deterministically — it will fail identically every run until jax is installed.

## Fix

Add `jax: 'true'` to the recovery job — exactly as `tests.yml`'s `pytest-jax` job already does for the same gradient path. A complete recovery environment provisions jax.

## Verification

- The two previously-failing cases pass locally in ~15s with jax present.
- Full end-to-end confirmation: this branch was dispatched via `workflow_dispatch` on the branch ref to confirm the whole recovery tier goes green under jax before merge. (Result linked in comments.)

## Sizing takeaways from the first dispatch (context for #517)

- **Recovery tier ≈ 12 min** on a 2-core runner — the ">1 hr" concern was a dev-machine artifact; it's comfortably schedulable.
- **Zero stochastic tolerance flakes** this run — the only failures were the deterministic jax gap fixed here.
- Side observation: the pre-existing `slow` job ran **32 min**, vs the ~8 min its comment claims. Not touched here; flagged for a possible follow-up.