### PR TITLE
ci: correct stale runtime figures in the integration.yml header

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -3,7 +3,7 @@ name: integration
 # The home for the test tiers too slow for the per-push gate. Two jobs:
 #
 #   slow     -- the 4 statistical-recovery tests against analytical targets
-#               (AnalyticalModel), bngsim-free and BNG2.pl-free, ~8 min. Runs
+#               (AnalyticalModel), bngsim-free and BNG2.pl-free, ~32 min. Runs
 #               nightly AND on manual dispatch.
 #   recovery -- the `recovery` tier: ~130 real parameter-recovery fits through
 #               the bngsim backend (over an hour on a dev machine, unmeasured on

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -6,10 +6,10 @@ name: integration
 #               (AnalyticalModel), bngsim-free and BNG2.pl-free, ~32 min. Runs
 #               nightly AND on manual dispatch.
 #   recovery -- the `recovery` tier: ~130 real parameter-recovery fits through
-#               the bngsim backend (over an hour on a dev machine, unmeasured on
-#               a 2-core hosted runner). DISPATCH-ONLY for now (see the job's
-#               `if:`), so it can be sized and given a flake policy before it
-#               goes on the nightly schedule (#517).
+#               the bngsim backend (over an hour on a dev machine, but ~12 min on
+#               a 2-core hosted runner, #517). DISPATCH-ONLY for now (see the
+#               job's `if:`), so a flake policy can be settled before it goes on
+#               the nightly schedule.
 #
 # NOTE: the fast bngsim *simulation* suites (true NFsim/RuleMonkey/SBML runs)
 # DO run in hosted CI -- tests.yml installs bngsim from public PyPI (#514).


### PR DESCRIPTION
Comment-only, no behavior change. The `integration.yml` header carried two stale runtime figures that the #517 sizing dispatch corrected:

- **`slow` job:** claimed ~8 min; actually ~32 min (the historical nightly runs, which ran only this job before #518, corroborate ~32–36 min).
- **`recovery` job:** said "unmeasured on a 2-core hosted runner"; the dispatch clocked it at ~11.5 min.

Follow-up to #517.