### PR TITLE
fix(gradient): declare the seed row for a species dose written before the first phase (#538, ADR-0101)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ All notable changes to PyBNF are documented below. This project adheres to
 ## [Unreleased]
 
 ### Fixed
+- **A pre-equilibration condition that doses a species from a fitted parameter no longer reports a
+  zero gradient column for it (#538, ADR-0101).** `preequilibrate:` applies its condition inline,
+  so a species target becomes a `setConcentration` written *before* the first phase — and
+  `Model.set_concentration` reads an assigned amount as a literal initial condition
+  (`∂x_k(0)/∂θ = 0`), retiring whatever seeding the species' `.net` expression carried
+  (lanl/bngsim#113). ADR-0098 supplies that row for a write between two phases; with nothing
+  pending it had nothing to rebuild and left the write to the backend, so an amount like
+  `"A()" = 2*k_deg` contributed **exactly zero** to `k_deg`'s derivative. Nothing failed and no
+  refusal fired: the fit simply walked a wrong steepest direction to a plausible answer. PyBNF now
+  *declares* the assignment's own `∂x_k(0)/∂θ` (`Model.declare_ic_sensitivity`, the API bngsim
+  documents for a hand-assigned θ-dependent initial condition), so bngsim's own seeding starts from
+  it — narrowly, only when a fitted parameter reaches the amount, so every protocol whose gradient
+  was already right reaches the backend through the same calls as before. An `addConcentration`
+  re-declares the row its constant shift left alone. Visible only with a **fixed-duration**
+  equilibration (`equil_t_end:`, what the preincubate → wash → dose-scan protocols use); a
+  steady-state equilibration relaxes the dose away, so the derivative is genuinely zero there.
+  Also new: an intervention amount that reads a fitted parameter **no** requested
+  forward-sensitivity column carries is now refused by name, on both this path and the
+  mid-protocol one, rather than silently contributing a zero row.
 - **A pre-equilibrated dose-response experiment can now be fit by a gradient method (#532,
   ADR-0098).** The preincubate → wash → dose-scan protocol (`preequilibrate:` + `condition:` +
   `type: parameter_scan`) refused every scored gradient evaluation, and the refusal landed at

--- a/docs/adr/0098-a-mid-protocol-intervention-supplies-the-seed-row-bngsim-declines-to-guess-so-a-pre-equilibrated-dose-response-scan-is-differentiable.md
+++ b/docs/adr/0098-a-mid-protocol-intervention-supplies-the-seed-row-bngsim-declines-to-guess-so-a-pre-equilibrated-dose-response-scan-is-differentiable.md
@@ -121,6 +121,14 @@ state, not a symbol a seed derivative reads"), and `Configuration._preequilibrat
 already refuses a parameter-valued perturbation inline in a pre-equilibration phase, so no such
 protocol reaches this code.
 
+> **Superseded by ADR-0101 (#538).** That last sentence is false. `_build_condition_mutation`
+> routes a target containing `(` to a species perturbation *before* the parameter-reference branch,
+> so a BNGL species-pattern condition is never `is_param_ref` and the pre-equilibration refusal
+> never sees it; the amount is emitted quoted, and such a protocol does reach this code. It reaches
+> it at the *other* end, though — as the `preequilibrate:` phase's own write, with nothing pending
+> — which the capture below reads as "no derivative to preserve" and leaves to bngsim, whose
+> reading of an assigned amount is a literal zero. ADR-0101 declares that row instead.
+
 ## Verification
 
 - **Closed-form oracle.** `e2e_ode_preequil_scan.net` equilibrates `A` to `k_prod/k_deg`, washes

--- a/docs/adr/0101-a-species-dose-written-before-the-first-phase-declares-its-own-seed-row-so-a-pre-equilibration-conditions-fitted-amount-is-not-a-silently-zero-gradient-column.md
+++ b/docs/adr/0101-a-species-dose-written-before-the-first-phase-declares-its-own-seed-row-so-a-pre-equilibration-conditions-fitted-amount-is-not-a-silently-zero-gradient-column.md
@@ -1,0 +1,155 @@
+# A species dose written before the first phase declares its own seed row, so a pre-equilibration condition's fitted amount is not a silently zero gradient column (issue #538)
+
+**Status: Accepted and implemented (2026-08-04).** ADR-0098 gave a mid-protocol species write the
+`∂x_k(0)/∂θ` row bngsim declines to guess — but only where a carried `dx/dθ` was pending. A write
+with *nothing* pending was read as a write with no derivative to preserve. It is not: what it
+supersedes there is the seeding bngsim derives from the `.net`'s own initial-condition expression,
+which `set_concentration` retires as well. So a dose written over a fitted parameter **before** the
+first phase lost its whole gradient column, and the write that does exactly that is a
+`preequilibrate:` condition with a species target.
+
+## The problem
+
+`e2e_ode_preequil_scan.net`, `k_deg` fitted, the dose written over it and nothing else changed:
+
+```
+setConcentration("A()","2*k_deg")     # ← the equilibration-phase perturbation
+simulate(t_end=0.5, suffix=>"pre")    # a FIXED-duration equilibration
+simulate(t_end=1,   suffix=>"relax")  # the measured phase
+```
+
+`A(T) = 2·k_deg·exp(-k_deg·T)` with `T = 1.5`, so `dA/dk_deg = 2·exp(-k_deg·T)·(1 - k_deg·T)`
+= **-0.199**. The backend reported **0.000**.
+
+`Model.set_concentration` documents the reading: an assigned amount is a *literal* initial
+condition, `∂x_k(0)/∂θ = 0`, and it therefore retires whatever parameter-graph seeding the species'
+`.net` expression carried (lanl/bngsim#113). That is right for the wash and the fixed bolus every
+#474 protocol opens with, and wrong for an amount a fitted parameter reaches — and there is nothing
+pending to rebuild, so ADR-0098's capture/restore pair was a no-op over it.
+
+Two things kept this out of sight:
+
+* **A steady-state equilibration relaxes the dose away.** The value *and* the derivative are then
+  genuinely insensitive to it, so nothing looks wrong. The defect is visible only when the
+  equilibration runs for a fixed duration — `equil_t_end:`, which is what the #474
+  preincubate → wash → dose-scan protocols use, and what NFsim requires.
+* **The column is zero, not absent.** No simulation fails, no objective moves, no refusal fires.
+  A `trf` fit walks a surface whose steepest direction is wrong and converges to a plausible
+  answer.
+
+### What #538 assumed, and what is actually there
+
+The issue filed this as *latent*, unreachable behind two guards. It is neither, and the guards do
+not stand where it places them:
+
+* `Configuration._build_condition_mutation` routes a target containing `(` — every BNGL species
+  pattern — to a **species** perturbation and returns before the parameter-reference branch. A
+  species-target condition is therefore never `is_param_ref`, so
+  `Configuration._preequilibration_perturbations`' refusal of a parameter-valued perturbation
+  ("guard 1") never sees one, and `BNGLModel._preequilibration_perturbation_line` already emits the
+  amount **quoted** (`setConcentration("A()","2*k_deg")`) rather than as a bare number. The
+  provenance the issue asks to preserve was already preserved; `float(value)` does not succeed on
+  an identifier.
+* The routing change the issue proposes would have been wrong here. A mid-protocol dose reaches the
+  trajectory through the **parameter** axis — the seed row, ADR-0098 — not through an
+  initial-condition axis. Adding an `IC` contribution for the same parameter would double the
+  column where the parameter axis already carries it (ADR-0100), and bngsim refuses
+  `sensitivity_ic` across a pre-equilibration boundary outright ("the carried state is no longer
+  the model's initial condition", GH #210), so the request would abort the fit. `pybnf.gradient`
+  is unchanged by this ADR.
+
+What *is* real is the third bullet of the issue's own diagnosis: a zero `∂x_k(0)/∂θ` row reached
+silently. It is reached one phase earlier than the ticket looked.
+
+## The decision
+
+**A species write with nothing pending declares its row instead of re-installing a matrix.**
+`Model.declare_ic_sensitivity` is the API bngsim added for precisely this case (lanl/bngsim#111):
+*"an initial condition assigned by hand is no longer described by the `.net` expression the
+parameter-graph seeding differentiates, so for a hand-assigned θ-dependent IC this declaration is
+the only way the engine can know `∂x_k(0)/∂θ`"*, and it is honoured by a plain `Simulator.run`, not
+only by a scan's `on_point` hook. bngsim's own seeding then starts the run from the declared row,
+so nothing about the run's carried-state arm changes — a fresh phase stays fresh, and
+`sensitivity_ic` keeps working where it worked before.
+
+The row is the same table ADR-0098 established, read at the other end of the protocol:
+
+| the write | its declared `∂x_k(0)/∂θ` |
+| --- | --- |
+| a literal amount (`setConcentration("P()",0)`) | **nothing declared** — bngsim's own reading is already `0` |
+| an amount no fitted parameter reaches | **nothing declared** — same |
+| arithmetic over model parameters (`"2*k_deg"`, `"bolus"`) | `d(expr)/dθ`, with the `.net`'s derived ids inlined first |
+| a constant shift (`addConcentration`) | the row the shift left alone, re-declared |
+| anything outside the arithmetic grammar | **refused** — a guessed row multiplies every later phase |
+
+**Declaring is deliberately narrow.** Every #474 protocol opens with literal writes, which are
+fresh-start writes too; declaring an all-zero row for them would say exactly what bngsim already
+says. So the declaration fires only when a fitted parameter reaches the amount, and every protocol
+whose gradient was right before this reaches the backend through the same calls it did before.
+
+**An amount that reads a fitted parameter no column carries is refused, not zeroed.**
+`_intervention_seed_row` answers such an amount with a clean zero row — it has no column to put the
+derivative in — and that zero is indistinguishable, to any objective, from a parameter the
+trajectory does not depend on. It is the one wrong answer this whole seam exists to avoid, so the
+parameter is named and the fit stops. This guards the carried path (ADR-0098) as well as the new
+one; both now build their row through `_intervention_row`.
+
+## Scope
+
+**In:** `BngsimModel._capture_own_sensitivity_row`, `._declare_fresh_start_sensitivity_row`,
+`._intervention_row`, `._refuse_unrouted_intervention_reads`; the `carried is None` arm of
+`._restore_carried_sensitivity_seed`; the `setConcentration` / `addConcentration` arms of
+`._execute_actions`.
+
+**Out (unchanged):** the scalar path — no request means no capture, no declaration, and the same
+backend calls as before. `pybnf.gradient.routing` and the assembly, which consume the parameter
+axis exactly as they did. The carried mid-protocol write (ADR-0098), apart from gaining the
+unrouted-parameter refusal. `_run_protocol`, the per-point protocol replay, which handles no seed
+row at either end.
+
+**Still out:** a species amount naming a free parameter that binds **no** model parameter — the
+per-condition estimated initial condition of ADR-0076 applied to a species. A mid-protocol write
+reaches the fit only through a parameter axis, and a fit-vector-only parameter has none, so there
+is no column to declare into. It is refused today by the edition-2 correspondence check ("Free
+parameter(s) match no model parameter"), which is a refusal with the wrong diagnosis rather than a
+silent wrong; giving it a route means giving the parameter a column, which is a larger change than
+this one.
+
+## Verification
+
+- **Closed-form oracle** (`e2e_ode_preequil_scan.net`, the #532 fixture). `P` is never loaded, so
+  nothing produces `A` and the dose decays at `k_deg + washout` through a fixed-duration
+  equilibration into the measured phase. Dosing `A` to `2*k_deg` — directly, and through the
+  `.net`'s derived `bolus = 2*k_deg`, which must be inlined before differentiating — matches
+  `2·exp(-k_deg·T)·(1 - k_deg·T)` to `rtol=1e-4`, where the backend alone returns exactly `0`.
+  A following `addConcentration("A()",1)` shifts the amount without replacing it: the truth is
+  `exp(-k_deg·T)·(2 - (2·k_deg+1)·T) = -0.274`, and re-declaring is what keeps the `2` term —
+  without it the reported value is `-0.373`.
+- **FD oracle on the assembled column.** `k_deg` sets the dose *and* the decay rate; `washout` only
+  decays. Central differences of PyBNF's own `loss(u)` agree with the assembled gradient to
+  `rtol=1e-4` on both columns. Before, the two columns came out **identical** (838.46 against a
+  true 323.76 for `k_deg`, a 159% error) — because without the dose term `k_deg` reaches the
+  trajectory only as a decay rate, exactly as `washout` does. The `washout` column was right the
+  whole time, which is what makes the failure a plausible wrong direction rather than a visibly
+  broken one.
+- **Narrowness.** A protocol whose fresh-start writes are all literal (the load, the wash) emits no
+  declaration at all, and its measured phase still meets the ADR-0098 oracle.
+- **Config layer.** A `preequilibrate:` condition with a species target emits
+  `setConcentration("A()","2*k_deg")` between the `resetConcentrations()` and the equilibration,
+  with a fixed-duration equilibration — the exact sequence the oracle above runs.
+- Full default suite green (3582 passed, 20 skipped); recovery tier green apart from two
+  environmental failures (`antimony` absent) that predate the change.
+
+## Consequences
+
+- A pre-equilibration experiment whose `preequilibrate:` condition doses a species from a fitted
+  parameter is differentiable. Before, its fitted parameter's column silently lost the dose half of
+  its derivative — the whole of it when the parameter reaches the trajectory only that way.
+- One new refusal: an intervention amount that reads a fitted parameter no requested
+  forward-sensitivity column carries. It names the parameter. No fit that was producing a correct
+  gradient can meet it.
+- ADR-0098's "Deliberately still out" paragraph is superseded: it rested on the same reading of
+  `_build_condition_mutation` that #538 filed, and the shape it called unreachable was reachable.
+- See ADR-0098 (#532, the carried seed row), ADR-0062 (#474, the protocol), ADR-0095 (#530, the
+  derivative grammar), ADR-0100 (#537, why the parameter axis already carries a seeding).
+  Closes #538.

--- a/docs/gradient_fitting.rst
+++ b/docs/gradient_fitting.rst
@@ -572,6 +572,17 @@ hint. Scanning a parameter the fit is *differentiating* is refused — the carri
 taken at the pre-scan value while each dose pins the same symbol — so scan the dose/condition
 parameter the data sweeps.
 
+The **pre-equilibration condition's own** species perturbation (a ``preequilibrate:`` condition
+with a species target) is the same assignment written one phase earlier, before anything has run,
+and it is differentiated the same way: PyBNF declares the assignment's
+:math:`\partial x_k(0)/\partial\theta` to the backend so the run is seeded from it (ADR-0101). This
+matters only for a **fixed-duration** equilibration (``equil_t_end:``) — a steady-state
+equilibration relaxes the assigned amount away, so the measured phase genuinely does not depend on
+it. In both positions, an amount that reads a fitted parameter which no requested sensitivity
+column carries is refused by name rather than contributing a zero row: write such a dose over model
+parameters the fit varies (``"A()" = 2*k_deg``, or through a derived id), not over a free parameter
+that binds no model parameter.
+
 
 Discrete events
 ---------------

--- a/pybnf/bngsim_model/net_model.py
+++ b/pybnf/bngsim_model/net_model.py
@@ -43,6 +43,7 @@ from .expressions import (
     _parse_net_rhs_symbols,
     _net_param_definitions,
     _net_species_ic_seed_map,
+    _intervention_expression_reads,
     _intervention_seed_row,
     _model_param_values,
 )
@@ -498,13 +499,27 @@ class BngsimModel(NetModel):
     # contract ``set_pending_sensitivity_seed`` documents ("a protocol primitive that restores a
     # species state TOGETHER WITH its θ-derivative"), and the same row-by-row reading bngsim
     # itself applies to a scan's ``on_point`` hook (lanl/bngsim#111).
+    #
+    # A write with NOTHING pending is the other half (#538). It is not a case with no derivative
+    # to preserve -- it is a write whose species has not been advanced yet, so its ``∂x_k(0)/∂θ``
+    # is the one bngsim derives from the .net's own initial-condition expression, and
+    # ``set_concentration`` retires that row too (lanl/bngsim#113: an assigned amount is no longer
+    # described by the expression it superseded). So an amount written over a *fitted* parameter --
+    # the equilibration-phase perturbation of a pre-equilibration protocol, ``"A()" = 2*k_deg`` --
+    # loses its whole column. There is no matrix to re-install there; the row is *declared* instead
+    # (``Model.declare_ic_sensitivity``, the API lanl/bngsim#111 documents for exactly this:
+    # "for a hand-assigned θ-dependent IC this declaration is the only way the engine can know
+    # ∂x_k(0)/∂θ"). bngsim's own seeding then starts the run from it, so nothing about the run's
+    # carried-state arm changes -- a fresh phase stays fresh.
 
     def _capture_carried_sensitivity_seed(self, model):
         """The pending carry-over ``∂x/∂θ`` and its column names, or ``None``.
 
-        ``None`` on the scalar path and whenever nothing is pending (no equilibration has run
-        yet, so a write has no derivative to preserve), which makes the restore below a no-op
-        and leaves the scalar path byte-identical.
+        ``None`` on the scalar path and whenever nothing is pending -- no phase has run since
+        the last reset, so the species state is still the model's own initial condition and
+        what the write supersedes is a *declared* row, not a carried matrix
+        (:meth:`_declare_fresh_start_sensitivity_row`). ``None`` leaves the scalar path
+        byte-identical.
         """
         if self._sensitivity_request is None:
             return None
@@ -514,7 +529,28 @@ class BngsimModel(NetModel):
         return (np.array(core.pending_sensitivity_seed(), dtype=float),
                 list(core.pending_sensitivity_seed_param_names))
 
-    def _restore_carried_sensitivity_seed(self, model, carried, species_name, expr):
+    def _capture_own_sensitivity_row(self, species_name, carried):
+        """``{param: ∂x_k(0)/∂θ}`` the backend seeds ``species_name`` with, or ``None`` (#538).
+
+        Read BEFORE a species write at a fresh start (``carried is None``), where the write
+        supersedes the parameter-graph row bngsim derives from the .net expression rather than a
+        carried matrix. Only an ``addConcentration`` -- a constant shift, which leaves ``d/dθ``
+        alone -- needs the old row back; a ``setConcentration`` replaces it outright.
+
+        ``None`` -- nothing to declare -- on the scalar path, on a carried write (which rebuilds
+        the pending matrix instead), and when no parameter axis is requested, so every such
+        protocol keeps bngsim's own reading unchanged. An empty mapping is the different answer
+        "the backend seeds this species from nothing"; it still enables the ``setConcentration``
+        arm, which does not read the old row.
+        """
+        if carried is not None or self._sensitivity_request is None:
+            return None
+        if not (self._sensitivity_request.params or ()):
+            return None
+        return dict((self.backend_ic_sensitivity() or {}).get(species_name) or {})
+
+    def _restore_carried_sensitivity_seed(self, model, carried, species_name, expr,
+                                          own_row=None):
         """Re-install a captured ``∂x/∂θ`` after writing ``species_name``, with its row rebuilt.
 
         ``expr`` is the assignment's source text, whose derivative becomes the species' new seed
@@ -524,12 +560,16 @@ class BngsimModel(NetModel):
         shifted it by a constant (``addConcentration``), whose derivative is the carried row
         unchanged. Every other species keeps the equilibration's row.
 
+        With nothing carried, the same row is *declared* on the model instead (#538) -- see
+        :meth:`_declare_fresh_start_sensitivity_row`.
+
         Refuses when the assignment cannot be differentiated, or when the written species is not
         one the engine names -- a seed row that is guessed rather than known is a silently wrong
         gradient, and this one multiplies the whole measured phase.
         """
         if carried is None:
-            return
+            return self._declare_fresh_start_sensitivity_row(
+                model, species_name, expr, own_row)
         seed, names = carried
         seed = seed.copy()
         if expr is not None:
@@ -541,22 +581,93 @@ class BngsimModel(NetModel):
                     "engine does not name, so its forward-sensitivity seed row cannot be placed. "
                     "Run a gradient-free fit for this protocol."
                     % (self.name, species_name)) from None
-            try:
-                seed[index, :] = _intervention_seed_row(
-                    expr, names, self._net_param_definitions,
-                    _model_param_values(model))
-            except NotDifferentiable as exc:
-                raise PybnfError(
-                    "Model %s: the intervention setConcentration(%r, %r) between the "
-                    "pre-equilibration and the measured phase cannot be differentiated (%s), so "
-                    "the initial condition it assigns has no known d/dtheta. Write the "
-                    "intervention amount as arithmetic over model parameters, or run a "
-                    "gradient-free fit." % (self.name, species_name, expr, exc)) from exc
+            seed[index, :] = self._intervention_row(species_name, expr, names,
+                                                    _model_param_values(model))
         core = model._core
         core.set_pending_sensitivity_seed(seed, names)
         # The state the next phase starts from is a θ-dependent snapshot, not a fresh initial
         # condition, so keep bngsim's carry-over arm engaged (the write cleared it).
         core.ic_state_dirty = True
+
+    def _declare_fresh_start_sensitivity_row(self, model, species_name, expr, own_row):
+        """Declare ``∂x_k(0)/∂θ`` for a species written before any phase has run (#538).
+
+        The fresh-start twin of the carried-seed rebuild above. ``set_concentration`` retires the
+        species' parameter-graph seed row (lanl/bngsim#113), which is right for the literal amount
+        it documents and wrong for an amount written over a fitted parameter -- the equilibration
+        perturbation of a pre-equilibration protocol (``preequilibrate:`` with a species target)
+        is exactly that write, and a fixed-duration equilibration carries its effect straight into
+        the measured phase. Left alone the fitted parameter's whole column comes back **zero**,
+        which no objective can detect.
+
+        Declaring is deliberately narrow: an all-zero row says exactly what bngsim already says,
+        so a θ-independent amount is left alone, and an ``addConcentration`` (``expr is None``)
+        re-declares the row its constant shift left untouched only when there is a non-trivial one
+        to restore. Every protocol whose gradient is right today therefore emits no declaration at
+        all -- which is what the returned row (``None`` when nothing was declared) lets a test
+        state. The refusals are *not* narrowed with it: they are decided inside
+        :meth:`_intervention_row`, before the row's values are known.
+        """
+        if own_row is None:
+            return None
+        targets = list(self._sensitivity_request.params or ())
+        if expr is None:
+            row = {name: value for name, value in own_row.items() if name in targets}
+        else:
+            row = dict(zip(targets, self._intervention_row(
+                species_name, expr, targets, _model_param_values(model))))
+        if not any(row.values()):
+            return None
+        try:
+            model.declare_ic_sensitivity({species_name: row})
+        except Exception as exc:
+            raise PybnfError(
+                "Model %s: the intervention setConcentration(%r, %r) assigns an initial "
+                "condition that depends on a fitted parameter, but its forward-sensitivity row "
+                "could not be declared to the backend (%s), so that parameter's gradient column "
+                "would be silently zero. Run a gradient-free fit for this protocol."
+                % (self.name, species_name, expr, exc)) from exc
+        return row
+
+    def _intervention_row(self, species_name, expr, targets, param_values):
+        """``[d(expr)/d(target)]`` for one intervention amount, refusing rather than guessing.
+
+        Wraps :func:`_intervention_seed_row` with the two refusals a guessed row would hide: an
+        amount outside the arithmetic grammar, and an amount that reads a parameter this fit
+        varies which no requested sensitivity column carries (#538).
+        """
+        self._refuse_unrouted_intervention_reads(species_name, expr, targets)
+        try:
+            return _intervention_seed_row(expr, targets, self._net_param_definitions,
+                                          param_values)
+        except NotDifferentiable as exc:
+            raise PybnfError(
+                "Model %s: the intervention setConcentration(%r, %r) between the "
+                "pre-equilibration and the measured phase cannot be differentiated (%s), so "
+                "the initial condition it assigns has no known d/dtheta. Write the "
+                "intervention amount as arithmetic over model parameters, or run a "
+                "gradient-free fit." % (self.name, species_name, expr, exc)) from exc
+
+    def _refuse_unrouted_intervention_reads(self, species_name, expr, targets):
+        """Refuse an intervention amount that reads a fitted parameter no column carries (#538).
+
+        :func:`_intervention_seed_row` answers such an amount with a clean zero row -- it has no
+        column to put the derivative in -- and that zero is indistinguishable, to any objective,
+        from a parameter the trajectory genuinely does not depend on. It is the one wrong answer
+        this whole seam exists to avoid, so name the parameter and stop instead.
+        """
+        fitted = set(self.param_set.keys()) if self.param_set is not None else set()
+        unrouted = sorted((_intervention_expression_reads(expr, self._net_param_definitions)
+                           & fitted) - set(targets))
+        if not unrouted:
+            return
+        raise PybnfError(
+            "Model %s: the intervention setConcentration(%r, %r) reads fitted parameter(s) %s, "
+            "which no requested forward-sensitivity column carries, so the initial condition it "
+            "assigns would contribute exactly zero to their gradient -- a wrong column no "
+            "objective can detect. Bind them to model parameters the gradient routes, or run a "
+            "gradient-free fit for this protocol."
+            % (self.name, species_name, expr, ', '.join(unrouted)))
 
     def execute(self, folder, filename, timeout, with_mutants=True):
         """Execute all simulation actions in-process using bngsim."""
@@ -787,9 +898,12 @@ class BngsimModel(NetModel):
             sc_expr = _parse_set_concentration_expr(line)
             if sc_expr is not None:
                 species_name, conc_expr = sc_expr
-                # The write drops any carried dx/dθ, so capture it first and put it back with
-                # this assignment's own row (#532); a no-op off the gradient path.
+                # The write drops this species' dx/dθ, so capture what it drops first and put
+                # back this assignment's own row: the carried matrix from a prior phase (#532),
+                # or -- with nothing pending -- the .net's own initial-condition seeding, which
+                # is declared rather than re-installed (#538). No-op off the gradient path.
                 carried = self._capture_carried_sensitivity_seed(model)
+                own_row = self._capture_own_sensitivity_row(species_name, carried)
                 applied = False
                 try:
                     conc_value = _eval_model_expression(conc_expr, model)
@@ -804,13 +918,14 @@ class BngsimModel(NetModel):
                     )
                 if applied:
                     self._restore_carried_sensitivity_seed(
-                        model, carried, species_name, conc_expr)
+                        model, carried, species_name, conc_expr, own_row=own_row)
                 continue
 
             ac = _parse_add_concentration(line)
             if ac is not None:
                 species_name, delta = ac
                 carried = self._capture_carried_sensitivity_seed(model)
+                own_row = self._capture_own_sensitivity_row(species_name, carried)
                 applied = False
                 try:
                     current = model.get_concentration(species_name)
@@ -824,7 +939,8 @@ class BngsimModel(NetModel):
                     )
                 if applied:
                     # A constant shift of the carried amount: d/dθ is the carried row itself.
-                    self._restore_carried_sensitivity_seed(model, carried, species_name, None)
+                    self._restore_carried_sensitivity_seed(model, carried, species_name, None,
+                                                           own_row=own_row)
                 continue
 
             ps_params = _parse_parameter_scan_action(line)

--- a/tests/test_bngsim_output_sensitivities.py
+++ b/tests/test_bngsim_output_sensitivities.py
@@ -635,6 +635,119 @@ def test_intervention_amount_reading_a_fitted_parameter_seeds_its_own_derivative
         2 * decay * (1.0 - PREEQUIL_K_DEG * PREEQUIL_T_END), rtol=1e-4, atol=1e-7)
 
 
+# ---- the same dose written BEFORE the first phase (#538) ----
+#
+# The perturbation of a ``preequilibrate:`` condition is a species write with nothing pending:
+# no phase has run since the reset, so what it supersedes is the .net's own initial-condition
+# seeding rather than a carried ``dx/dθ``. bngsim retires that row on an assignment
+# (lanl/bngsim#113), which is right for the literal amount ``set_concentration`` documents and
+# wrong for an amount written over a fitted parameter -- the row has to be *declared* instead.
+#
+# Oracle: with ``P`` never loaded nothing produces ``A``, so a dose of ``2*k_deg`` decays
+# through a FIXED-duration equilibration into the measured phase, and only the total elapsed
+# time matters:
+#
+#     A(T) = 2*k_deg*exp(-k_deg*T)          T = PREEQUIL_EQUIL_T + PREEQUIL_T_END
+#     dA/dk_deg = 2*exp(-k_deg*T)*(1 - k_deg*T)
+#
+# A steady-state equilibration would wash the dose out entirely and see nothing; a fixed
+# duration is what the #474 preincubate protocols use (``equil_t_end:``), and it is what
+# carries the defect into the measured phase.
+
+PREEQUIL_EQUIL_T = 0.5
+PREEQUIL_TOTAL_T = PREEQUIL_EQUIL_T + PREEQUIL_T_END
+
+_PREEQUIL_FIXED_EQUIL = ('simulate({method=>"ode",t_start=>0,t_end=>%g,n_steps=>1,'
+                         'suffix=>"pre"})' % PREEQUIL_EQUIL_T)
+
+
+def _fresh_dose_model(*writes):
+    """The dose-before-the-first-phase protocol: ``writes`` -> fixed equilibration -> measure."""
+    return _preequil_model([*writes, _PREEQUIL_FIXED_EQUIL, _PREEQUIL_MEASURE],
+                           [('simulate', 'pre'), ('simulate', 'relax')])
+
+
+@pytest.mark.parametrize('amount', ['2*k_deg', 'bolus'], ids=['literal_expr', 'derived_param'])
+def test_equilibration_phase_dose_reading_a_fitted_parameter_declares_its_own_derivative(amount):
+    """A dose written over the fitted parameter BEFORE the first phase keeps its derivative.
+
+    The mid-protocol twin of the test above, and the half #532 left open: with nothing pending
+    there is no matrix to rebuild, so the assignment's row is declared to the engine
+    (``Model.declare_ic_sensitivity``) and bngsim's own seeding starts from it. Left to the
+    backend the write retires the species' parameter-graph row and the column comes back
+    **exactly zero** -- 0 where the truth is ``-0.199`` -- which no objective can detect."""
+    model = _fresh_dose_model('setConcentration("A()","%s")' % amount)
+    data = model.execute('/tmp', 'preequil_fresh_bolus', 120)['relax']
+
+    decay = np.exp(-PREEQUIL_K_DEG * PREEQUIL_TOTAL_T)
+    assert data.data[-1, data.cols['A_tot']] == pytest.approx(
+        2 * PREEQUIL_K_DEG * decay, rel=1e-5)
+    assert data.output_sensitivities.slice_for('observable:A_tot')[-1, 0] == pytest.approx(
+        2 * decay * (1.0 - PREEQUIL_K_DEG * PREEQUIL_TOTAL_T), rel=1e-4)
+
+
+def test_a_constant_shift_of_a_declared_dose_keeps_the_declared_row():
+    """``addConcentration`` shifts the amount without replacing it, so ``d/dθ`` is unchanged --
+    the same reading as the carried case, applied before the first phase.
+
+    Dosing to ``2*k_deg`` and then adding a literal ``1`` gives ``A(0) = 2*k_deg + 1``, so
+    ``dA/dk_deg = exp(-k_deg*T)*(2 - (2*k_deg+1)*T)``. bngsim retires the row on the shift too
+    (it is a ``set_concentration`` underneath), so without re-declaring it the ``2`` term is
+    lost and only the ``-(2*k_deg+1)*T`` half survives."""
+    model = _fresh_dose_model('setConcentration("A()","2*k_deg")', 'addConcentration("A()",1)')
+    data = model.execute('/tmp', 'preequil_fresh_shift', 120)['relax']
+
+    decay = np.exp(-PREEQUIL_K_DEG * PREEQUIL_TOTAL_T)
+    a0 = 2 * PREEQUIL_K_DEG + 1.0
+    assert data.data[-1, data.cols['A_tot']] == pytest.approx(a0 * decay, rel=1e-5)
+    assert data.output_sensitivities.slice_for('observable:A_tot')[-1, 0] == pytest.approx(
+        decay * (2.0 - a0 * PREEQUIL_TOTAL_T), rel=1e-4)
+
+
+def test_a_literal_dose_before_the_first_phase_declares_nothing(monkeypatch):
+    """Narrowness guard: only an amount a fitted parameter reaches is declared.
+
+    Every #474 protocol opens with literal writes (the load, the wash), which are fresh-start
+    writes too -- and bngsim's own reading of them (``∂x_k(0)/∂θ = 0``) is already right. So
+    the declaration must not fire for them, and every gradient that was correct before #538 is
+    produced by exactly the same backend calls."""
+    declared = []
+    original = bngsim_model.BngsimModel._declare_fresh_start_sensitivity_row
+
+    def spy(self, model, species_name, expr, own_row):
+        row = original(self, model, species_name, expr, own_row)
+        if row is not None:
+            declared.append((species_name, row))
+        return row
+
+    monkeypatch.setattr(bngsim_model.BngsimModel,
+                        '_declare_fresh_start_sensitivity_row', spy)
+    model = _preequil_model(
+        [_PREEQUIL_LOAD, _PREEQUIL_EQUIL, _PREEQUIL_WASH, _PREEQUIL_MEASURE],
+        [('simulate', 'pre'), ('simulate', 'relax')])
+    data = model.execute('/tmp', 'preequil_fresh_literal', 120)['relax']
+
+    assert declared == []
+    np.testing.assert_allclose(
+        data.output_sensitivities.slice_for('observable:A_tot')[-1, 0],
+        _preequil_derivative(0.0), rtol=1e-4, atol=1e-7)
+
+
+def test_a_dose_reading_a_fitted_parameter_no_column_carries_refuses():
+    """A zero row that is *arithmetically* correct for the columns on hand is still a wrong
+    gradient when the amount reads a fitted parameter none of them carries -- and it is the
+    silent kind. Dosing over ``k_prod`` while only ``k_deg`` is on the sensitivity axis names
+    the parameter and refuses, rather than reporting a flat-zero ``k_prod`` column."""
+    model = _fresh_dose_model('setConcentration("A()","2*k_prod")')
+    model.param_set = pset.PSet([
+        pset.FreeParameter('k_deg', 'uniform_var', 0.0, 10.0, value=PREEQUIL_K_DEG),
+        pset.FreeParameter('k_prod', 'uniform_var', 0.0, 10.0, value=PREEQUIL_K_PROD)])
+    with pytest.raises(PybnfError) as exc:
+        model.execute('/tmp', 'preequil_fresh_unrouted', 120)
+    msg = str(exc.value)
+    assert 'k_prod' in msg and 'zero' in msg
+
+
 def test_non_differentiable_intervention_refuses_rather_than_guessing_a_seed_row():
     """An intervention amount outside the arithmetic grammar has no known ``d/dθ``; a guessed
     row would multiply the whole measured phase, so refuse and name the assignment."""

--- a/tests/test_gradient_assembly.py
+++ b/tests/test_gradient_assembly.py
@@ -2326,6 +2326,75 @@ def _decay_run(k_eff, s0_eff, with_sensitivities):
     return model.execute('/tmp', 'fd', 60)['tc']
 
 
+# The #532 pre-equilibration fixture with its LOADING DOSE written over a fitted parameter
+# (#538) -- the shape a ``preequilibrate:`` condition with a species target emits. ``P`` is
+# never loaded, so nothing produces ``A`` and the dose simply decays at ``k_deg + washout``
+# through a fixed-duration equilibration into the measured phase.
+PREEQUIL_DOSE_ACTIONS = [
+    'setConcentration("A()","2*k_deg")',
+    'simulate({method=>"ode",t_start=>0,t_end=>0.5,n_steps=>1,suffix=>"pre"})',
+    'simulate({method=>"ode",t_start=>0,t_end=>1,n_steps=>10,suffix=>"relax"})',
+]
+
+
+def _preequil_dose_run(k_deg, washout, free=None):
+    """Run the pre-equilibration net at the given rates, on the gradient path when ``free``.
+
+    Returns the measured ``relax`` :class:`Data` and the routing built from the model's own
+    bind-by-id namespace. Both free parameters land on the parameter axis; ``k_deg`` reaches
+    the trajectory twice over -- through the decay rate AND through the dose it sets -- and the
+    second path exists only because the write's ``∂x_k(0)/∂θ`` row is declared (#538)."""
+    import pybnf.bngsim_model as bngsim_model
+    from pybnf.gradient import route_for_model, apply_routing
+    net = FIXTURES / 'e2e_ode_preequil_scan.net'
+    model = bngsim_model.BngsimModel(
+        net.stem, list(PREEQUIL_DOSE_ACTIONS),
+        [('simulate', 'pre'), ('simulate', 'relax')], [], nf=str(net))
+    model.param_set = PSet([
+        FreeParameter('k_deg', 'uniform_var', 0.0, 100.0, value=k_deg),
+        FreeParameter('washout', 'uniform_var', 0.0, 100.0, value=washout),
+    ])
+    routing = None
+    if free is not None:
+        routing = route_for_model(model, [p.name for p in free])
+        apply_routing(model, routing)
+        model.set_scored_suffixes({'relax'})
+    return model.execute('/tmp', 'fd_preequil', 60)['relax'], routing
+
+
+@pytest.mark.bngsim
+def test_fd_acceptance_gate_preequilibration_dose_over_a_fitted_parameter():
+    """Central differences of PyBNF's own loss(u) vs the assembled gradient(u) for a
+    pre-equilibration protocol whose **loading dose is a fitted parameter** (#538).
+
+    This is the assembled-column form of the acceptance #538 asks for: ``k_deg`` sets the dose
+    (``setConcentration("A()","2*k_deg")``, the write a ``preequilibrate:`` species condition
+    emits) *and* the decay rate, while ``washout`` only decays. Without the declared
+    ``∂x_k(0)/∂θ`` row the dose half of ``k_deg``'s column vanishes and the assembled gradient
+    misses central differences by a wide margin -- while ``washout``'s column, which never
+    passes through the write, stays right. A fit sees only a plausible wrong direction."""
+    sigma = 0.02
+    free = [FreeParameter('k_deg', 'uniform_var', 0.1, 10.0, value=2.0),
+            FreeParameter('washout', 'uniform_var', 0.0, 10.0, value=0.4)]
+    names = [p.name for p in free]
+
+    gen, _ = _preequil_dose_run(1.7, 0.3)
+    t = gen.data[:, gen.cols['time']]
+    a = gen.data[:, gen.cols['A_tot']]
+    exp = Data.from_columns(np.column_stack([t, a, np.full(len(a), sigma)]),
+                            ['time', 'A_tot', 'A_tot_SD'])
+
+    def loss_at(u_vec):
+        theta = {n: p.from_sampling_space(u) for n, p, u in zip(names, free, u_vec)}
+        sim, _ = _preequil_dose_run(theta['k_deg'], theta['washout'])
+        return ChiSquareObjective().evaluate(sim, exp)
+
+    grad_fd = _fd_gradient(loss_at, free)
+    sim, routing = _preequil_dose_run(free[0].value, free[1].value, free)
+    res = assemble_gaussian_gradient(ChiSquareObjective(), [(sim, exp, routing)], free)
+    np.testing.assert_allclose(res.gradient, grad_fd, rtol=1e-4, atol=1e-4)
+
+
 @pytest.mark.bngsim
 @pytest.mark.parametrize('k_type', ['uniform_var', 'loguniform_var'])
 def test_fd_acceptance_gate(k_type):

--- a/tests/test_preequilibration.py
+++ b/tests/test_preequilibration.py
@@ -230,6 +230,25 @@ class TestBoundaries:
                      'setParameter("k_deg",5)'):
             assert i_equil < acts.index(line) < i_save, (line, acts)
 
+    def test_equilibration_phase_species_dose_keeps_its_parameter_provenance(self, tmp_path):
+        # #538: the pre-equilibration condition's own species perturbation is emitted BEFORE the
+        # equilibration, and a fitted amount must reach the backend as the expression that names
+        # the parameter -- not as the number that parameter currently holds. The number is what
+        # erases the provenance, and the backend cannot recover a d/dtheta it was never told.
+        conf = _build(tmp_path, _BASE + [
+            'condition: dose, perturbations: "A()" = 2*k_deg',
+            "experiment: relax, preequilibrate: dose, equil_t_end: 0.5, data: relax.exp",
+        ])
+        acts = conf.models["m"].actions
+        assert 'setConcentration("A()","2*k_deg")' in acts
+        i_reset = acts.index("resetConcentrations()")
+        i_dose = acts.index('setConcentration("A()","2*k_deg")')
+        i_equil = next(i for i, a in enumerate(acts) if "relax_preequil" in a)
+        assert i_reset < i_dose < i_equil, acts
+        # a FIXED-duration equilibration is what carries the dose into the measured phase (a
+        # steady-state one would relax it away, which is why the gap stayed invisible).
+        assert "steady_state" not in acts[i_equil] and "t_end=>0.5" in acts[i_equil]
+
     def test_species_perturbation_relative_op_is_refused(self, tmp_path):
         # A species amount (setConcentration) is an absolute set; a relative op has no meaning.
         with pytest.raises(PybnfError, match="species perturbation|only '='"):


### PR DESCRIPTION
Closes #538. ADR-0101.

## The ticket's premise does not hold — and there is an active defect underneath it

#538 filed this as *latent*, unreachable behind two guards. It is neither, and the guards do not stand where it places them.

`Configuration._build_condition_mutation` routes a target containing `(` — every BNGL species pattern — to a **species** perturbation and returns *before* the parameter-reference branch. So `"I(s)" = I0_CA` is never `is_param_ref`: `_preequilibration_perturbations`' refusal of a parameter-valued perturbation ("guard 1") never sees one, and `BNGLModel._preequilibration_perturbation_line` already emits the amount **quoted** (`float(value)` does not succeed on an identifier). The provenance the ticket asks to preserve was already preserved, and a *mid-protocol* dose over a fitted parameter already differentiates correctly — confirmed against finite differences before touching anything.

The routing change the ticket proposes would have been **wrong** here. A mid-protocol dose reaches the fit through the **parameter** axis (the ADR-0098 seed row), so an added initial-condition contribution would double the column the parameter axis already carries (ADR-0100) — and bngsim refuses `sensitivity_ic` across a pre-equilibration boundary outright (`the carried state is no longer the model's initial condition`, GH #210), so the request would abort the fit. `pybnf/gradient` is untouched by this PR.

What *is* real is the ticket's own third bullet — a zero `∂x_k(0)/∂θ` row reached silently. It is reached one phase earlier than the ticket looked.

## The defect

ADR-0098 supplies the seed row for a species write only where a carried `dx/dθ` is **pending**. A write with *nothing* pending was read as a write with no derivative to preserve. It is not: what it supersedes there is the seeding bngsim derives from the `.net`'s own initial-condition expression, and `set_concentration` retires that row too (lanl/bngsim#113 — an assigned amount is no longer described by the expression it superseded). So

```
setConcentration("A()","2*k_deg")     # the equilibration-phase perturbation
simulate(t_end=0.5, suffix=>"pre")    # a FIXED-duration equilibration
simulate(t_end=1,   suffix=>"relax")  # the measured phase
```

reports `dA/dk_deg = 0.000` where the truth is `-0.199`. The write that does this is a `preequilibrate:` condition with a species target — `resetConcentrations()` → `setConcentration(...)` → equilibrate.

Two things kept it out of sight:

* **A steady-state equilibration relaxes the dose away.** The value *and* the derivative are then genuinely insensitive to it, so nothing looks wrong. The defect needs a **fixed-duration** equilibration (`equil_t_end:`, what the #474 preincubate → wash → dose-scan protocols use, and what NFsim requires).
* **The column is zero, not absent.** No simulation fails, no objective moves, no refusal fires. A `trf` fit walks a wrong steepest direction and converges to a plausible answer.

## The fix

**Declare the row rather than re-install a matrix.** `Model.declare_ic_sensitivity` is the API bngsim added for exactly this (lanl/bngsim#111): *"for a hand-assigned θ-dependent IC this declaration is the only way the engine can know `∂x_k(0)/∂θ`"*, and it is honoured by a plain `Simulator.run`, not only by a scan's `on_point` hook. bngsim's own seeding then starts the run from it, so nothing about the run's carried-state arm changes — a fresh phase stays fresh, and `sensitivity_ic` keeps working where it worked before.

Deliberately **narrow**: an all-zero row says exactly what bngsim already says, so a θ-independent amount is left alone and an `addConcentration` re-declares only a non-trivial row. Every protocol whose gradient was right before this reaches the backend through the same calls it did before.

**One new refusal**, on this path *and* the mid-protocol one: an amount that reads a fitted parameter no requested forward-sensitivity column carries. `_intervention_seed_row` answers such an amount with a clean zero row — it has no column to put the derivative in — and that zero is indistinguishable, to any objective, from a parameter the trajectory does not depend on.

**Still out:** a species amount naming a free parameter that binds *no* model parameter (ADR-0076 applied to a species). A mid-protocol write reaches the fit only through a parameter axis, and a fit-vector-only parameter has none. It is refused today by the edition-2 correspondence check — a refusal with the wrong diagnosis rather than a silent wrong; giving it a route means giving the parameter a column, which is a larger change than this one.

## Verification

* **Closed-form oracle** on the #532 fixture (`e2e_ode_preequil_scan.net`). Dosing `A` to `2*k_deg` — directly, and through the `.net`'s derived `bolus = 2*k_deg`, which must be inlined before differentiating — matches `2·exp(-k_deg·T)·(1 - k_deg·T)` to `rtol=1e-4`, where the backend alone returns exactly `0`. A following `addConcentration("A()",1)` lands on `-0.274`; dropping the re-declaration gives `-0.373`.
* **FD oracle on the assembled column.** `k_deg` sets the dose *and* the decay rate; `washout` only decays. Both agree with central differences to `rtol=1e-4`. Before, the two columns came out **identical** — 838.46 against a true 323.76 for `k_deg`, 159% off — because without the dose term `k_deg` reaches the trajectory only as a decay rate, exactly as `washout` does. `washout`'s column was right the whole time, which is what makes this a plausible wrong direction rather than a visibly broken one.
* **Narrowness.** A protocol whose fresh-start writes are all literal (the load, the wash) emits no declaration at all, and its measured phase still meets the ADR-0098 oracle.
* **Config layer.** A `preequilibrate:` condition with a species target emits `setConcentration("A()","2*k_deg")` between the `resetConcentrations()` and a fixed-duration equilibration — the exact sequence the oracle runs.
* All five new tests fail on the pre-change code. Full default suite green (**3582 passed, 20 skipped**); recovery tier green apart from two environmental failures (`antimony` absent) that predate the change.

## Files

| | |
| --- | --- |
| `pybnf/bngsim_model/net_model.py` | the fresh-start declaration, the unrouted-parameter refusal |
| `tests/test_bngsim_output_sensitivities.py` | closed-form oracles, narrowness guard, refusal |
| `tests/test_gradient_assembly.py` | FD acceptance gate on the assembled column |
| `tests/test_preequilibration.py` | config-layer emission contract |
| `docs/adr/0101-…md` | new ADR |
| `docs/adr/0098-…md` | supersedes the "Deliberately still out" paragraph, which rested on the same reading #538 filed |
| `docs/gradient_fitting.rst`, `CHANGELOG.md` | user-facing |
