### PR TITLE
perf(sbml): warm the engine template on the scalar path too, so clones inherit the Jacobian (#544)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ All notable changes to PyBNF are documented below. This project adheres to
 ## [Unreleased]
 
 ### Fixed
+- **A scalar fit no longer re-derives the analytical Jacobian on every action (#544).** #543
+  warmed the cached engine template so clones inherit the compiled sensitivity RHS, but it
+  warmed only when a sensitivity request was active — and the same never-warmed-parent shape
+  costs the **scalar** path too, one artifact over. bngsim's `Simulator.__init__` calls
+  `model.prepare_analytical_jacobian()`; PyBNF builds that `Simulator` on the per-action
+  *clone*, and the clone is discarded. `clone()` carries the `_jac_attempted` sentinel parent
+  → child precisely so a derived parent yields cheap clones, but nothing ever derived it on
+  the parent, so every scalar action re-ran the SymPy derivation from scratch. PyBNF now warms
+  unconditionally and lets the *shape* of the warm depend on the request rather than gating
+  the warm itself on there being one. Measured through PyBNF's own action path on the
+  44-species `yeast_cell_cycle` model: **0.1542 s → 0.0057 s per action** (27x), derivations
+  10 of 10 → 0 of 10. As reported on #544, `Smith_BMCSystBiol2013` goes 0.0401 s → 0.0224 s,
+  20 of 20 → 0 of 20, taking that job's shipped 64,000-evaluation `cmaes` budget from ~36
+  core-hours to ~14. Trajectories are bit-for-bit unchanged. Two guards this needed: a scalar
+  warm must **not** satisfy a later gradient warm (bngsim clears a plain-RHS artifact and
+  regenerates it at the first sensitivity request, so a scalar-warmed template would be
+  correct and save the gradient path nothing) — the warm-state predicate and the per-shape
+  attempt memo both answer "not yet" for the sensitivity shape; and a model with **no ODE
+  action** warms nothing, since bngsim derives the Jacobian under ODE dispatch and nowhere
+  else, having deliberately moved it off the load path so a stochastic run never pays SymPy.
+  Applies to every SBML/Antimony fit through
+  `sbml_backend = bngsim`, on every `job_type`; the larger the model the bigger
+  the effect, since the derivation scales with the network and the solve does not. The `.net`
+  backend clones from a held `_engine_model` in the same never-warmed shape and does re-attempt
+  the derivation per evaluation (measured 4 of 4), but it costs it essentially nothing: a BNGL
+  network is all-Elementary, so bngsim takes its closed-form C++ Jacobian rather than SymPy —
+  0.1511 s → 0.1472 s per evaluation on `egfr_ground.net` (356 species), within noise. Left
+  alone rather than warmed on a measurement that does not justify it.
 - **A gradient fit no longer rebuilds the analytical sensitivity RHS on every action (#543).**
   `_get_engine_template` caches one loaded bngsim model per SBML text per worker process and
   #415 clones it per action, precisely so the parse and the derived Jacobian are paid once.
@@ -24,10 +52,12 @@ All notable changes to PyBNF are documented below. This project adheres to
   action goes from 3.731 s to 0.327 s. Invisible in a profile
   that looks at simulation — the integration is untouched and all of the difference is
   `Simulator(...)` construction. A **scalar** (metaheuristic) fit never generates the source at
-  all, warms nothing, and is byte-identical to before this existed (0.194 s per action either
-  way), which bounds who this helps. The `.net` backend clones from a held `_engine_model` in
-  the same never-warmed shape but is **not** affected: its `.net` codegen memo is keyed on the
-  file path rather than on generated source, and it regenerates nothing (measured 0 of 6).
+  all and was left untouched here (0.194 s per action either way), which bounded who *this*
+  entry helps; #544 above warms it for a different artifact. The `.net` backend clones from a
+  held `_engine_model` in the same never-warmed shape but is **not** affected here: its `.net`
+  codegen memo is keyed on the file path rather than on generated source, and it regenerates
+  nothing (measured 0 of 6).
+- **A pre-equilibration condition that doses a species from a fitted parameter no longer reports a
   zero gradient column for it (#538, ADR-0101).** `preequilibrate:` applies its condition inline,
   so a species target becomes a `setConcentration` written *before* the first phase — and
   `Model.set_concentration` reads an assigned amount as a literal initial condition

--- a/pybnf/bngsim_sbml_model.py
+++ b/pybnf/bngsim_sbml_model.py
@@ -43,13 +43,16 @@ logger = logging.getLogger(__name__)
 _ENGINE_TEMPLATE_CACHE = {}
 
 
-# Templates a warm was already ATTEMPTED on, keyed like _ENGINE_TEMPLATE_CACHE and
-# holding the template the attempt was made on. Only failures need remembering -- a
-# successful warm is legible on the template itself (_template_is_warm) -- but a warm
-# that raises leaves no trace there, and re-attempting it per action would double the
-# very cost this is meant to remove. Holding the template rather than a bare flag keeps
-# the memo honest if the cache above is cleared and reloaded (the tests do): a fresh
-# template is not the one that failed, so it is warmed. See issue #543.
+# Templates a warm was already ATTEMPTED on, keyed by (template key, whether the attempt
+# asked for sensitivities) and holding the template the attempt was made on. Only failures
+# need remembering -- a successful warm is legible on the template itself
+# (_template_is_warm / _template_jacobian_is_warm) -- but a warm that raises leaves no
+# trace there, and re-attempting it per action would double the very cost this is meant to
+# remove. The shape is part of the key because the two warms are not interchangeable: a
+# scalar warm, failed or successful, must not talk a later gradient warm out of running
+# (#544). Holding the template rather than a bare flag keeps the memo honest if the cache
+# above is cleared and reloaded (the tests do): a fresh template is not the one that
+# failed, so it is warmed. See issues #543 and #544.
 _ENGINE_TEMPLATE_WARM_ATTEMPTED = {}
 
 
@@ -68,6 +71,23 @@ def _template_is_warm(template):
         and (getattr(template, '_codegen_so_path', '')
              or getattr(template, '_codegen_c_source', ''))
     )
+
+
+def _template_jacobian_is_warm(template):
+    """Has ``template`` already attempted the analytical-Jacobian derivation (#544)?
+
+    bngsim derives the (SymPy) Functional Jacobian at most once per model, guarded by the
+    ``_jac_attempted`` sentinel that ``clone()`` copies parent -> child precisely so "a
+    derived parent [yields] cheap, already-warm clones". That sentinel is what a clone
+    reads, so it -- and not whether the derivation produced a *complete* analytical
+    Jacobian -- is what "already warm" has to mean here: a model that fell back to finite
+    differences has still paid the derivation, and neither it nor its clones re-pay it.
+
+    Deliberately weaker than :func:`_template_is_warm`, which the sensitivity warm needs:
+    a scalar-warmed template answers True here and False there, so a gradient fit whose
+    template was scalar-warmed still takes its own (sensitivity-shaped) warm.
+    """
+    return bool(getattr(template, '_jac_attempted', False))
 
 
 from ._bngsim_caps import (
@@ -747,11 +767,12 @@ class BngsimSbmlModelNoTimeout(Model):
         """Return the process-cached base engine model for this SBML text.
 
         Loads the bngsim model once per worker process (paying the libSBML
-        parse + analytical-Jacobian derivation) and reuses it for every
-        evaluation, cloning it for each per-evaluation parameter application.
-        See issue #415. On the gradient path the template is also *warmed* on
-        first use, so the clones inherit the compiled sensitivity RHS instead of
-        each rebuilding it (:meth:`_warm_engine_template`, issue #543).
+        parse) and reuses it for every evaluation, cloning it for each
+        per-evaluation parameter application. See issue #415. The template is
+        also *warmed* on first use, so the clones inherit the derived analytical
+        Jacobian -- and, on the gradient path, the compiled sensitivity RHS --
+        instead of each rebuilding it (:meth:`_warm_engine_template`, issues
+        #543 and #544).
         """
         key = getattr(self, '_engine_template_key', None)
         if key is None:
@@ -764,34 +785,69 @@ class BngsimSbmlModelNoTimeout(Model):
         self._warm_engine_template(key, template)
         return template
 
+    def _runs_ode_actions(self):
+        """Does any action on this model integrate deterministically (#544)?
+
+        The warm below builds artifacts only an ODE solve consumes: bngsim derives the
+        analytical Jacobian and runs its large-model codegen under ``dispatch == 'ode'``
+        and nowhere else, having deliberately moved both off the model-load path so that
+        "non-ODE dispatch ... never pays the SymPy derivation or the codegen compile". A
+        gillespie-only model would otherwise warm something no action of its own ever
+        reads, which is a cost this backend does not pay today. ``actions`` is set in
+        ``__init__``, before any template fetch; an empty list -- a template pulled by a
+        structural query on a model that has none yet -- simply defers the warm to the
+        first fetch that has one, which is what the warm's laziness is for anyway.
+        """
+        return any(self._resolve_method(act) == 'ode'
+                   for act in getattr(self, 'actions', ()))
+
     def _warm_engine_template(self, key, template):
-        """Build the sensitivity codegen artifact on the template itself, once (#543).
+        """Build the ODE-solve artifacts on the template itself, once (#543, #544).
 
-        Every gradient action needs a compiled analytical sensitivity RHS, and bngsim
-        builds one in ``Simulator.__init__`` whenever the constructor is handed
-        ``sensitivity_params``/``sensitivity_ic``. PyBNF builds that Simulator on the
-        per-action *clone* (:meth:`_prepare_engine_model` -> :meth:`_make_simulator`), so
-        the clone is what discovers the artifact and records it -- and the clone is thrown
-        away at the end of the action. ``clone()`` copies the artifact parent -> child but
-        nothing copies it back, so the template's ``_codegen_so_path`` stays empty forever
-        and every action regenerates the C source, and every symbolic derivative behind it,
-        because bngsim keys its compiled ``.so`` on a hash of that source. Constructing one
-        throwaway Simulator **on the template** writes the artifact where ``clone()`` can
-        find it, and every action from then on inherits it. It does not need to run: the
-        codegen happens at construction. Measured through this backend's own action path on
-        Smith_BMCSystBiol2013 (133 species, 16 sensitivity columns) as 2.015 s -> 0.537 s per
-        action, source generated 4 of 4 times before and 0 of 4 after, tensor bit-identical.
+        Every ODE action needs a derived analytical Jacobian, and every *gradient* action
+        additionally needs a compiled analytical sensitivity RHS. bngsim builds both in
+        ``Simulator.__init__`` -- the Jacobian always, the sensitivity RHS whenever the
+        constructor is handed ``sensitivity_params``/``sensitivity_ic``. PyBNF builds that
+        Simulator on the per-action *clone* (:meth:`_prepare_engine_model` ->
+        :meth:`_make_simulator`), so the clone is what derives and records them -- and the
+        clone is thrown away at the end of the action. ``clone()`` copies both parent ->
+        child but nothing copies them back, so the template stays cold forever and every
+        action re-pays: the SymPy Jacobian derivation, and (on the gradient path) the
+        regenerated C source and every symbolic derivative behind it, because bngsim keys
+        its compiled ``.so`` on a hash of that source. Constructing one throwaway Simulator
+        **on the template** writes both where ``clone()`` can find them, and every action
+        from then on inherits them. It does not need to run: both happen at construction.
 
-        Warmed with the sensitivity request the actions will use, not a scalar stand-in.
-        bngsim emits the output-sensitivity evaluator only when the model carries
-        ``_want_output_sens`` -- which the *constructor* sets from its own sensitivity
-        arguments -- and clears a plain-RHS artifact to regenerate it at the first
-        sensitivity request, so a scalar-warmed template would be correct and save nothing.
-        Which parameters are requested does not enter into it: the emitted source covers the
-        whole RHS, and only that flag varies. The scalar path warms nothing at all -- it
-        never generates the source (measured on the same model: 0.194 s per action warmed or
-        not), so there is nothing there to save, and it stays byte-identical to before this
-        existed.
+        Measured per action, the Smith rows as reported on #543 and #544 and the yeast row
+        through this backend's own ``execute``:
+
+        =========================  ================  =========  =========  ==========
+        model                      path              unwarmed   warmed     re-derived
+        =========================  ================  =========  =========  ==========
+        Smith (133 sp, 16 cols)    sensitivity        2.015 s    0.537 s    4/4 -> 0/4
+        Smith                      scalar             0.0401 s   0.0224 s  20/20 -> 0
+        yeast_cell_cycle (44 sp)   scalar             0.1542 s   0.0057 s  10/10 -> 0
+        =========================  ================  =========  =========  ==========
+
+        Tensor and trajectory are bit-identical either way; only how many times the engine
+        re-derives things that depend on model structure alone changes. The ``.net`` backend
+        clones from a held ``_engine_model`` in this same shape and does re-attempt the
+        derivation per evaluation (4 of 4), but a BNGL network is all-Elementary, so bngsim
+        takes its closed-form C++ Jacobian instead of SymPy and the re-attempt costs
+        essentially nothing (0.1511 -> 0.1472 s per evaluation on ``egfr_ground.net``, 356
+        species). Left unwarmed rather than warmed on a number that does not justify it.
+
+        Two shapes, and the weaker one must not satisfy the stronger. bngsim emits the
+        output-sensitivity evaluator only when the model carries ``_want_output_sens`` --
+        which the *constructor* sets from its own sensitivity arguments -- and clears a
+        plain-RHS artifact to regenerate it at the first sensitivity request. So a
+        scalar-warmed template is correct for a gradient fit but saves it nothing, and
+        ``_template_is_warm`` (unlike :func:`_template_jacobian_is_warm`) answers False for
+        one, leaving the gradient warm to run. Which parameters are requested does not
+        enter into it: the emitted source covers the whole RHS, and only that flag varies,
+        so the warm is keyed on the template's own state rather than on a shape tuple. The
+        reverse direction needs nothing: a sensitivity warm derives the Jacobian on its way
+        past.
 
         A warm that raises is recorded and swallowed, so it costs one attempt per process
         rather than one per action. Everything that can fail here -- a rate law bngsim cannot
@@ -800,20 +856,25 @@ class BngsimSbmlModelNoTimeout(Model):
         refusal handling (and the #536 event-sensitivity diagnosis) it already has. An
         optimization must not become a new place for the fit to die.
         """
+        if not self._runs_ode_actions():
+            return
         kwargs = self._sensitivity_request_kwargs('ode')
-        if not kwargs:
+        if kwargs:
+            if _template_is_warm(template):
+                return
+        elif _template_jacobian_is_warm(template):
             return
-        if _template_is_warm(template):
+        memo_key = (key, bool(kwargs))
+        if _ENGINE_TEMPLATE_WARM_ATTEMPTED.get(memo_key) is template:
             return
-        if _ENGINE_TEMPLATE_WARM_ATTEMPTED.get(key) is template:
-            return
-        _ENGINE_TEMPLATE_WARM_ATTEMPTED[key] = template
+        _ENGINE_TEMPLATE_WARM_ATTEMPTED[memo_key] = template
         try:
             bngsim.Simulator(template, method='ode', **kwargs)
         except Exception as exc:
             logger.debug(
                 'Could not warm the engine template for model %s (%s: %s); each action '
-                'will build its own sensitivity RHS.', self.name, type(exc).__name__, exc)
+                'will build its own Jacobian%s.', self.name, type(exc).__name__, exc,
+                ' and sensitivity RHS' if kwargs else '')
 
     def _set_engine_value_if_present(self, engine_model, name, value):
         """Apply a value to the engine model. Returns True iff it is a species.

--- a/tests/test_bngsim_sbml_bridge.py
+++ b/tests/test_bngsim_sbml_bridge.py
@@ -835,9 +835,10 @@ def test_template_loaded_before_the_request_is_warmed_at_the_first_action(
     This is the real fit's ordering, not a corner case: the differentiability gate
     (``has_discrete_events``, #461/#536) and the seed reader (``backend_ic_sensitivity``,
     #537) both load the template during ``_after_init``, *before* ``_setup_gradient_path``
-    activates the sensitivity request. Warming eagerly at load would therefore bake a
-    scalar-shaped artifact in and save nothing, so the warm is checked on every template
-    fetch and fires at the first action that actually asks for sensitivities.
+    activates the sensitivity request. That fetch now takes the scalar warm (#544), which
+    must not be mistaken for the sensitivity one: a scalar-shaped artifact would save the
+    gradient path nothing, so the warm is checked on every template fetch and the
+    sensitivity shape fires at the first action that actually asks for sensitivities.
     """
     calls = _count_generated_sources(monkeypatch)
     model = bngsim_sbml_model.BngsimSbmlModelNoTimeout(
@@ -880,13 +881,17 @@ def test_warming_the_template_does_not_change_the_tensor(tmp_path, _clear_engine
 
 
 @pytest.mark.bngsim_sbml
-def test_scalar_path_never_warms_the_template(tmp_path, monkeypatch, _clear_engine_cache):
-    """A scalar (metaheuristic) fit warms nothing and generates no source (#543).
+def test_scalar_path_warms_the_template_without_the_sensitivity_shape(
+        tmp_path, monkeypatch, _clear_engine_cache):
+    """A scalar (metaheuristic) fit warms too, with the scalar shape (#544).
 
-    The scalar path never asks for an analytical sensitivity RHS, so there is nothing there
-    to save -- measured on Smith_BMCSystBiol2013 at 0.194 s per action warmed or not. It must
-    stay byte-identical to before the warm existed, which means no stray ``Simulator``
-    construction on the template.
+    The same never-warmed-parent shape #543 fixed for the sensitivity RHS costs the scalar
+    path one artifact over: ``Simulator.__init__`` derives the analytical Jacobian, PyBNF
+    builds that Simulator on the per-action clone, and the clone is discarded -- so every
+    scalar action re-derives from scratch (measured 0.1542 -> 0.0057 s per action on the
+    44-species yeast_cell_cycle model through this backend's own action path, derivations
+    10/10 -> 0/10). It warms with a plain ODE ``Simulator``: no sensitivity request, so no
+    C source is generated, and the template must not come out looking sensitivity-warm.
     """
     calls = _count_generated_sources(monkeypatch)
     action = pset.TimeCourse({'time': '100', 'step': '10'})
@@ -900,10 +905,164 @@ def test_scalar_path_never_warms_the_template(tmp_path, monkeypatch, _clear_engi
         )
         model.execute(str(tmp_path), 'raf_scalar_%d' % i, 100)
 
-    assert calls['n'] == 0
-    assert bngsim_sbml_model._ENGINE_TEMPLATE_WARM_ATTEMPTED == {}
+    assert calls['n'] == 0, (
+        'the scalar warm generated C source %d times; it asks for no sensitivities, so it '
+        'must not reach the output-sensitivity emitter' % calls['n'])
     template, = bngsim_sbml_model._ENGINE_TEMPLATE_CACHE.values()
+    assert bngsim_sbml_model._template_jacobian_is_warm(template), (
+        'the cached template carries no derived Jacobian after three scalar actions, so '
+        'its clones each re-derive one')
+    assert not bngsim_sbml_model._template_is_warm(template), (
+        'a scalar warm must not leave the template looking sensitivity-warm; a gradient '
+        'fit that inherited it would build a plain-RHS artifact bngsim then discards')
+    key, = bngsim_sbml_model._ENGINE_TEMPLATE_CACHE
+    assert list(bngsim_sbml_model._ENGINE_TEMPLATE_WARM_ATTEMPTED) == [(key, False)], (
+        'the attempt memo must record the shape it warmed, so a later gradient warm is '
+        'not mistaken for one already tried')
+
+
+@pytest.mark.bngsim_sbml
+def test_scalar_actions_derive_the_jacobian_once(tmp_path, monkeypatch, _clear_engine_cache):
+    """The analytical Jacobian is derived once per process, not once per scalar action (#544).
+
+    The count, not the clock, is the regression guard: bngsim's ``_jac_attempted`` sentinel
+    is what ``clone()`` carries parent -> child, so an unwarmed template hands every clone
+    ``False`` and each action re-runs the SymPy derivation. Warming the template flips the
+    sentinel once and every clone thereafter inherits it.
+    """
+    import bngsim._model as _bngsim_model
+
+    derivations = {'n': 0}
+    original = _bngsim_model.Model.prepare_analytical_jacobian
+
+    def _counting(self):
+        if not self._jac_attempted:
+            derivations['n'] += 1
+        return original(self)
+
+    monkeypatch.setattr(_bngsim_model.Model, 'prepare_analytical_jacobian', _counting)
+
+    action = pset.TimeCourse({'time': '100', 'step': '10'})
+    for i, k3 in enumerate((8000., 8100., 8200., 8400.)):
+        ps = pset.PSet([
+            pset.FreeParameter('K3', 'uniform_var', 2000., 10000., k3),
+            pset.FreeParameter('K5', 'uniform_var', 0.1, 1., 0.3),
+        ])
+        model = bngsim_sbml_model.BngsimSbmlModelNoTimeout(
+            _raf_xml_path(), _raf_xml_path(), pset=ps, actions=(action,),
+        )
+        model.execute(str(tmp_path), 'raf_jac_%d' % i, 100)
+
+    assert derivations['n'] == 1, (
+        'the analytical Jacobian was derived %d times across 4 scalar actions; expected '
+        'exactly 1 (the template warm, inherited by every clone)' % derivations['n'])
+
+
+@pytest.mark.bngsim_sbml
+def test_scalar_warm_does_not_satisfy_a_later_gradient_warm(
+        tmp_path, monkeypatch, _clear_engine_cache):
+    """A scalar-warmed template still takes the sensitivity warm (#544).
+
+    The two warms are not interchangeable and the weaker one runs first in every real
+    gradient fit: the differentiability gate loads the template during ``_after_init``,
+    before ``_setup_gradient_path`` activates the request, so the template is already
+    scalar-warmed by the time a sensitivity request exists. bngsim clears a plain-RHS
+    artifact and regenerates it at the first sensitivity request, so a template left at the
+    scalar warm would be correct and would save the gradient fit nothing. Both the warm-state
+    predicate and the per-shape attempt memo have to answer "not yet" for the sensitivity
+    shape.
+    """
+    calls = _count_generated_sources(monkeypatch)
+    scalar_action = pset.TimeCourse({'time': '100', 'step': '10'})
+    scalar = bngsim_sbml_model.BngsimSbmlModelNoTimeout(
+        _raf_xml_path(), _raf_xml_path(), pset=pset.PSet(_raf_params()),
+        actions=(scalar_action,),
+    )
+    scalar.execute(str(tmp_path), 'raf_scalar_first', 100)
+
+    template, = bngsim_sbml_model._ENGINE_TEMPLATE_CACHE.values()
+    assert bngsim_sbml_model._template_jacobian_is_warm(template)
     assert not bngsim_sbml_model._template_is_warm(template)
+    assert calls['n'] == 0
+
+    _run_raf_gradient_actions(tmp_path, (8000., 8100., 8200.))
+
+    assert bngsim_sbml_model._template_is_warm(template), (
+        'the scalar warm suppressed the sensitivity warm; every gradient action would then '
+        'regenerate the C source that #543 removed')
+    assert calls['n'] == 1, (
+        'the sensitivity RHS source was generated %d times after a scalar-warmed template; '
+        'expected exactly 1 (one warm, inherited by every clone)' % calls['n'])
+
+
+@pytest.mark.bngsim_sbml
+@pytest.mark.parametrize('kwargs, actions', [
+    ({'integrator': 'gillespie'}, (pset.TimeCourse({'time': '10', 'step': '2'}),)),
+    ({}, (pset.TimeCourse({'time': '10', 'step': '2', 'suffix': 's', 'method': 'ssa'}),)),
+    ({}, ()),
+])
+def test_stochastic_only_model_does_not_warm(kwargs, actions, _clear_engine_cache):
+    """A model with no ODE action warms nothing: it would derive what nothing reads (#544).
+
+    bngsim derives the Jacobian and runs its codegen under ODE dispatch and nowhere else,
+    having deliberately moved both off the model-load path so a stochastic run never pays
+    SymPy. Warming unconditionally would hand that cost straight back to the fits bngsim
+    excused from it. Asserted at ``_get_engine_template``, which is where the decision is
+    made -- raf itself refuses SSA (reversible non-mass-action reactions), so an
+    ``execute`` here would fail for a reason that has nothing to do with the warm.
+
+    The empty-action case is the ordering guard: a template pulled by a structural query
+    before any action exists must defer the warm rather than skip or misshape it.
+    """
+    model = bngsim_sbml_model.BngsimSbmlModelNoTimeout(
+        _raf_xml_path(), _raf_xml_path(), pset=pset.PSet(_raf_params()),
+        actions=actions, **kwargs,
+    )
+    template = model._get_engine_template()
+
+    assert bngsim_sbml_model._ENGINE_TEMPLATE_WARM_ATTEMPTED == {}
+    assert not bngsim_sbml_model._template_jacobian_is_warm(template)
+    assert not bngsim_sbml_model._template_is_warm(template)
+
+
+@pytest.mark.bngsim_sbml
+def test_scalar_warm_does_not_change_the_trajectory(tmp_path, _clear_engine_cache):
+    """The scalar warm is an optimization only: the trajectory is bit-for-bit unchanged (#544).
+
+    The warmed template is what every action clones from, so the derived Jacobian rides into
+    every evaluation -- and the Jacobian steers CVODE's Newton iteration, which is exactly
+    the kind of thing that shifts a trajectory in the last digits rather than raising.
+    Pinned against the unwarmed path, exactly.
+    """
+    def _run():
+        out = []
+        for i, k3 in enumerate((8000., 8100.)):
+            ps = pset.PSet([
+                pset.FreeParameter('K3', 'uniform_var', 2000., 10000., k3),
+                pset.FreeParameter('K5', 'uniform_var', 0.1, 1., 0.3),
+            ])
+            model = bngsim_sbml_model.BngsimSbmlModelNoTimeout(
+                _raf_xml_path(), _raf_xml_path(), pset=ps,
+                actions=(pset.TimeCourse({'time': '100', 'step': '10'}),),
+            )
+            out.append(model.execute(str(tmp_path), 'raf_scalar_pin_%d' % i, 100)
+                       ['time_course'].data)
+        return out
+
+    unwarmed_cls = bngsim_sbml_model.BngsimSbmlModelNoTimeout
+    original_warm = unwarmed_cls._warm_engine_template
+    unwarmed_cls._warm_engine_template = lambda self, key, template: None
+    try:
+        cold = _run()
+    finally:
+        unwarmed_cls._warm_engine_template = original_warm
+
+    bngsim_sbml_model._ENGINE_TEMPLATE_CACHE.clear()
+    bngsim_sbml_model._ENGINE_TEMPLATE_WARM_ATTEMPTED.clear()
+    warm = _run()
+
+    for cold_data, warm_data in zip(cold, warm):
+        npt.assert_allclose(warm_data, cold_data, rtol=0, atol=0)
 
 
 @pytest.mark.bngsim_sbml


### PR DESCRIPTION
Closes #544.

#543 warmed the cached engine template so clones inherit the compiled sensitivity RHS, but it warmed only when a sensitivity request was active — and it said so, reporting the scalar path as "completely unaffected" on the strength of a source-generation count. The same never-warmed-parent shape costs the scalar path too, one artifact over.

bngsim's `Simulator.__init__` calls `model.prepare_analytical_jacobian()` for every ODE dispatch. PyBNF builds that `Simulator` on the per-action **clone**, and the clone is discarded at the end of the action. `clone()` carries the `_jac_attempted` sentinel parent → child precisely so that "a derived parent [yields] cheap, already-warm clones", but nothing ever derived it on the parent, so every scalar action re-ran the SymPy derivation from scratch.

The fix is to warm unconditionally and let the **shape** of the warm depend on the request, rather than gating the warm itself on there being one.

## Measurement

Per action, the Smith rows as reported on #543/#544 and the yeast row measured here through the backend's own `execute`:

| model | path | unwarmed | warmed | re-derived |
|---|---|---|---|---|
| Smith (133 sp, 16 cols) | sensitivity | 2.015 s | 0.537 s | 4/4 → 0/4 |
| Smith | scalar | 0.0401 s | 0.0224 s | 20/20 → 0/20 |
| `yeast_cell_cycle` (44 sp) | scalar | 0.1542 s | 0.0057 s | 10/10 → 0/10 |

27x on yeast. Trajectories are bit-for-bit unchanged; only how many times the engine re-derives something that depends on model structure alone changes. On the Smith numbers, that job's shipped 64,000-evaluation `cmaes` budget goes from ~36 core-hours to ~14.

## Two guards this needed

**A scalar warm must not satisfy a later gradient warm.** This is not a corner case — it is the ordering of every real gradient fit, since the differentiability gate (`has_discrete_events`, #461/#536) and the seed reader (`backend_ic_sensitivity`, #537) fetch the template during `_after_init`, *before* `_setup_gradient_path` activates the request. bngsim clears a plain-RHS artifact and regenerates it at the first sensitivity request, so a template left at the scalar warm would be correct and would save the gradient path nothing. Two things had to answer "not yet": the warm-state predicate (`_template_is_warm` already did; the new `_template_jacobian_is_warm` is deliberately the weaker one) and the attempt memo, now keyed on the shape as well as the template. The reverse direction needs nothing — a sensitivity warm derives the Jacobian on its way past.

**A model with no ODE action warms nothing.** bngsim derives the Jacobian and runs its large-model codegen under `dispatch == "ode"` and nowhere else, having deliberately moved both off the model-load path so that non-ODE dispatch "never pays the SymPy derivation or the codegen compile" (bngsim GH #145). Warming unconditionally would hand that cost straight back to the fits bngsim excused from it, so `_runs_ode_actions` gates it. An empty action list — a template pulled by a structural query before any action exists — defers the warm rather than skipping or misshaping it.

## One correction to the issue's write-up

#544 says `.net` models are unaffected "for the same reason they were unaffected by #543". That reason was the file-path-keyed codegen memo, which has nothing to do with the Jacobian. The `.net` backend clones from a held `_engine_model` in this same never-warmed shape and **does** re-attempt the derivation per evaluation (measured 4 of 4).

It is left alone anyway, but on the measurement rather than the prediction: a BNGL network is all-Elementary, so bngsim takes its closed-form C++ Jacobian instead of SymPy and the re-attempt costs essentially nothing — 0.1511 → 0.1472 s per evaluation on `egfr_ground.net` (356 species), within noise.

## Tests

Six new regression guards in `tests/test_bngsim_sbml_bridge.py`, all counting derivations rather than clocking them, since the count is what the sentinel actually controls:

- the scalar path warms with the scalar shape and generates no C source;
- the Jacobian is derived once across four scalar actions;
- a scalar-warmed template still takes the sensitivity warm;
- a gillespie model, an `ssa`-method action, and an action-less model each warm nothing;
- the scalar warm leaves the trajectory bit-identical.

`test_scalar_path_never_warms_the_template` is renamed and inverted — #543 pinned "the scalar path warms nothing", which is exactly what this changes.

Full suite, branch vs `main` on the same machine: **260 failed / 3251 passed** vs **260 failed / 3245 passed**, with zero failures unique to the branch. The 260 are pre-existing and all want `BNG2.pl` / `BNGPATH`, which this machine does not have. The +6 are the new tests. `uvx ruff@0.15.14 check .` passes.

## Also

#543's CHANGELOG entry ate the opening line of the #538 bullet directly below it. Restored.
