### PR TITLE
feat(gradient): fold a chain of data-level normalizations instead of refusing it (#539, ADR-0102)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -245,6 +245,22 @@ All notable changes to PyBNF are documented below. This project adheres to
   ≤3.7e-06.
 
 ### Added
+- **A chain of two or more data-level normalizations on one column is now differentiable (#539,
+  ADR-0102).** `normalization` is an ordered chain (ADR-0066), and five of its transforms —
+  `peak`, `init`, `zero`, `unit`, `floor` — rewrite the column in place. Stacking two of them
+  (`normalization pStat = floor 0.03, peak`) was refused on every gradient `job_type`, because the
+  sidecar recording *how* a column was normalized kept one record per column: the second transform
+  overwrote the first one's facts, and its intermediate values were gone with them. The sidecar is
+  now the **list** of a column's transforms in chain order, and the gradient folds it — each
+  stage's chain rule is the same closed form it always was, read in that stage's own inputs (the
+  previous stage's per-row sensitivities) rather than in the raw ones, so the fold wraps the
+  sensitivity accessor once per stage. The values a stage produced, which its own rule reads, ride
+  along on its record when the next transform overwrites them; a column normalized once — every
+  fit in the wild — retains nothing and costs what it did before, and its gradient is the same
+  arithmetic in the same order. Every normalized *value* is unchanged: this is about what is
+  recorded alongside them, not what is computed. `floor 0.03, scale` is unaffected either way, and
+  a chain of any length still composes with the analytic `scale` (ADR-0099), the cumulative and
+  per-measurement transforms, and the EFIM path.
 - **A gradient routing that would read one sensitivity column twice is now refused, not
   assembled (#537).** A route's derivative is the sum over its contributions, so two of them
   naming the same native `(axis, key)` column add that column twice — and the result is a clean
@@ -285,11 +301,9 @@ All notable changes to PyBNF are documented below. This project adheres to
   σ-unweighted, so `c*` is not in general the objective's own minimizer over the scale. A scaled
   fixed-σ Gaussian fit stays an exact least-squares model, so `trf`, `lbfgs`, and `gntr` all consume
   it; the profiled scale is resolved per experiment, so a column scaled in one experiment stays an
-  ordinary column in another. One boundary is now stated rather than silently mis-differentiated: a
-  chain of two or more *data-level* transforms on one column (`floor 0.03, peak`) keeps only the
-  last one's facts, so the gradient path refuses it by name, pointing at the open issue that
-  tracks composing them (#539) — `floor 0.03, scale` is unaffected, since `scale` is applied at
-  scoring time rather than to the column.
+  ordinary column in another. One boundary was stated here rather than silently mis-differentiated
+  — a chain of two or more *data-level* transforms on one column (`floor 0.03, peak`), which kept
+  only the last one's facts — and is closed by #539 above.
 - **A total wall-clock budget for a fit, `wall_time_fit`, that finalizes on expiry (#529,
   ADR-0093).** PyBNF's time limits were all per unit of work — `wall_time_sim` bounds one
   simulation, `wall_time_gen` one network generation — and nothing bounded a *run*: the only native

--- a/docs/adr/0099-a-profiled-per-series-scale-is-differentiated-through-its-own-profiling-condition-so-an-analytically-scaled-column-is-a-gradient-target.md
+++ b/docs/adr/0099-a-profiled-per-series-scale-is-differentiated-through-its-own-profiling-condition-so-an-analytically-scaled-column-is-a-gradient-target.md
@@ -103,7 +103,15 @@ constraint, and measurement-model layers, which compose with this unchanged.
 
 **Deliberately still out:** composing a chain of two or more `Data`-level normalizations
 (refused above; tracked as issue **#539**, which the refusal names — composing it needs each
-stage's record *and* its intermediate values, neither of which the sidecar retains). The prediction-dependent σ sources keep reading the *raw* simulated column
+stage's record *and* its intermediate values, neither of which the sidecar retains).
+
+> **Closed by ADR-0102 (#539).** The sidecar now keeps a *list* of records per column in chain
+> order, and a stage whose output a later transform overwrites keeps a copy of it on its record
+> — so both of the things named as missing are retained, and the gradient folds the chain
+> forward one stage at a time instead of refusing it. The `chained` flag introduced here is gone
+> with the refusal it fed.
+
+The prediction-dependent σ sources keep reading the *raw* simulated column
 for both their value and their sensitivity, so a scaled column's σ is unaffected either way —
 self-consistent, and unchanged by this ADR.
 

--- a/docs/adr/0102-a-normalization-chains-sidecar-is-a-list-of-stages-each-keeping-the-values-a-later-transform-overwrote-so-the-gradient-folds-the-chain-rather-than-refusing-it.md
+++ b/docs/adr/0102-a-normalization-chains-sidecar-is-a-list-of-stages-each-keeping-the-values-a-later-transform-overwrote-so-the-gradient-folds-the-chain-rather-than-refusing-it.md
@@ -1,0 +1,131 @@
+# A normalization chain's sidecar is a list of stages, each keeping the values a later transform overwrote, so the gradient folds the chain rather than refusing it (issue #539)
+
+**Status: Accepted and implemented (2026-08-04).** Closes the deferral ADR-0099 (#533) opened
+when it turned a silently wrong Jacobian into an explicit refusal: a column put through two or
+more **data-level** normalizations (`normalization pStat = floor 0.03, peak`) is now
+differentiated, stage by stage, like any other transform chain.
+
+## The problem
+
+`normalization` is a **chain** (ADR-0066): a comma-separated, ordered list of transforms applied
+left to right. Five of them — `peak`, `init`, `zero`, `unit`, `floor` — are *data-level*: they
+rewrite the column in `Data` before scoring ever sees it. (`scale` is the sixth and is not one:
+it is profiled at scoring time, which is why `floor 0.03, scale` — the motivating ADR-0066 chain
+— was already differentiable.)
+
+`Data.normalization` was a `{column: NormalizationRecord}` sidecar, one record per column, so a
+second data-level transform **overwrote** the first one's record. And each rule in
+`gradient/assembly._normalized_sensitivity` was written against two inputs: the *raw* per-row
+sensitivities from the #447 tensor, and the *final* values read back from the rescaled column.
+For a chain, neither the earlier stage's facts nor its values survived. Since #533 a second
+record carried `chained` and the gradient refused by name; before that, half these chains
+threaded the last transform's rule over a column an earlier transform had already moved — a
+wrong Jacobian with nothing said.
+
+## The decision
+
+**A chain of transforms is a chain rule. Keep the sidecar in chain order and fold it.**
+
+- **`Data.normalization` becomes `{column: [record, …]}`** in chain order.
+  `_record_normalization` appends rather than replaces, and `NormalizationRecord.chained` is
+  gone: "this column was normalized before" is now `index > 0`, not a flag to keep in sync.
+
+- **Each stage's rule is the one already written.** Every method's closed form is a chain rule
+  *in that stage's own inputs* — the values it consumed and the values it produced — and nothing
+  about it assumes those inputs are raw:
+
+  | stage | output | rule (`s` = the sensitivities of what this stage consumed) |
+  | --- | --- | --- |
+  | `floor` | `y_i = x_i + ρ·max x` | `∂y_i = s_i + ρ·s_ref` |
+  | `peak` / `init` | `y_i = x_i / N` | `∂y_i = (s_i − y_i·s_ref)/N` |
+  | `unit` | `y_i = (x_i − x_b)/N` | `∂y_i = ((s_i − s_b) − sign·y_i·(s_ref − s_b))/N` |
+  | `zero` | `y_i = (x_i − μ)/σ` | `∂y_i = (s_i − s̄)/σ − y_i·(∂σ)/σ`, `∂σ = Σ_k y_k(s_k − s̄)/(K−ddof)` |
+
+  So the fold is literal: `_normalized_sensitivity` starts from the tensor accessor and **wraps
+  it once per stage**, each wrapper reading the accessor the previous stage returned. It returns
+  an accessor with `tensor_sens`'s own `(col, row)` signature, which is what lets a stage call
+  its predecessor exactly as the un-chained rule called the tensor. One transform is the
+  one-iteration case and threads precisely the rule it always did.
+
+- **What a stage needed and did not have is its own output values.** Only the last stage's
+  survive in the column. So a stage whose output the next transform is about to overwrite keeps
+  a copy on its record (`NormalizationRecord.values`), handed to it by
+  `_record_normalization` at the moment the next stage records — the values that stage is about
+  to replace *are* the previous stage's output. A column normalized once — every job in the wild
+  — keeps nothing: `values` stays `None`, the values are read from the `Data`, and the sidecar
+  costs exactly what it did before.
+
+  Two alternatives were weighed. **Retain the raw column and replay the chain forward** in the
+  gradient (the cheapest to describe) means writing each transform's *forward* formula a second
+  time, in `assembly.py`, next to the derivative — two implementations of one reduction, free to
+  drift, in a module whose whole premise is that `data.py` owns the transform and records the
+  facts. **Invert the chain backwards from the final values** is tempting because peak / init /
+  unit / floor are each invertible from their record, but `zero` is not: μ is never recorded,
+  only σ. Retaining an overwritten stage's output costs the same one array and needs neither.
+
+- **The capture lives in the `normalize_to_*` methods, not in the `Data.normalize` chain
+  driver**, so a chain assembled by calling two of them directly is recorded as correctly as one
+  spelled in a config. That makes the moment of capture the thing to get right, and two methods
+  had to move to get it: `normalize_to_zero` now centres and scales **out of place** (it used to
+  mutate the column in place and record afterwards, by which time the column held the *output*),
+  and `normalize_to_unit_scale` — the one method that moves the column before it records, since
+  it subtracts the baseline for every column first — snapshots what it consumed at the top. The
+  arithmetic in both is unchanged.
+
+- **The fold memoizes per (stage, row).** A stage reads its predecessor at rows other than the
+  scored one: the reference row a divisor is read from, and for `zero` *every* row. So a `zero`
+  mid-chain asks the stage below it for the whole column once per scored row, and that stage
+  asks the one below it — without a memo the work multiplies down the chain, per scored row.
+  With one, each (stage, row) is computed once per experiment per evaluation. The tensor at the
+  bottom of the fold is left unmemoized, so a single transform costs exactly what it did before.
+
+## Scope
+
+**In:** `data.py` (`Data.normalization` as a list per column, `NormalizationRecord.values`,
+`_chain_stage_input`, `_record_normalization` appending; `chained` removed; the out-of-place
+`normalize_to_zero` and the pre-baseline snapshot in `normalize_to_unit_scale`),
+`gradient/assembly.py` (`_normalized_sensitivity` as a fold returning an accessor,
+`_stage_sensitivity` memo, `_stage_rule` holding the per-method rules unchanged, the per-column
+accessor cache in `_raw_sensitivity_accessor`).
+
+**Out (unchanged):** every normalized value. `Data.normalize` applies the same transforms in the
+same order and writes the same numbers, so no fit's objective value moves — this ADR is about
+what is *recorded* alongside them. The single-transform gradient is the same arithmetic in the
+same order. `scale` (ADR-0099) is untouched: it is not a `Data` transform, records nothing, and
+composes with a chain of any length exactly as before. The PEtab export boundary (ADR-0066):
+normalization still has no PEtab v2 representation and is still refused there.
+
+**Deliberately out:** nothing in this area remains deferred. A chain is now differentiable
+whatever its length or composition; what a chain *means* is unchanged (ADR-0066 keeps
+peak/init/zero/unit sim-only and `floor`/`scale` symmetric), and stacking two whole-trajectory
+reductions on one column stays an unusual thing to author — it is now merely unusual, not
+refused.
+
+## Verification
+
+- **Finite-difference oracle on the assembled gradient**, extended from the five single
+  transforms to five chains: `floor 0.03, peak` and `peak, floor 0.03` (the additive offset on
+  each side of the divisor it feeds), `init, zero` and `zero, unit` (the method that couples
+  every row, on each side), and the three-stage `floor 0.03, peak, zero`. The oracle is a
+  central difference of PyBNF's **own** `Data.normalize` applied to the raw column perturbed
+  along its sensitivity, so it arbitrates the whole chain against the actual reduction, not
+  against a hand-derived composition.
+- **A closed-form arbiter for `floor 0.03, peak`**, where the composition is visible: the peak's
+  divisor is the *floored* max and its reference term carries the floor's own `(1+ρ)`. Asserted
+  positively, and with the negative control — the last stage's rule alone over the raw
+  sensitivities (what the pre-#533 path computed) is a different number, and the test says so.
+- **A chain built by direct `normalize_to_*` calls** (`peak` then `unit`, the method that
+  records after it moves the column) folds to the same finite difference, pinning the capture
+  points rather than the chain driver.
+- **The sidecar's own contract**: the records come back in chain order, the overwritten stage's
+  retained `values` equal the mid-chain column, and the last stage retains nothing.
+- **The config path end to end**: `normalization x = floor 0.03, peak` compiles to its two
+  ordered pairs *in chain order* (the previous chain test's second element, `scale`, is not a
+  `Data` transform and never had an order to get wrong), and applying the compiled grid records
+  the two stages in that order.
+- The full default suite is green (3588 passed, 20 skipped).
+
+Relevant ADRs: **0099** (the floor and analytic-scale gradients, whose refusal this replaces),
+**0066** (the chain grammar and the two primitives), **0053** (the per-observable normalization
+transform and its `∂(raw/N)/∂θ` rules, which this reads unchanged one stage at a time). Closes
+issue **#539**.

--- a/docs/config_keys.rst
+++ b/docs/config_keys.rst
@@ -1129,10 +1129,9 @@ Algorithm Options
   exporter refuses it rather than silently scoring the raw, un-normalized columns. Every
   transform here, ``floor`` and ``scale`` included, *is* differentiable, so a
   :ref:`gradient-based fit <gradient_fitting>` (``trf`` / ``lbfgs`` / ``gntr``) can run on a
-  normalized or analytically scaled column. The one exception is a chain of two or more
-  **data-level** transforms on the same column (``floor 0.03, peak``), which the gradient path
-  refuses (issue #539); ``floor 0.03, scale`` is fine, since ``scale`` is applied at scoring time
-  rather than to the column.
+  normalized or analytically scaled column -- including a **chain** of them
+  (``floor 0.03, peak``), which the gradient composes stage by stage, each stage's chain rule
+  read in the values that stage consumed and produced.
 
   Default: No normalization
 

--- a/docs/gradient_fitting.rst
+++ b/docs/gradient_fitting.rst
@@ -436,10 +436,11 @@ own derivative so it stays exact.
   (:math:`\hat y_i + \rho\max\hat y`) is additive, so every row picks up the same
   :math:`\rho\,\partial\hat y_p/\partial\theta` term. All five are
   threaded, and any combination of these transforms composes (normalization is applied first, then
-  the cumulative/per-measurement transform on top, exactly as scoring does). The one exception is a
-  **chain of two or more of these** on one column (``floor 0.03, peak``): only the last transform's
-  facts are recorded, so the gradient path refuses it rather than compose it wrongly. A chain
-  ending in ``scale`` is fine — ``scale`` is not a data-level transform.
+  the cumulative/per-measurement transform on top, exactly as scoring does). A **chain** of two or
+  more of them on one column (``floor 0.03, peak``) composes as well: each stage's rule is that
+  same closed form read in *its own* inputs — the previous stage's per-row sensitivities — so the
+  gradient folds the chain forward, one wrapper per stage, with the values a stage produced riding
+  along on its record when the next transform overwrites them (#539).
 
 * **Analytic per-series scale** (``normalization <obs> = scale``): the scored value is
   :math:`c^{*}(\theta)\,\hat y_i(\theta)`, where :math:`c^{*}` is profiled out of the *whole*
@@ -643,8 +644,8 @@ log; see *Log / lognormal noise scale* above), with each noise parameter either 
 from the data / a constant) or estimated as a **single free parameter** (see *Estimated σ* and
 *Asymmetric and non-Gaussian families* above), the prediction formed through any of the
 per-observable **trajectory transforms** (cumulative→incident, a per-measurement scale/offset,
-normalization — floor included — or an analytic per-series scale; see *Trajectory transforms and
-normalization* above), and observables materialized
+normalization — floor and multi-transform chains included — or an analytic per-series scale; see
+*Trajectory transforms and normalization* above), and observables materialized
 through a **measurement-model layer** (the SBML/Antimony / ``observableFormula`` path; see
 *Measurement-model layer* above). Any other configuration raises a clear ``GradientNotSupported``
 naming what is missing, so a caller can fall back to a gradient-free step rather than trust a wrong

--- a/pybnf/data.py
+++ b/pybnf/data.py
@@ -4,7 +4,7 @@
 import logging
 import numpy as np
 import re
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from typing import Optional
 from .printing import PybnfError
 
@@ -201,9 +201,10 @@ class NormalizationRecord:
     lives in :mod:`pybnf.gradient.assembly` (this is a plain fact holder; ``data.py`` knows
     no gradient math).
 
-    Every method's ``∂(normalized_i)/∂θ`` is a function of the **raw** per-row sensitivity
-    ``s_k = ∂raw_k/∂θ`` (the #447 tensor, untouched by normalization) and the **normalized**
-    column values ``n_k`` (read back from the now-rescaled ``Data``):
+    Every method's ``∂(normalized_i)/∂θ`` is a function of the per-row sensitivity of the values
+    this transform *consumed*, ``s_k = ∂raw_k/∂θ`` (the #447 tensor for the first transform of a
+    column, untouched by normalization), and of this transform's own output values ``n_k`` (for
+    the last transform of a column, read back from the now-rescaled ``Data``):
 
     * ``peak``/``init``: ``n_i = raw_i / N`` with ``N`` the column max (``ref_row`` =
       argmax) or the initial value (``ref_row`` = 0) -- ``∂n_i/∂θ = (s_i - n_i·s_ref)/N``.
@@ -219,13 +220,18 @@ class NormalizationRecord:
       to the simulated and the experimental column* so a log/relative objective stays finite where
       a series legitimately touches zero. ``∂n_i/∂θ = s_i + ρ·s_ref`` (#533).
 
-    One record is kept per column -- the **last** transform applied -- so a column put through a
-    *chain* of two or more ``Data``-level transforms (``floor 0.03, peak``) cannot be
-    reconstructed from the sidecar: each rule above reads the raw sensitivities, and the
-    intermediate stage's values are gone. Such a record carries :attr:`chained`, and the gradient
-    path refuses it rather than threading the last rule alone (the analytic ``scale`` is *not* a
-    ``Data`` transform, so the ``floor 0.03, scale`` chain records only the floor and stays
-    differentiable).
+    ``normalization`` is a **chain** (ADR-0066): ``normalization pStat = floor 0.03, peak`` puts
+    one column through two ``Data``-level transforms in order. :attr:`Data.normalization` maps a
+    column to the **list** of its records, in that order, and each stage's rule is the one above
+    read in *that stage's* own inputs -- so the gradient folds the chain forward, threading stage
+    1's rule through stage 2's, rather than reading a single record (#539, ADR-0102).
+
+    Each rule needs its stage's output values, and only the **last** stage's survive in the
+    column itself, so a stage whose output a later transform is about to overwrite keeps a copy
+    in :attr:`values` (populated by :meth:`Data._record_normalization` when the next stage
+    arrives). A column normalized once -- every job in the wild -- retains nothing: ``values``
+    stays ``None`` and the values are read from the ``Data``. The analytic ``scale`` is *not* a
+    ``Data`` transform, so the ``floor 0.03, scale`` chain records only the floor.
     """
 
     method: str                          # 'peak' | 'init' | 'zero' | 'unit' | 'floor'
@@ -235,7 +241,10 @@ class NormalizationRecord:
     sign: float = 1.0                    # unit-min branch flips the reference term's sign
     rho: float = 0.0                     # floor: the max-fraction added (x' = x + rho*max); 0 for every other method
     ddof: int = 0                        # zero: the K - ddof denominator of the std derivative
-    chained: bool = False                # this column was already normalized once (a chain; the earlier record is gone)
+    # This stage's output column, kept only when a LATER transform in the chain overwrote it
+    # (the last stage's output is the column itself). Out of the repr/eq: a record is compared
+    # and printed as the handful of scalars above, not as an array of values.
+    values: Optional[np.ndarray] = field(default=None, repr=False, compare=False)
 
 
 class Data:
@@ -257,9 +266,10 @@ class Data:
         # Forward output sensitivities (#385/#447): None on the scalar path,
         # an OutputSensitivities payload on the gradient path. Additive only.
         self.output_sensitivities = None
-        # Per-column normalization records (#453/#385): None until normalize() runs,
-        # then {col_name: NormalizationRecord}. The gradient path reads it to thread the
-        # normalizer's own derivative; absent -> byte-identical. Additive only.
+        # Per-column normalization records (#453/#385): None until normalize() runs, then
+        # {col_name: [NormalizationRecord, ...]} in chain order (ADR-0066/0102). The gradient
+        # path reads it to thread the normalizer's own derivative; absent -> byte-identical.
+        # Additive only.
         self.normalization = None
         self.bind_to(self.update_weights)
         if file_name is not None:
@@ -528,7 +538,7 @@ class Data:
                 # rows where this observable is unmeasured; np.max would poison the whole column,
                 # so peak/argmax skip the NaNs and normalize only the real points.
                 self._record_normalization(c, NormalizationRecord(
-                    'peak', float(np.nanmax(column)), ref_row=int(np.nanargmax(column))))
+                    'peak', float(np.nanmax(column)), ref_row=int(np.nanargmax(column))), column)
                 self.data[:, c] = self.data[:, c] / np.nanmax(self.data[:, c])
 
     def normalize_to_init(self, idx=0, cols='all'):
@@ -550,7 +560,7 @@ class Data:
                 # Record N = initial value before the in-place divide overwrites row 0
                 # (#453): ref_row 0 is the divisor's source row for the gradient chain rule.
                 self._record_normalization(c, NormalizationRecord(
-                    'init', float(self.data[0, c]), ref_row=0))
+                    'init', float(self.data[0, c]), ref_row=0), self.data[:, c])
                 self.data[:, c] = self.data[:, c] / self.data[0, c]
 
     def normalize_to_zero(self, idx=0, bc=True, cols='all'):
@@ -571,17 +581,19 @@ class Data:
                 cols.remove(idx)
             ddof = 0 if not bc else 1
             for c in cols:
+                # Centre and scale out of place, so the column still holds this transform's
+                # *input* values when they are recorded below (a chain hands them to the
+                # previous stage, whose rule reads them -- ADR-0102). The arithmetic is the
+                # same subtract-then-divide as the in-place form it replaces.
                 col = self.data[:, c]
-                col -= np.mean(col)
-                std = np.std(col, ddof=ddof)
-                if std != 0:
-                    col /= std
-                self.data[:, c] = col
+                centered = col - np.mean(col)
+                std = np.std(centered, ddof=ddof)
                 # Record the z-score scale (std; 0 means the column was left un-divided) and
                 # the K - ddof denominator the gradient's d std/d theta uses (#453). z-score
                 # couples every row, so only these scalars are recorded -- the per-row mean of
                 # the sensitivities is recomputed from the tensor at gradient time.
-                self._record_normalization(c, NormalizationRecord('zero', float(std), ddof=ddof))
+                self._record_normalization(c, NormalizationRecord('zero', float(std), ddof=ddof), col)
+                self.data[:, c] = centered / std if std != 0 else centered
 
     def _subtract_baseline(self, idx=0, cols='all'):
         if cols == 'all':
@@ -606,6 +618,11 @@ class Data:
         if cols == 'all':
             cols = list(range(self.data.shape[1]))
             cols.remove(idx)
+        # Snapshot each column *before* the baseline subtraction: unlike every other method this
+        # one moves the column before it records, and a chain's earlier stage needs the values
+        # this transform consumed, not the baseline-subtracted ones (ADR-0102). A no-op (None)
+        # unless this column is already normalized, so a single unit-scaling copies nothing.
+        consumed = {c: self._chain_stage_input(c) for c in cols}
         self._subtract_baseline(idx, cols)
         for c in cols:
             # nan-aware (#479 follow-up): skip NaN rows (a sparse column's unmeasured points) so a
@@ -617,13 +634,14 @@ class Data:
                 # sensitivity enters with a flipped sign (#453); the baseline is still row 0.
                 self._record_normalization(c, NormalizationRecord(
                     'unit', float(np.abs(np.nanmin(self.data[:, c]))),
-                    ref_row=int(np.nanargmin(self.data[:, c])), baseline_row=0, sign=-1.0))
+                    ref_row=int(np.nanargmin(self.data[:, c])), baseline_row=0, sign=-1.0),
+                    consumed[c])
                 self.data[:, c] = self.data[:, c] / np.abs(np.nanmin(self.data[:, c]))
             else:
                 # N = the max-after-baseline; ref_row is its argmax, baseline is row 0 (#453).
                 self._record_normalization(c, NormalizationRecord(
                     'unit', float(cmax), ref_row=int(np.nanargmax(self.data[:, c])),
-                    baseline_row=0, sign=1.0))
+                    baseline_row=0, sign=1.0), consumed[c])
                 self.data[:, c] = self.data[:, c] / np.nanmax(self.data[:, c])
 
     def normalize_to_floor(self, rho, idx=0, cols='all'):
@@ -659,7 +677,7 @@ class Data:
             # Record the added amount (rho) and the max its argmax row before the offset -- the
             # gradient's ∂(x + rho*max)/∂θ = s_i + rho*s_argmax reads them (#533).
             self._record_normalization(c, NormalizationRecord(
-                'floor', cmax, ref_row=int(np.nanargmax(column)), rho=float(rho)))
+                'floor', cmax, ref_row=int(np.nanargmax(column)), rho=float(rho)), column)
             self.data[:, c] = column + rho * cmax
 
     @staticmethod
@@ -682,8 +700,24 @@ class Data:
         output.data = np.mean(np.stack([d.data for d in datas]), axis=0)
         return output
 
-    def _record_normalization(self, col_index, record):
-        """Stash how column ``col_index`` was normalized, keyed by its header name (#453).
+    def _chain_stage_input(self, col_index):
+        """The values a transform about to run on ``col_index`` will consume -- copied, but only
+        when an earlier transform already recorded this column (ADR-0102).
+
+        ``None`` for the first transform of a column, which is every column of every job that
+        normalizes once: there is no earlier stage waiting for these values, so nothing is
+        copied and the sidecar costs what it always did. Callers that move the column before
+        they record it (:meth:`normalize_to_unit_scale`, which subtracts the baseline for every
+        column first) take this snapshot at the top; the rest hand
+        :meth:`_record_normalization` the live column, which still holds its input values."""
+        if self.normalization is None:
+            return None
+        if not self.normalization.get(self.headers.get(col_index, col_index)):
+            return None
+        return self.data[:, col_index].copy()
+
+    def _record_normalization(self, col_index, record, consumed):
+        """Append how column ``col_index`` was just normalized, keyed by its header name (#453).
 
         The gradient path reads :attr:`normalization` to thread the normalizer's own
         derivative through ``∂(raw/N)/∂θ``; every other path ignores it. Keyed by **name**
@@ -691,19 +725,31 @@ class Data:
         scored column. Lazily creates the dict, so a never-normalized ``Data`` keeps
         ``normalization is None`` (byte-identical).
 
-        A second record for the same column means the column went through a *chain* of
-        ``Data``-level transforms (ADR-0066): the earlier stage's facts are overwritten and its
-        intermediate values are gone, so the new record is flagged :attr:`~NormalizationRecord.chained`
-        and the gradient refuses it rather than threading the last rule over a column an earlier
-        transform already moved."""
+        A column's value is the **list** of records for the transforms it went through, in chain
+        order (ADR-0066: ``floor 0.03, peak`` is two stages), so the gradient can fold the chain
+        stage by stage instead of reading a single record (#539, ADR-0102). Each stage's rule
+        reads that stage's *output* values, and only the last stage's survive in the column, so
+        a second record hands ``consumed`` -- the values this transform is about to replace,
+        which are exactly the previous stage's output -- back to the record that produced them.
+
+        :param consumed: the column as it stands *before* this transform, still holding the
+            values the transform consumes. Only read when this column is already normalized;
+            pass :meth:`_chain_stage_input`'s snapshot if the column moved before recording."""
         if self.normalization is None:
             self.normalization = {}
         # Key by header name when known (the gradient looks up a scored column by name); fall
         # back to the index for a headerless Data (no gradient path reads it -- just no crash).
         key = self.headers.get(col_index, col_index)
-        if key in self.normalization:
-            record = replace(record, chained=True)
-        self.normalization[key] = record
+        chain = self.normalization.setdefault(key, [])
+        if chain:
+            if consumed is None:
+                raise ValueError(
+                    "Recording a chained normalization ('%s' after '%s') on column %r without "
+                    "the values it consumes: the earlier stage's output is about to be "
+                    "overwritten and its chain rule reads it (ADR-0102)."
+                    % (record.method, chain[-1].method, key))
+            chain[-1] = replace(chain[-1], values=np.array(consumed, dtype=float))
+        chain.append(record)
 
     def normalize(self, method):
         """

--- a/pybnf/gradient/assembly.py
+++ b/pybnf/gradient/assembly.py
@@ -75,7 +75,9 @@ transform: a **cumulative -> incident** difference (ADR-0051), a **per-measureme
 offset formula (ADR-0045), or an upstream ``Data``-level **normalization** (ADR-0053/0066). Each
 makes ``∂pred/∂θ`` differ from the raw observable sensitivity, so the assembly reads a
 ``raw_sens(col, row)`` accessor (the #447 tensor, routing-factor-folded, with normalization's
-own quotient/chain rule threaded in -- ``_normalized_sensitivity``) and hands it to the
+own quotient/chain rule threaded in -- ``_normalized_sensitivity``, which for a *chain* of
+``Data``-level transforms wraps the tensor accessor once per stage, each stage's rule read in
+the values that stage consumed and produced, #539/ADR-0102) and hands it to the
 objective's :meth:`~pybnf.objective.SummationObjective.prediction_sensitivity` seam, which
 mirrors ``_prediction`` branch for branch (cumulative differences sensitivity rows; a per-
 measurement formula chains its symbolic gradient through each referenced column's sensitivity
@@ -565,6 +567,7 @@ def _raw_sensitivity_accessor(objective, sim_data, sens, routing, index, n_param
     routing.check_column_multiplicity()
     _check_axes_are_not_the_same_derivative(sens, routing)
     norm = sim_data.normalization or {}
+    normalized = {}   # col -> the folded chain accessor, built on first use and reused per row
     measurement = getattr(objective, 'measurement', None)
     measurement_models = ({mm.observable_id: mm for mm in measurement.models}
                           if measurement else {})
@@ -588,10 +591,12 @@ def _raw_sensitivity_accessor(objective, sim_data, sens, routing, index, n_param
         model = measurement_models.get(col_name)
         if model is not None:
             return model.prediction_sensitivity(sim_data, row, pset_values, raw_sens, index)
-        record = norm.get(col_name)
-        if record is None:
+        records = norm.get(col_name)
+        if not records:
             return tensor_sens(col_name, row)
-        return _normalized_sensitivity(record, col_name, row, sim_data, tensor_sens)
+        if col_name not in normalized:
+            normalized[col_name] = _normalized_sensitivity(records, col_name, sim_data, tensor_sens)
+        return normalized[col_name](col_name, row)
 
     return raw_sens
 
@@ -665,28 +670,68 @@ def _check_axes_are_not_the_same_derivative(sens, routing):
                float(np.abs(p_col - ic_sum).max()) / scale, name))
 
 
-def _normalized_sensitivity(record, col_name, row, sim_data, tensor_sens):
-    """Thread a per-column normalizer's own derivative into ``∂(normalized col)/∂θ`` (ADR-0053).
+def _normalized_sensitivity(records, col_name, sim_data, tensor_sens):
+    """Fold a column's normalization **chain** into one ``∂(normalized col)/∂θ`` accessor
+    (ADR-0053/0066, #539).
 
     ``normalization`` rescales the predicted column by a θ-dependent ``N(θ)`` read off the
     moving trajectory, so ``∂(raw/N)/∂θ`` is a quotient/chain rule coupling the scored row with
-    the row(s) ``N`` is read from. The raw per-row sensitivities ``s_k`` come from the
-    (un-normalized) #447 tensor; the normalized values ``n_k`` are read back from the now-
-    rescaled ``Data`` (so the raw values need not be retained). See
-    :class:`~pybnf.data.NormalizationRecord` for each method's closed form."""
-    normed = sim_data.data[:, sim_data.cols[col_name]]
+    the row(s) ``N`` is read from. A chain (``floor 0.03, peak``) applies two or more such
+    transforms in order, and each one's rule is that same closed form read in *its own* inputs:
+    the previous stage's per-row sensitivities, and its own output values. So the fold is
+    literal -- start from the raw #447 tensor accessor and wrap it once per stage, each wrapper
+    reading the accessor the previous stage returned. A single transform is the one-iteration
+    case and threads exactly the rule it always did.
+
+    The values a stage's rule reads are its **output** column: retained on the record when a
+    later transform overwrote them (:class:`~pybnf.data.NormalizationRecord.values`), and for
+    the last stage read back from the now-rescaled ``Data`` -- so a column normalized once
+    retains nothing. See :class:`~pybnf.data.NormalizationRecord` for each method's closed form.
+
+    Returns an accessor with ``tensor_sens``'s own ``(col_name, row)`` signature, which is what
+    lets each stage call its predecessor exactly as the un-chained rule called the tensor."""
+    final = sim_data.data[:, sim_data.cols[col_name]]
+    stage_sens = tensor_sens
+    for i, record in enumerate(records):
+        values = record.values if i < len(records) - 1 else final
+        if values is None:
+            # Only reachable if a caller normalized the column twice without going through
+            # Data's own normalize_* methods, which hand each overwritten stage its values.
+            raise GradientNotSupported(
+                "Column '%s' went through a chain of normalizations (%s) but stage %d ('%s') "
+                "kept none of the values it produced, which its own chain rule reads, so the "
+                "chain cannot be folded (issue #539). Use a single normalization per column, or "
+                "a gradient-free step."
+                % (col_name, ' -> '.join(r.method for r in records), i + 1, record.method))
+        stage_sens = _stage_sensitivity(record, values, stage_sens)
+    return stage_sens
+
+
+def _stage_sensitivity(record, normed, previous):
+    """One stage of a normalization chain: ``∂(this stage's output)/∂θ`` from ``previous``, the
+    accessor for the values it consumed, and ``normed``, the values it produced.
+
+    Memoized per row, because a stage reads its predecessor at rows other than the scored one --
+    the reference row a divisor is read from, and for ``zero`` *every* row. So a ``zero`` mid-
+    chain asks the stage below it for the whole column, once per scored row, and that stage asks
+    the one below it; without the memo the work would multiply down the chain per scored row.
+    With it each (stage, row) is computed once per experiment per evaluation. The tensor at the
+    bottom is not memoized, so a single transform costs exactly what it always did."""
+    cache = {}   # keyed by row alone: a stage belongs to the one column its chain normalizes
+
+    def stage(col_name, row):
+        if row not in cache:
+            cache[row] = _stage_rule(record, col_name, row, normed, previous)
+        return cache[row]
+
+    return stage
+
+
+def _stage_rule(record, col_name, row, normed, tensor_sens):
+    """The closed-form rule for one recorded transform (:class:`~pybnf.data.NormalizationRecord`),
+    read in the values it consumed (``tensor_sens``, the previous stage's accessor -- the #447
+    tensor itself for the first transform of a column) and the values it produced (``normed``)."""
     s_i = tensor_sens(col_name, row)
-    if record.chained:
-        # Only the LAST transform of a multi-transform chain is recorded (the sidecar is keyed by
-        # column), and each rule below reads the *raw* per-row sensitivities, so composing an
-        # unrecorded earlier stage is not possible from what is retained. Refuse rather than
-        # thread the last rule alone over a column an earlier transform already moved.
-        raise GradientNotSupported(
-            "Column '%s' is normalized more than once (a chain of transforms ending in '%s'); only "
-            "the last one's facts are recorded, so the gradient path cannot compose the chain "
-            "(issue #539). Use a single normalization per column -- a chain ending in the analytic "
-            "'scale' is fine, since 'scale' is applied at scoring time rather than to the column "
-            "-- or use a gradient-free step." % (col_name, record.method))
     if record.method == 'floor':
         # x' = x + rho*max(x) (ADR-0066): additive and separable, so ∂x'_i/∂θ = s_i + rho*s_argmax
         # -- the scored row's own sensitivity plus rho times the row the max is read from
@@ -706,7 +751,8 @@ def _normalized_sensitivity(record, col_name, row, sim_data, tensor_sens):
 def _zscore_sensitivity(record, col_name, row, tensor_sens, normed, s_i):
     """``∂/∂θ`` of a z-score-normalized column (subtract mean μ, divide by std σ) -- the one
     method that couples **every** row through σ (ADR-0053). With ``s_bar`` the per-row mean of
-    the raw sensitivities and σ = ``record.scale``::
+    the sensitivities of the values it consumed (the #447 tensor's, or -- mid-chain -- the
+    previous stage's) and σ = ``record.scale``::
 
         ∂n_i/∂θ = (s_i - s_bar)/σ - n_i·(∂σ/∂θ)/σ,
         ∂σ/∂θ  = Σ_k n_k (s_k - s_bar)/(K - ddof)

--- a/tests/test_config_class.py
+++ b/tests/test_config_class.py
@@ -768,6 +768,22 @@ class TestNewEraNormalization:
         assert c.config['analytic_scale'] == {'egf_high': frozenset({'x', 'y'}),
                                               'egf_low': frozenset({'x', 'y'})}
 
+    def test_data_level_chain_compiles_in_order_and_records_both_stages(self):
+        # A chain of two DATA-level transforms (#539, ADR-0102): both are applied to the column,
+        # so both are emitted -- in chain order, which is what makes the sim Data record the two
+        # stages in the order the gradient folds them.
+        c = self._build_grid({('normalization', 'x'): [('floor', 0.03), 'peak']})
+        assert c.config['normalization'] == {
+            'egf_high': [(('floor', 0.03), ['x']), ('peak', ['x'])],
+            'egf_low': [(('floor', 0.03), ['x']), ('peak', ['x'])]}
+        assert not c.config.get('analytic_scale')      # no scoring-time transform here
+        d = data.Data(file_name='bngl_files/par1.exp')
+        raw_x = d.data[:, d.cols['x']].copy()
+        d.normalize(c.config['normalization']['egf_high'])
+        assert [r.method for r in d.normalization['x']] == ['floor', 'peak']
+        np.testing.assert_allclose(d.normalization['x'][0].values,
+                                   raw_x + 0.03 * np.nanmax(raw_x))
+
     def test_invalid_type_in_chain_lists_floor_and_scale(self):
         with pytest.raises(printing.PybnfError, match='floor, scale'):
             self._resolve({('normalization', 'x'): [('bogus', 1.0)]})
@@ -831,7 +847,7 @@ class TestNewEraPreprocessingKeysRideThrough:
         assert c.obj._scale_mode('x') == 'linear'
         # The experimental x column was floored in place (a 'floor' record proves it).
         floored = next(iter(c.exp_data.values()))['par1']
-        assert floored.normalization['x'].method == 'floor'
+        assert [r.method for r in floored.normalization['x']] == ['floor']
 
 
 class TestRaggedReplicates:

--- a/tests/test_data_class.py
+++ b/tests/test_data_class.py
@@ -213,8 +213,11 @@ class TestData:
     def test_floor_records_rho_and_argmax(self):
         d1 = copy.deepcopy(self.d1)
         d1.normalize_to_floor(0.03, cols=[1])
-        rec = d1.normalization['obs1']
+        chain = d1.normalization['obs1']
+        assert len(chain) == 1             # one transform -> a one-stage chain (ADR-0102)
+        rec = chain[0]
         assert rec.method == 'floor'
+        assert rec.values is None          # nothing overwrote its output, so nothing is retained
         assert rec.rho == 0.03
         assert rec.scale == 4.0            # the column max
         assert rec.ref_row == 2            # argmax (obs1 peaks at row 2)
@@ -228,6 +231,22 @@ class TestData:
         d1c = copy.deepcopy(self.d1)
         d1c.normalize([(('floor', 0.1), [1]), ('peak', [1])])
         npt.assert_allclose(d1c.data[:, 1], np.array([3.4, 2.4, 4.4]) / 4.4)
+
+    def test_a_chain_records_every_stage_in_order_and_keeps_what_it_overwrote(self):
+        # The sidecar is the LIST of a column's transforms in chain order (ADR-0102), so the
+        # gradient can fold the chain stage by stage. Each stage's rule reads the values that
+        # stage produced, and only the last stage's survive in the column -- so the floor's
+        # output rides along on its own record once peak overwrites it.
+        d1 = copy.deepcopy(self.d1)
+        d1.normalize([(('floor', 0.1), [1]), ('peak', [1])])
+        floor_rec, peak_rec = d1.normalization['obs1']
+        assert (floor_rec.method, peak_rec.method) == ('floor', 'peak')
+        assert floor_rec.rho == 0.1 and floor_rec.scale == 4.0   # the raw column's max
+        assert peak_rec.scale == 4.4                             # the FLOORED column's max
+        npt.assert_allclose(floor_rec.values, np.array([3.4, 2.4, 4.4]))
+        assert peak_rec.values is None                           # its output IS the column
+        # Untouched columns keep their own one-stage chains (or none at all).
+        assert d1.normalization.get('obs2') is None
 
     def test_floor_peak_unit_are_nan_aware_on_sparse_columns(self):
         # #479 follow-up: a sparse multi-observable target carries NaN in the rows where an
@@ -250,7 +269,7 @@ class TestData:
         df = mk(); df.normalize_to_floor(0.1, cols=[1])
         npt.assert_allclose(df.data[[0, 2], 1], np.array([3.4, 4.4]))
         assert np.isnan(df.data[1, 1])
-        assert df.normalization['obs1'].scale == 4.0 and df.normalization['obs1'].ref_row == 2
+        assert df.normalization['obs1'][0].scale == 4.0 and df.normalization['obs1'][0].ref_row == 2
 
         # peak on the sparse obs1: /nanmax(=4); NaN row stays NaN.
         dp = mk(); dp.normalize_to_peak(cols=[1])

--- a/tests/test_gradient_assembly.py
+++ b/tests/test_gradient_assembly.py
@@ -1030,20 +1030,36 @@ def test_normalization_peak_closed_form():
     assert obj is not None
 
 
-@pytest.mark.parametrize('method', ['peak', 'init', 'zero', 'unit', ('floor', 0.03)],
-                         ids=['peak', 'init', 'zero', 'unit', 'floor'])
-def test_normalization_chain_rule_matches_finite_difference(method):
+@pytest.mark.parametrize('chain', [
+    ['peak'], ['init'], ['zero'], ['unit'], [('floor', 0.03)],
+    [('floor', 0.03), 'peak'], ['peak', ('floor', 0.03)], ['init', 'zero'], ['zero', 'unit'],
+    [('floor', 0.03), 'peak', 'zero'],
+], ids=['peak', 'init', 'zero', 'unit', 'floor',
+        'floor+peak', 'peak+floor', 'init+zero', 'zero+unit', 'floor+peak+zero'])
+def test_normalization_chain_rule_matches_finite_difference(chain):
     """Every normalization method's threaded derivative ``∂(normalize(raw))/∂θ`` matches a
     central finite difference of PyBNF's own ``Data.normalize`` applied to the raw column
     perturbed along its sensitivity -- an implementation-independent oracle (the analytic chain
     rule vs the actual reduction). Covers the row-coupling each method introduces: ``peak``/
     ``init`` (one reference row), ``unit`` (baseline + max), ``zero`` (every row, through σ),
-    and ``floor`` (the additive max-fraction offset, ADR-0066/#533)."""
+    and ``floor`` (the additive max-fraction offset, ADR-0066/#533).
+
+    Also covers **chains** of two or more ``Data``-level transforms (#539, ADR-0102), which the
+    fold composes stage by stage rather than reading a single record: each ordering of
+    floor/peak (the offset before and after the divisor it feeds), an ``init, zero`` and a
+    ``zero, unit`` (``zero`` couples every row through σ, on either side of the chain), and a
+    three-stage chain. The same FD oracle arbitrates all of them, since ``Data.normalize``
+    applies the whole chain."""
     raw = np.array([2.0, 9.0, 5.0, 3.0])
     dk = np.array([0.5, -2.0, 1.3, -0.7])
     sigma = 1.0
+    # One transform is spelled bare (the whole-column form the config emits for a single
+    # method); a chain is the ordered-pair list, one entry per stage, on the one scored column.
+    method = chain[0] if len(chain) == 1 else [(m, ['Stot']) for m in chain]
     sim = _sim_with_sensitivities(raw.copy(), d_param=dk)
     sim.normalize(method)
+    assert [r.method for r in sim.normalization['Stot']] == [
+        m[0] if isinstance(m, tuple) else m for m in chain]
     exp = _exp(np.zeros(4), sigma)
     routing = ExperimentRouting(routes={'k': ParamRoute.single('k', PARAM, 'k', 1.0)})
     free = _free(('k', 'uniform_var', 0.0, 10.0, 0.3))
@@ -1069,7 +1085,7 @@ def test_floor_normalization_closed_form():
     rho, sigma = 0.03, 1.0
     sim = _sim_with_sensitivities(raw.copy(), d_param=dk)
     sim.normalize(('floor', rho))              # records method='floor', ref_row=argmax
-    assert sim.normalization['Stot'].method == 'floor'
+    assert [r.method for r in sim.normalization['Stot']] == ['floor']
     exp = _exp(np.zeros(4), sigma)
     routing = ExperimentRouting(routes={'k': ParamRoute.single('k', PARAM, 'k', 1.0)})
     free = _free(('k', 'uniform_var', 0.0, 10.0, 0.3))
@@ -1080,20 +1096,78 @@ def test_floor_normalization_closed_form():
     np.testing.assert_allclose(res.jacobian[:, 0], expected / sigma)
 
 
-def test_chained_data_normalizations_refuse():
-    """Only the LAST ``Data``-level transform of a chain is recorded (the sidecar is keyed by
-    column) and every rule reads the *raw* sensitivities, so a two-transform chain
-    (``floor 0.03, peak``) cannot be composed from what is retained -- refused rather than
-    threading peak's rule alone over an already-floored column (#533)."""
+def test_chained_data_normalizations_fold_stage_by_stage():
+    """A chain of two ``Data``-level transforms composes to the closed form of the *composition*,
+    not to the last stage's rule alone (#539, ADR-0102 -- refused before it).
+
+    ``floor 0.03, peak`` is the arbiter: the floor moves the column the peak then divides by, so
+    the peak's divisor ``Y = M + ρM`` and its reference row both belong to the floored column,
+    and the reference term carries the floor's own ``(1+ρ)``::
+
+        y_i = x_i + ρM,     ∂y_i/∂θ = s_i + ρ s_p
+        n_i = y_i / y_p,    ∂n_i/∂θ = (∂y_i/∂θ - n_i ∂y_p/∂θ) / y_p
+
+    Threading peak's rule alone over the already-floored column -- what the pre-#533 path did --
+    would use the *raw* ``s_p`` for the reference term and miss the ``(1+ρ)`` entirely."""
     raw = np.array([2.0, 9.0, 5.0, 3.0])
-    sim = _sim_with_sensitivities(raw.copy(), d_param=np.array([0.5, -2.0, 1.3, -0.7]))
-    sim.normalize([(('floor', 0.03), ['Stot']), ('peak', ['Stot'])])
-    assert sim.normalization['Stot'].method == 'peak' and sim.normalization['Stot'].chained
+    dk = np.array([0.5, -2.0, 1.3, -0.7])
+    rho = 0.03
+    sim = _sim_with_sensitivities(raw.copy(), d_param=dk)
+    sim.normalize([(('floor', rho), ['Stot']), ('peak', ['Stot'])])
+
+    # The sidecar is the chain in order, and the floor's own output -- which peak overwrote --
+    # rode along on its record, since its rule reads it and the column no longer holds it.
+    floor_rec, peak_rec = sim.normalization['Stot']
+    assert (floor_rec.method, peak_rec.method) == ('floor', 'peak')
+    np.testing.assert_allclose(floor_rec.values, raw + rho * np.max(raw))
+    assert peak_rec.values is None             # the last stage's output IS the column
+
     exp = _exp(np.zeros(4), 1.0)
     routing = ExperimentRouting(routes={'k': ParamRoute.single('k', PARAM, 'k', 1.0)})
     free = _free(('k', 'uniform_var', 0.0, 10.0, 0.3))
-    with pytest.raises(GradientNotSupported, match='chain'):
-        assemble_gaussian_gradient(ChiSquareObjective(), [(sim, exp, routing)], free)
+
+    res = assemble_gaussian_gradient(ChiSquareObjective(), [(sim, exp, routing)], free)
+
+    p = int(np.argmax(raw))
+    floored = raw + rho * np.max(raw)
+    d_floored = dk + rho * dk[p]               # every row picks up the same max-row term
+    normed = floored / floored[p]
+    expected = (d_floored - normed * d_floored[p]) / floored[p]
+    np.testing.assert_allclose(res.jacobian[:, 0], expected)
+
+    # The defect this closes: peak's rule alone, over the raw sensitivities, is a different
+    # number -- it misses the floor's contribution to the divisor's own derivative.
+    wrong = (dk - normed * dk[p]) / floored[p]
+    assert not np.allclose(res.jacobian[:, 0], wrong)
+
+
+def test_chain_built_by_direct_normalize_calls_folds():
+    """The chain's retained values come from the ``normalize_to_*`` methods themselves, not from
+    the ``Data.normalize`` chain driver, so a chain assembled by calling two of them directly
+    folds identically (#539). ``unit`` is the one that records *after* it moves the column (it
+    subtracts the baseline for every column first), so it is the stage this pins."""
+    raw = np.array([2.0, 9.0, 5.0, 3.0])
+    dk = np.array([0.5, -2.0, 1.3, -0.7])
+    sim = _sim_with_sensitivities(raw.copy(), d_param=dk)
+    sim.normalize_to_peak(cols=[1])
+    sim.normalize_to_unit_scale(cols=[1])      # consumes the peak-normalized column
+    np.testing.assert_allclose(sim.normalization['Stot'][0].values, raw / np.max(raw))
+
+    exp = _exp(np.zeros(4), 1.0)
+    routing = ExperimentRouting(routes={'k': ParamRoute.single('k', PARAM, 'k', 1.0)})
+    free = _free(('k', 'uniform_var', 0.0, 10.0, 0.3))
+
+    res = assemble_gaussian_gradient(ChiSquareObjective(), [(sim, exp, routing)], free)
+
+    def normed_of(column):
+        d = Data.from_columns(np.column_stack([TIMES, column]), ['time', 'Stot'])
+        d.normalize_to_peak(cols=[1])
+        d.normalize_to_unit_scale(cols=[1])
+        return d.data[:, 1]
+
+    h = 1e-6
+    fd = (normed_of(raw + h * dk) - normed_of(raw - h * dk)) / (2.0 * h)
+    np.testing.assert_allclose(res.jacobian[:, 0], fd, rtol=1e-5, atol=1e-7)
 
 
 def _scaled_objective(obj, cols=('Stot',), data_key='expt'):


### PR DESCRIPTION
Closes #539.

`normalization` is an ordered **chain** (ADR-0066), and five of its transforms — `peak`, `init`, `zero`, `unit`, `floor` — rewrite the column in `Data`. Stacking two of them

```
normalization pStat = floor 0.03, peak
```

was refused on every gradient `job_type`: the sidecar recording *how* a column was normalized kept one record per column, so the second transform overwrote the first one's facts and its intermediate values went with them. (Before #533 there was no refusal — half these chains threaded the last transform's rule over a column an earlier transform had already moved, a wrong Jacobian with nothing said, which is why the guard was put in.)

## The fix

**The sidecar becomes a list per column**, in chain order. `_record_normalization` appends rather than replaces, and `NormalizationRecord.chained` is gone — "this column was normalized before" is now `index > 0`, not a flag to keep in sync.

**The gradient folds it.** Every method's closed form is already a chain rule in *that stage's own* inputs, and nothing in it assumes those inputs are raw. So `_normalized_sensitivity` returns an accessor with `tensor_sens`'s own `(col, row)` signature and wraps it once per stage, each wrapper reading the accessor the previous stage returned — a stage calls its predecessor exactly as the un-chained rule called the tensor, and the per-method rules move to `_stage_rule` unchanged. One transform is the one-iteration case and threads precisely the rule it always did.

**What a stage needed and did not have is its own output values**, since only the last stage's survive in the column. A stage whose output the next transform is about to overwrite keeps a copy on its record (`NormalizationRecord.values`), handed to it at the moment the next stage records — the values that stage is about to replace *are* the previous stage's output. A column normalized once (every fit in the wild) keeps nothing: `values` stays `None`, the values are read from the `Data`, and the sidecar costs what it did before.

Two alternatives were weighed and rejected. *Retain the raw column and replay the chain forward in the gradient*: that writes each transform's **forward** formula a second time, in `assembly.py`, next to the derivative — two implementations of one reduction, free to drift. *Invert the chain backwards from the final values*: founders on `zero`, whose μ is never recorded, only σ.

The capture lives in the `normalize_to_*` methods rather than the `Data.normalize` chain driver, so a chain assembled by calling two of them directly is recorded as correctly as one spelled in a config. Two methods moved to get the moment right: `normalize_to_zero` now centres and scales out of place (it used to mutate the column and record afterwards, by which time the column held the *output*), and `normalize_to_unit_scale` — the one method that moves the column before it records, since it subtracts the baseline for every column first — snapshots what it consumed at the top. **The arithmetic in both is unchanged**, so every normalized value is identical: this changes what is recorded alongside them, not what is computed.

The fold memoizes per (stage, row) — a stage reads its predecessor at rows other than the scored one (the reference row a divisor is read from, and for `zero` *every* row), so without a memo the work multiplies down the chain per scored row. The tensor at the bottom is left unmemoized, so a single transform costs exactly what it did.

## Verification

- **The parametrized FD gate gains five chains**: `floor 0.03, peak` and `peak, floor 0.03` (the additive offset on each side of the divisor it feeds), `init, zero` and `zero, unit` (the method that couples every row, on each side), and the three-stage `floor 0.03, peak, zero` — each matched against a central difference of PyBNF's *own* `Data.normalize` on the perturbed raw column, an implementation-independent oracle.
- **The old refusal test becomes a closed-form arbiter** for `floor 0.03, peak`, where the peak's divisor is the *floored* max and its reference term carries the floor's own `(1+ρ)` — asserted positively and with a negative control: peak's rule alone over the raw sensitivities (what the pre-#533 path computed) is a different number, and the test says so.
- **A chain built by direct `normalize_to_*` calls** folds to the same finite difference, pinning the capture points rather than the chain driver.
- **The sidecar's own contract**: records in chain order, the overwritten stage's retained values equal the mid-chain column, the last stage retains nothing.
- **The config path**: `normalization x = floor 0.03, peak` compiles to its two ordered pairs *in chain order* (the previous chain test's second element, `scale`, is not a `Data` transform and never had an order to get wrong).
- Full default suite green: **3590 passed, 20 skipped**.

## Scope

`data.py` (the list sidecar, `values`, `_chain_stage_input`, the two relocated captures) and `gradient/assembly.py` (the fold, the stage memo, the unchanged rules). Unchanged: every normalized value; `scale` (ADR-0099), which is not a `Data` transform and composes with a chain of any length as before; the PEtab export boundary, which still refuses normalization.

Docs: ADR-0102 (new), ADR-0099's deferral marked closed, `config_keys.rst`, `gradient_fitting.rst`, CHANGELOG.
