### PR TITLE
perf(sbml): give back the per-species tightening ADR-0103 charged the whole model for (#549, ADR-0105)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,48 @@ All notable changes to PyBNF are documented below. This project adheres to
 
 ## [Unreleased]
 
+### Changed
+- **An SBML model on `sbml_backend = bngsim` no longer charges every species for the tolerance its
+  smallest one needs (#549, ADR-0105, supersedes ADR-0103).** ADR-0103 derived a single `atol` from
+  the median species value because bngsim's `Simulator.run` took only a scalar, and it wrote down
+  what that cost: `Brannmark_JBC2010` reads `3.3e-10`, which holds its `IR`/`IRS`/`X` species at ~10
+  to `3.3e-11` *relative* — three decades tighter than the `rtol` that governs them — to buy a
+  resolution for a `1.76e-9` transient that the same ADR had already decided not to chase. Now that
+  lanl/bngsim#196 routes a vector to `CVodeSVtolerances`, that over-tightening is given back per
+  species: `atol_i = clamp(sbml_rtol * y_i, the model's scalar, 1e-8)`. Measured on 100 points
+  sampled from Brannmark's own fit box with the fit's sensitivity request applied, 39 dead
+  simulations become **33**, in 428 s rather than 576 s.
+  **The lower clamp is the change, and it is there because the obvious rule loses.** "Resolve each
+  species to `rtol` of its own magnitude", full stop — which is what #549 proposes — puts that
+  transient at `1.76e-17`, and on the same 100 points killed **91 of 100**: ADR-0103's withdrawn
+  *minimum* rule reappearing one species at a time. The `1e-16` floor #549 asks about rescued
+  nothing (91 either way), because the damage is done well above it. A tolerance below `rtol*|y|` is
+  inert until a species has decayed far below its nominal value, and what it then demands is that a
+  species which has decayed into nothing be resolved as if it had not; telling that apart from a
+  genuinely tiny species needs the trajectory, not the initial values. So every entry now lies in
+  `[the model's scalar, 1e-8]`: no species is integrated more tightly than PyBNF integrates it
+  today, and no model that runs today can start failing. A control confirms the mechanism is the
+  values and not the plumbing — the same scalar sent as a uniform vector reproduces the baseline
+  exactly, 39 and 39.
+  Over the 23-slug subset-I corpus 19 models take the same scalar call as today and the 4 that #546
+  tightened take vectors, which is the shape of a refund: only a model that was charged can receive
+  one. A species declared at zero has no magnitude of its own and falls out of the same expression
+  at the model's scalar, leaving it where ADR-0103 put it.
+  The derivation stays a property of the **model file** — read off the SBML document at load, held
+  for the whole fit, never re-derived from the fit point, which is why bngsim's state-reading `AUTO`
+  token is not used: a tolerance that moved with a fitted initial condition would put a step in the
+  objective wherever the derivation crossed a rounding boundary, and it would be invisible, since
+  the objective still looks correct and only the search behaves oddly. ADR-0103's median-derived
+  scalar does not retire either — it becomes the steady-state convergence cutoff, passed explicitly
+  whenever the vector is in force, because bngsim's own fallback for that cutoff is the Simulator's
+  `1e-8` rather than anything derived from the vector, and taking it would silently return every
+  `time = inf` measurement and every pre-equilibration phase to "equilibrium at t = 0" on a
+  small-scale model. `sbml_atol` remains a single number and remains the off-switch: stating it
+  integrates every species at that value and pins the pre-#196 code path bit-for-bit. A bngsim
+  without the capability keeps ADR-0103's scalar unchanged, detected by name (`bngsim.AUTO`) rather
+  than by version, because the build that first carried #196 declares the same version string as the
+  wheel that predates it.
+
 ### Fixed
 - **A PEtab v1 problem whose parameter table merely *has* a prior column no longer loses its log
   estimation scale (#548).** `petab1to2_preserve_scale` re-injects the `parameterScale` that

--- a/docs/adr/0103-a-constant-absolute-ode-tolerance-is-a-statement-about-a-models-units-so-the-bngsim-sbml-path-derives-atol-from-the-models-own-species-magnitude-rather-than-inheriting-bng2pls.md
+++ b/docs/adr/0103-a-constant-absolute-ode-tolerance-is-a-statement-about-a-models-units-so-the-bngsim-sbml-path-derives-atol-from-the-models-own-species-magnitude-rather-than-inheriting-bng2pls.md
@@ -1,6 +1,11 @@
 # A constant absolute ODE tolerance is a statement about a model's units, so the bngsim SBML path derives `atol` from the model's own species magnitude rather than inheriting BNG2.pl's (issue #546)
 
-**Status: Accepted and implemented (2026-08-06).** `Giordano_Nature2020`'s gradient was wrong on
+**Status: Accepted and implemented (2026-08-06); superseded by ADR-0105 (2026-08-10).** Everything
+below still holds, including the median and the reason the minimum was withdrawn — ADR-0105 keeps
+this scalar as the *floor* of a per-species vector and as the steady-state convergence cutoff, and
+changes only what "Deliberately out" below says needed a backend change first (lanl/bngsim#196).
+
+`Giordano_Nature2020`'s gradient was wrong on
 41 of its 50 fitted parameters, by up to 26%, with no refusal and no warning. The cause is not the
 model's piecewise-in-time structure, which the backend already handles; it is that bngsim's
 absolute solver tolerance — BNG2.pl's `1e-8` — is larger than that model's entire state.

--- a/docs/adr/0105-a-scalar-absolute-tolerance-charges-every-species-for-the-smallest-one-so-the-bngsim-sbml-path-gives-that-tightening-back-per-species-while-refusing-to-tighten-any-species-past-what-it-integrates-today.md
+++ b/docs/adr/0105-a-scalar-absolute-tolerance-charges-every-species-for-the-smallest-one-so-the-bngsim-sbml-path-gives-that-tightening-back-per-species-while-refusing-to-tighten-any-species-past-what-it-integrates-today.md
@@ -1,0 +1,273 @@
+# A scalar absolute tolerance charges every species for the smallest one, so the bngsim SBML path gives that tightening back **per species** — while refusing to tighten any species past what it integrates today (issue #549)
+
+**Status: Accepted and implemented (2026-08-10). Supersedes ADR-0103.** ADR-0103 was correct for
+the capability available when it was written: bngsim's `Simulator.run` took a scalar `atol`, so the
+only question open to it was *which* scalar. lanl/bngsim#196 removed that constraint. What #549
+proposed doing with the new freedom turned out to be wrong, and the measurement that says so is the
+substance of this ADR.
+
+## What ADR-0103 could not say
+
+ADR-0103 derived `atol` from the model and let it only ever tighten, with the scale read as the
+**median** strictly-positive nominal species value. It documented the cost of the median in its own
+text:
+
+> The median rather than the minimum, because `Brannmark_JBC2010` seeds one transient intermediate
+> at `1.8e-9` against principal species at `0.1..10`, and resolving *that* asks for `1e-17`, which
+> makes the model fail outright on `mxstep` at interior fit points.
+
+That is a compromise, not a rule. CVODE's error test weights state *i* by `rtol*|y_i| + atol`, so a
+scalar `atol` is a single statement about a state that may span decades. `Brannmark_JBC2010` reads
+`3.3e-10`, which is **too tight for the top**: `IR`, `IRS` and `X` sit at ~10, so `3.3e-10` puts
+them under an absolute floor a hundredth of what `rtol` alone would ask — `3.3e-11` *relative* —
+and that is the end of the model that never needed anything. ADR-0103 listed the fix under
+**Deliberately out**, naming the blocker (`Simulator.run` takes a scalar). lanl/bngsim#196 is that
+backend change: `run(atol=...)` now accepts a sequence and routes it to `CVodeSVtolerances`, on a
+code path that leaves a float taking `CVodeSStolerances` bit-for-bit unchanged.
+
+## The decision, and the measurement that shaped it
+
+**Derive one absolute tolerance per species from the model's nominal state, clamped into
+`[the model's own scalar, the backend default]`.**
+
+```python
+atol_i = clamp(rtol * y_i, scalar_atol, default_atol)
+```
+
+Both clamps carry an argument.
+
+### The upper clamp is ADR-0103's, applied per species
+
+Nothing is ever loosened past the backend default, so a species of order one keeps `1e-8` and a
+model whose species are all of order one integrates exactly as before. This cannot be delegated:
+bngsim's own `derive_atol` has **no** upper clamp and returns `1.0e-07` for `Brannmark`'s `X`,
+looser than the default. `test_only_ever_tighten_is_pybnfs_to_apply_not_the_backends` pins that
+against the library rather than against a copy of our own arithmetic.
+
+### The lower clamp is the model's own scalar, because the alternative was measured and lost
+
+This is where #549's plan and this ADR part company. Read literally, "resolve each species to
+`rtol` of its own magnitude" says `Brannmark`'s `IRp` (nominal `1.76e-9`) should be integrated at
+`1.76e-17`. That rule was implemented and measured, on 100 points sampled from Brannmark's own fit
+box the way a multi-start start is sampled, with the fit's union sensitivity request applied — the
+isolate #549 asks for under "claim A", no optimizer in the loop:
+
+| rule | simulations dead / 100 | CVODES `mxstep` lines | wall clock |
+|---|---:|---:|---:|
+| ADR-0103's scalar (`3.3e-10` for every species) | **39** | 3542 | 576 s |
+| the same scalar, sent as a uniform *vector* | **39** | 3957 | 587 s |
+| per-species, floored at `1e-16` (#549 as written) | **91** | 6220 | 985 s |
+| per-species, no floor at all | **91** | — | — |
+| **per-species, floored at the model's own scalar** | **33** | 2930 | 428 s |
+
+Every failure in every row is a solver failure; none is a `wall_time_sim` kill. The first round of
+this measurement ran the regimes concurrently and had to be discarded and re-run serially, because
+a 10 s per-simulation budget on a contended machine kills points the tolerance had nothing to do
+with.
+
+Three things follow.
+
+- **#549's rule as written more than doubles the deaths on the slug it was filed from.** It is
+  ADR-0103's withdrawn *minimum* rule reappearing one species at a time, and the reasoning that
+  withdrew it did not stop being true when the tolerance became a vector.
+
+- **#549's "one genuinely open design question" — whether to keep `_DERIVED_ATOL_FLOOR = 1e-16` —
+  is moot.** The issue frames it as a 5.7x decision on one species of one model, settleable by
+  measurement. The measurement says 91 either way: the damage is done well above `1e-16`, by the
+  species landing at `1.1e-13` and `1.6e-12`. Under the clamp adopted here nothing reaches `1e-16`
+  at all, since the scalar is itself clamped at or above it.
+
+- **The uniform-vector control lands exactly on the baseline, 39 = 39.** So the vector plumbing and
+  the `CVodeSVtolerances`-vs-`SStolerances` switch are a non-event, and the differences above are
+  attributable to the tolerance *values* alone. That control is what makes the rest of the table
+  worth anything.
+
+**Why the tightening hurts.** A tolerance below `rtol*|y_i|` is inert until `|y_i|` falls far below
+its *nominal* value, and what it then demands is that a species which has decayed into nothing be
+resolved as if it had not. Initial values cannot tell that case apart from a species that genuinely
+lives down there. Distinguishing them needs the trajectory, which is lanl/bngsim#213's
+`CVodeWFtolerances`, not this.
+
+**So what this change does is give back ADR-0103's over-tightening to the species that never needed
+it, and nothing else.** Every entry lands in `[scalar_atol, default_atol]`, so no species is
+integrated more tightly than PyBNF integrates it today and **no model that runs today can start
+failing** — a property, not a hope, and asserted as one
+(`test_no_species_is_ever_integrated_more_tightly_than_it_is_today`).
+
+### The rest of the decision
+
+- **A species with no magnitude falls out of the same expression.** `rtol * 0` clamps up to
+  `scalar_atol`, so a species seeded at zero is measured against the model's own scale and needs no
+  rule of its own. That is also the no-regression choice: bngsim's `derive_atol` substitutes the
+  smallest strictly positive entry instead, which on `Giordano_Nature2020` — this change's control
+  — would put its four zero-seeded species at `1.667e-08` against a model scale of `3.67e-07`,
+  tightening them 22x for no measured reason.
+
+- **The vector is a constant of the model, not of the fit point.** Read off the document at load and
+  memoized, exactly as ADR-0103's scalar was, and for the same two reasons: a tolerance that moved
+  with a fitted initial condition would put a step in the objective wherever the derivation crossed
+  a rounding boundary, and a gradient fit's scalar (line-search) evaluations must be integrated to
+  the same accuracy as the sensitivities they are compared against or the two disagree about what
+  the objective *is*. bngsim ships an `AUTO` token that derives from the model's **live** state —
+  the one the next `run()` would start from, which on a fit is the fit point — so it is the wrong
+  tool here. PyBNF fits initial conditions on several problems; bare `AUTO` would be invisible in
+  the usual way, since the objective still looks correct, the finite-difference gradient check still
+  passes, and only the search behaves oddly.
+
+- **The vector is ordered to the *engine* model's `species_names`,** the names bngsim indexes its
+  state by. `normalize_atol_vector` (lanl/bngsim#212) takes the length/position contract once at
+  setup rather than at the first `run()`, which on a fit is a long way from where the vector was
+  built.
+
+- **ADR-0103's scalar does not retire; it changes job.** bngsim falls its steady-state cutoff back
+  to the scalar `atol` when unset — "also when a per-species atol is in force (issue #196): the
+  criterion is a single norm over every species and has no per-species reading to take" — and
+  `_resolve_atol` returns the *Simulator's own* `1e-8` in that case, not anything derived from the
+  vector. Left alone that silently reverts ADR-0103's steady-state fix: on a model whose states are
+  ~1e-8, `||dx/dt|| < 1e-8` is satisfied *at t = 0*, so every `time = inf` measurement (ADR-0086)
+  and every pre-equilibration phase (ADR-0052/0104) would return the initial state and call it
+  equilibrium. So the median-derived scalar is passed explicitly as `steady_state_tol` whenever the
+  vector is in force. One statement about the model's magnitude still governs both, and today's
+  steady-state behaviour is reproduced exactly.
+
+- **`sbml_atol` stays scalar-only, and stating it switches the derivation off.** PyBNF's config
+  grammar is scalar (`numkeys_float`); a per-species vector in a `.conf` would need a new
+  species-keyed grammar, and the case for it is hypothetical. Keeping it scalar also keeps a clean
+  off-switch: stating it pins the pre-#196 `CVodeSStolerances` path bit-for-bit, ulp included.
+
+- **A vector that says nothing a scalar does not is not sent.** True of 19 of the 23 subset-I slugs
+  — which is what "ADR-0103 had nothing to give back here" looks like, since a model the scalar
+  derivation left at the backend default has no over-tightening to undo.
+
+## What actually moves
+
+| slug | ADR-0103 scalar | ADR-0105 vector `[min, max]` | released |
+|---|---:|---|---:|
+| `Armistead_CellDeathDis2024` | 4.94e-09 | `[4.944e-09, 1.000e-08]` | 2 of 4 |
+| `Bertozzi_PNAS2020` | 5.00e-09 | `[5.000e-09, 9.000e-09]` | 1 of 3 |
+| `Brannmark_JBC2010` | 3.30e-10 | `[3.302e-10, 1.000e-08]` | 4 of 9 |
+| `Giordano_Nature2020` | 3.67e-15 | `[3.667e-15, 1.000e-08]` | 4 of 13 |
+
+The other 19 take the scalar call unchanged. These are exactly the four slugs #546 tightened, which
+is the shape of the change: it is a *refund*, so only a model that was charged can receive one.
+
+Two consequences worth stating rather than discovering:
+
+- **`Raia_CancerResearch2011` does not move**, although an earlier reading of #549 predicted it
+  would. Its smallest species is `0.34`, so an unclamped derivation would tighten it from the
+  backend default to `3.4e-09`. Under this ADR the vector never tightens, so Raia keeps the scalar
+  path. #549's verification bullet — "the 19 that ADR-0103 left untouched should be unchanged" — is
+  therefore satisfied literally, which the plan it was written against would not have been.
+
+- **`Smith_BMCSystBiol2013` reaches the ordering fallback** and keeps its scalar: bngsim renames a
+  species whose SBML id collides with an Antimony reserved word, so its `NULL`/`null` load as
+  `_ant_NULL`/`_ant_null` and the vector cannot be ordered against the document without guessing. A
+  mis-ordered vector would assign one species' tolerance to another and nothing downstream would say
+  so. It costs nothing here — Smith's vector would have been elementwise the default anyway — and
+  the fallback is taken *after* the "says nothing a scalar does not" test, so a model in Smith's
+  position whose vector was a no-op stays silent rather than warning about a difference that would
+  not have existed.
+
+## Scope
+
+**In:** `_bngsim_caps.py` (`BNGSIM_HAS_PER_SPECIES_ATOL`); `bngsim_sbml_model.py`
+(`_derive_atol_vector`, `_compute_nominal_species_values`, `_per_species_atol`,
+`_derive_per_species_atol`, `_run_tolerance_kwargs`, and the tolerance kwargs on `_run_simulation`'s
+`sim.run` call); `docs/config_keys.rst`.
+
+**Out (unchanged):** every BNGL/net model, whose tolerances come from BNG2.pl's actions block. Every
+stochastic (`ssa`) run, which has no CVODE tolerances to set. The RoadRunner SBML backend. Every
+model the scalar derivation left at the backend default. Any install without lanl/bngsim#196, which
+keeps ADR-0103's scalar bit-for-bit and runs every fit it runs today.
+
+**The capability probe is a name, not a version floor.** The build that first carried #196 declares
+`0.12.2`, which is also the version of the released wheel 25 commits behind it, so a version floor
+would report *present* on an install without the capability — the expensive direction, since the
+vector would then be handed to a `run` that takes only a scalar. `AUTO` and `normalize_atol_vector`
+are exported from the package namespace by lanl/bngsim#212 and listed in `__all__`; probing the two
+names PyBNF actually calls keeps the flag honest if either ever moves. (This was worth getting
+right: when #549 was filed both lived in the private `bngsim._atol`, so `hasattr(bngsim, 'AUTO')`
+returned `False` on a build that *had* the capability — silently routing a capable install down the
+scalar fallback, with a result that still looked correct.)
+
+**Deliberately out:** resolving a species *below* the model's own scale, and a tolerance that
+follows the trajectory — the same thing from two directions, and the reason the lower clamp exists.
+A vector built from initial values cannot see a species that starts at order one and decays to
+something tiny, nor tell a genuinely-tiny species from one that is merely transient. That is
+lanl/bngsim#213's `CVodeWFtolerances`, which takes a #196 vector as its *ceiling*, and it is also
+what `Weber_BMC2015` needs: Weber's seven species all start **above** one, so every entry of its
+nominal-state vector is the backend default and the vector is elementwise the scalar it replaces.
+#549 originally claimed Weber as a second slug this change would unblock; it is not reachable from
+here, and it and the `decades` config surface belong to the follow-up.
+
+## Verification
+
+Two claims are braided together in #549 and they cost very different amounts. **A**, that the
+`mxstep` tax is lifted, is a property of simulating at a parameter point. **B**, that
+`Brannmark_JBC2010` now solves — final `OG` under 1.92 rather than 3.21 — needs a real fit, is a
+claim about the benchmark corpus rather than about PyBNF's tolerance handling, and belongs to
+wshlavacek/BNGL-Models#38 where the 16-of-23 count is tracked. Gating a code review on an hours-long
+stochastic fit whose single-run outcome near the threshold would not settle much is the wrong trade.
+This ADR verifies **A**, and the box-sample table above is that verification: 39 dead simulations to
+33, and 576 s to 428 s, on 100 points of Brannmark's own fit box.
+
+- **The corpus derivation**, over all 23 subset-I slugs: 19 unchanged, and the 4 that #546 tightened
+  moving to vectors. Table above.
+- **Nothing moves that should not**, checked as an objective rather than as a tolerance.
+  `tools/nominal_check.py` over all 23 slugs, run twice in the same process against the same bngsim
+  build with `BNGSIM_HAS_PER_SPECIES_ATOL` forced off and on — a cleaner control than the committed
+  `nominal_check.json`, whose values predate this wheel and would have conflated this change with
+  everything since:
+
+  | | slugs | `J_paper` |
+  |---|---:|---|
+  | scalar path | 19 | **bit-identical**, every one |
+  | vector, and unmoved anyway | 1 (`Giordano_Nature2020`) | **bit-identical** |
+  | vector, moved | 3 | 8.2e-15 (`Bertozzi`), 1.8e-09 (`Armistead`), 1.9e-08 (`Brannmark`) |
+
+  Giordano is the interesting row: it takes a vector, and its objective does not move at all, because
+  the four species released are the ones already governed by the relative term. The three that do
+  move, move in the eighth significant digit or beyond — a trajectory integrated at a different
+  tolerance, not a different model.
+- **`Giordano_Nature2020` does not regress** — the slug ADR-0103 was written for, and the one whose
+  wrong gradient started this line. Its four released species are the ones sitting at or above the
+  model's scale; its small ones keep `3.67e-15`. Its assembled gradient against central differences,
+  at an interior bounds-clear point, worst relative error over all 50 fitted columns:
+
+  | | `h = 1e-3` | `h = 3e-3` | `h = 1e-2` |
+  |---|---:|---:|---:|
+  | ADR-0103's scalar | 5.89e-04 | 2.45e-03 | 1.50e-03 |
+  | ADR-0105's vector | 8.57e-04 | 2.56e-04 | 1.11e-03 |
+
+  Read that by the corpus's own rule (`pybnf-jobs/.../tools/README.md`): a real defect does not move
+  with `h`, FD noise does. Both rows move with `h` by more than they differ from each other, and the
+  ordering between them flips — the vector is worse at `1e-3`, ten times better at `3e-3`. So there
+  is no defect in either and no difference between them that this instrument can resolve; both sit
+  two to three decades under the 7.7e-02 #546 opened on. A single `h` would have supported a
+  confident wrong statement in either direction, which is exactly what that README warns about.
+- **The mechanism, in a fixture** (`tests/test_sbml_solver_tolerances.py`): a species at 10 in a
+  model whose median is 1e-2, so ADR-0103 hands it `1e-10` and the vector gives it the `1e-8` it was
+  always entitled to. 288 CVODE steps against 377, with the released species still matching its
+  closed form to 2.0e-05 wherever it is clear of its own tolerance.
+- **The boundary, also in a fixture.** `test_the_vector_does_not_resolve_what_adr_0103_declined_to`
+  asserts that a species *below* the model's scale keeps the compromise ADR-0103 struck for it and
+  is still under-resolved. It is tempting to read "one tolerance per species" as "every species is
+  finally resolved against its own magnitude", and the measurement above is why that reading is not
+  shipped; a test is a better place to say so than a comment.
+- **The safety property, asserted as a property**: every entry lies in
+  `[scalar_atol, default_atol]`.
+- **The scalar tests did not move.** They now also cover the fallback path — an older bngsim, an
+  explicit `sbml_atol`, a model with no over-tightening to undo.
+- **The full default suite, against the same suite on the base commit** — run by stashing the
+  working tree rather than in a second worktree, because PyBNF is installed editable and pinned to
+  this checkout, so a worktree would have run the base commit's *tests* against the branch's *code*.
+  263 failed / 35 errors on both, and the 298 `FAILED`/`ERROR` lines are byte-identical between the
+  two; the branch passes 21 more tests, which is exactly the number added here. (The 263 are this
+  machine's BNG2.pl-dependent tests, which need a BNG2.pl it does not have.)
+
+Relevant ADRs: **0103** (superseded — the scalar, and why the median was the least-bad single
+answer), **0086** and **0052**/**0104** (the steady-state and pre-equilibration paths the explicit
+`steady_state_tol` protects), **0093** (the wall-clock budget a tolerance change spends against).
+Relevant issues: lanl/bngsim **#196** (the vector), **#212** (its public export), **#213** (the
+trajectory-following successor, and `Weber_BMC2015`), **#546** (the scalar this supersedes).
+Closes issue **#549**.

--- a/docs/config_keys.rst
+++ b/docs/config_keys.rst
@@ -1222,22 +1222,51 @@ Algorithm Options
   ``begin actions`` block instead — that is BioNetGen's own surface for them.
 
   Leave both unset unless you have a reason not to. ``sbml_rtol`` then takes the
-  backend default (``1e-8``), and ``sbml_atol`` is **derived from the model**: it is
-  set to ``sbml_rtol`` times the *median* strictly-positive species initial value in
-  the SBML file, clamped to at most the backend default (``1e-8``) and at least
-  ``1e-16``. Because the clamp only ever tightens, a model whose species are of order
-  one keeps the backend default exactly. The median, rather than the smallest species,
-  keeps one negligible transient intermediate from driving the tolerance for the whole
-  model.
+  backend default (``1e-8``), and the absolute tolerance is **derived from the model**
+  in two steps.
 
-  The derivation exists because a constant absolute tolerance is a statement about the
+  First a single number for the model: ``sbml_rtol`` times the *median* strictly-positive
+  species initial value in the SBML file, clamped to at most the backend default
+  (``1e-8``) and at least ``1e-16``. Because that clamp only ever tightens, a model whose
+  species are of order one keeps the backend default exactly. The median, rather than the
+  smallest species, keeps one negligible transient intermediate from driving the tolerance
+  for the whole model.
+
+  That number exists because a constant absolute tolerance is a statement about the
   model's units: CVODE weights each state by ``rtol*|y| + atol``, so ``atol = 1e-8``
   declares values below ``1e-8`` to be noise. That is true of a model in molecule
   counts and false of, say, a population-*fraction* epidemic model whose species sit
   around ``1e-7``, whose whole early trajectory then carries no significant digits —
-  and whose forward sensitivities, which a gradient fit reads, carry fewer still. Set
-  ``sbml_atol`` explicitly if your model lives below the ``1e-16`` floor, or if you
-  want a looser tolerance than the derivation picks.
+  and whose forward sensitivities, which a gradient fit reads, carry fewer still.
+
+  Then, **per species**, each one is released back toward the backend default as far as
+  its own initial value allows: species *i* is integrated at ``sbml_rtol`` times its own
+  initial value, but never below the model-wide number above and never above ``1e-8``.
+  A species whose initial value is at or below the model's median keeps the model-wide
+  number, as does one declared at zero.
+
+  The point of the second step is that one number over-charges the large species. A model
+  with principal species at ``10`` and one transient intermediate at ``1e-9`` gets a
+  tolerance that holds the former far tighter than ``sbml_rtol`` alone would, which costs
+  steps and sometimes the simulation, and buys nothing. Note the direction: this step only
+  ever *loosens*, so no species is integrated more tightly than the model-wide number, and
+  a model that simulates today cannot start failing. Resolving the *small* species better
+  than the model-wide number is deliberately not attempted — it was measured, and it
+  roughly doubled the failed simulations on the model it was meant to help.
+
+  The derivation is a property of the **model file**, not of the point being fitted: it
+  is read off the species initial values in the SBML document once, at load, and held
+  for the whole fit. A tolerance that moved with a fitted initial condition would put a
+  step in the objective wherever the derivation crossed a rounding boundary.
+
+  Set ``sbml_atol`` explicitly if your model lives below the ``1e-16`` floor, or if you
+  want a different tolerance from the one the derivation picks. It is a **single number**
+  and it replaces the whole derivation: stating it integrates every species at that value,
+  which is also the way to pin the pre-per-species behaviour exactly.
+
+  A bngsim build without per-species tolerance support stops after the first step and
+  integrates every species at the model-wide number, so an older bngsim runs every fit it
+  ran before.
 
   Default: unset (see above)
 

--- a/pybnf/_bngsim_caps.py
+++ b/pybnf/_bngsim_caps.py
@@ -198,6 +198,26 @@ BNGSIM_HAS_EVENT_SENS = bool(
 )
 
 
+# A **per-species** absolute tolerance: ``Simulator.run(atol=...)`` accepts a vector and
+# routes it to ``CVodeSVtolerances`` (lanl/bngsim#196), so a model spanning ten decades no
+# longer has to pick one number for both ends. ADR-0103 derived a scalar because that was
+# the whole of what the backend offered; ADR-0105 derives the vector.
+#
+# The probe is a name, not a version. The build that first carried #196 still declares
+# 0.12.2 -- the same string as the released wheel 25 commits behind it -- so a version
+# floor here would report *present* on an install that does not have it, and that is the
+# expensive direction: the vector would be handed to a ``run`` that takes only a scalar.
+# ``AUTO`` and ``normalize_atol_vector`` are exported from the package namespace by
+# lanl/bngsim#212 and both are listed in ``__all__``; probing the two names PyBNF
+# actually calls keeps the flag honest if either ever moves. Absent, the SBML backend
+# keeps ADR-0103's scalar bit-for-bit, so an older bngsim runs every fit it runs today.
+BNGSIM_HAS_PER_SPECIES_ATOL = bool(
+    BNGSIM_AVAILABLE
+    and hasattr(bngsim, 'AUTO')
+    and hasattr(bngsim, 'normalize_atol_vector')
+)
+
+
 def event_sens_min_version():
     """The bngsim version whose forward sensitivities survive a discrete event (#536)."""
     return '%d.%d.%d' % _BNGSIM_EVENT_SENS_VERSION

--- a/pybnf/bngsim_sbml_model.py
+++ b/pybnf/bngsim_sbml_model.py
@@ -92,6 +92,56 @@ def _derive_atol(scale, rtol, default_atol, *, model_name=None, warned=None):
     return min(max(wanted, _DERIVED_ATOL_FLOOR), default_atol)
 
 
+def _derive_atol_vector(nominal, scalar_atol, rtol, default_atol):
+    """One absolute tolerance per species, from the model's nominal state (ADR-0105).
+
+    ``atol_i = clamp(rtol * y_i, scalar_atol, default_atol)``, with ``y_i`` the species'
+    own nominal magnitude and ``scalar_atol`` the model-wide number :func:`_derive_atol`
+    gives it. Both clamps carry an argument and neither is decoration:
+
+    * **The upper clamp is ADR-0103's, per species.** Nothing is ever loosened past the
+      backend default, so a species of order one keeps ``1e-8`` and a model whose species
+      are all of order one integrates exactly as before. bngsim's own ``derive_atol`` has
+      no upper clamp -- it returns ``1.0e-07`` for ``Brannmark_JBC2010``'s ``X``, looser
+      than the default -- so only-ever-tighten is PyBNF's to apply, and is applied here.
+
+    * **The lower clamp is the model's own scalar, and it is there because the
+      alternative was measured and lost.** Read literally, "resolve each species to
+      ``rtol`` of its own magnitude" says ``Brannmark``'s ``IRp`` (nominal ``1.76e-9``)
+      should be integrated at ``1.76e-17``. Over 100 points sampled from that model's fit
+      box, with the fit's own sensitivity request applied, that rule **killed 91
+      simulations out of 100 against the scalar's 39** -- ADR-0103's withdrawn
+      *minimum* rule reappearing one species at a time. Nothing rescued it: the
+      ``1e-16`` floor #549 asks about made no difference at all (91 either way), because
+      the damage is done well above it, by the species at ``1.1e-13`` and ``1.6e-12``.
+
+      A tolerance below ``rtol*|y_i|`` only ever binds once ``|y_i|`` has fallen far
+      below its *nominal* value, and what it then demands is that a species which has
+      decayed into nothing be resolved as if it had not. Initial values cannot tell that
+      case apart from a species that genuinely lives down there; that needs the
+      trajectory (lanl/bngsim#213).
+
+    So what this vector does is **give back ADR-0103's over-tightening to the species
+    that never needed it**, and nothing else. Every entry lands in
+    ``[scalar_atol, default_atol]``, so no species is integrated more tightly than PyBNF
+    integrates it today and no model that runs today can start failing. On the same 100
+    box points that is 39 dead simulations to **33**, in 428 s rather than 576 s.
+    ``Brannmark``'s ``IR``/``IRS``/``X`` sit at ~10 and were being held to ``3.3e-10`` --
+    ``3.3e-11`` *relative*, three decades tighter than the ``rtol`` that governs them --
+    to buy a resolution for ``IRp`` that ADR-0103 had already decided not to chase.
+
+    A species declared at zero falls out of the same expression rather than needing a
+    rule: ``rtol * 0`` clamps up to ``scalar_atol``, i.e. a species with no magnitude of
+    its own is measured against the model's. That is also the no-regression choice --
+    bngsim's ``derive_atol`` substitutes the smallest strictly positive entry instead,
+    which on ``Giordano_Nature2020`` would tighten its four zero-seeded species 22x.
+
+    ``nominal`` is ordered; the caller owns the ordering contract against
+    ``Model.species_names``.
+    """
+    return np.clip(rtol * np.asarray(nominal, dtype=float), scalar_atol, default_atol)
+
+
 # Process-level cache of loaded bngsim engine models, keyed by a hash of the
 # model's base SBML text. The engine model -- including the analytically
 # derived (SymPy) Jacobian -- depends only on the model *structure*, not on
@@ -152,6 +202,7 @@ def _template_jacobian_is_warm(template):
 
 from ._bngsim_caps import (
     BNGSIM_HAS_OUTPUT_SENS,
+    BNGSIM_HAS_PER_SPECIES_ATOL,
     BNGSIM_HAS_SBML,
     BNGSIM_SBML_ERROR,
     bngsim,
@@ -296,13 +347,19 @@ class BngsimSbmlModelNoTimeout(Model):
     _config_rtol = None
     _config_atol = None
 
-    # The model's typical (median strictly-positive) nominal species value, set from the
-    # parsed document by _extract_sbml_structure; ``None`` = no scale to derive an atol
-    # from, which keeps the backend default. Memo for the derived pair, and the names the
-    # floor warning has already fired for. All class attributes so an instance built via
-    # object.__new__ answers "cannot say" rather than raising.
+    # The model's per-species nominal values in bngsim's units, and their typical (median
+    # strictly-positive) magnitude, both set from the parsed document by
+    # _extract_sbml_structure. ``None`` = nothing to derive an atol from, which keeps the
+    # backend default. ``_tolerance_cache`` memoizes the derived *scalar* pair (ADR-0103,
+    # still the steady-state cutoff under ADR-0105) and ``_atol_vector_cache`` the derived
+    # per-species vector together with the species ordering it was built for.
+    # ``_atol_floor_warned`` holds the names the floor warning has already fired for. All
+    # class attributes so an instance built via object.__new__ -- the ``_make_simulator``
+    # test fakes, unpickling -- answers "cannot say" rather than raising.
+    _nominal_species_values = None
     _nominal_state_scale = None
     _tolerance_cache = None
+    _atol_vector_cache = None
     _atol_floor_warned = None
 
     def __init__(self, file, abs_file, pset=None, actions=(), save_files=False, integrator='cvode',
@@ -351,6 +408,7 @@ class BngsimSbmlModelNoTimeout(Model):
         self._config_rtol = None if rtol is None else float(rtol)
         self._config_atol = None if atol is None else float(atol)
         self._tolerance_cache = None
+        self._atol_vector_cache = None
         self._atol_floor_warned = set()
         self.suffixes = [(a.bng_codeword, a.suffix) for a in actions]
         self.mutants = [MutationSet()]
@@ -381,20 +439,52 @@ class BngsimSbmlModelNoTimeout(Model):
          self._unsafe_volume) = self._compute_species_unit_factors(doc.getModel())
         self._ic_seed_map = self._compute_ic_seed_map(doc.getModel())
         self._rhs_symbols = self._compute_rhs_symbols(doc.getModel())
-        self._nominal_state_scale = self._compute_nominal_state_scale(doc.getModel())
+        self._nominal_species_values = self._compute_nominal_species_values(doc.getModel())
+        self._nominal_state_scale = self._compute_nominal_state_scale(
+            self._nominal_species_values)
 
-    def _compute_nominal_state_scale(self, sbml_model):
+    def _compute_nominal_species_values(self, sbml_model):
+        """Every species' nominal value, by id, in bngsim's units (ADR-0105).
+
+        The state both tolerance derivations are read off: the **median** of the
+        strictly-positive entries is ADR-0103's scalar scale
+        (:meth:`_compute_nominal_state_scale`), and the entries themselves are
+        ADR-0105's per-species vector (:func:`_derive_atol_vector`). Read from the
+        parsed document rather than from a loaded engine model, so it costs nothing on
+        top of the parse ``_extract_sbml_structure`` already pays -- and so it is a
+        property of the model *text*, not of the fit point or of whether this evaluation
+        took the cached-clone or the structural-reload path. ``_species_unit_factor``
+        puts an amount-declared species into the concentration units bngsim integrates
+        in, exactly as the in-place value paths do.
+
+        A non-positive or non-finite declaration is stored as ``0.0``, meaning "no
+        magnitude of its own": the median skips it, and the vector's lower clamp puts it
+        at the model's scalar without needing a rule of its own. ``None`` -- meaning
+        "nothing to derive from", which leaves the tolerance at the backend default --
+        when a non-constant compartment volume makes the unit factors themselves
+        parameter-dependent, since then the values here are not the ones that would be
+        integrated.
+        """
+        if self._unsafe_volume:
+            return None
+        values = {}
+        for i in range(sbml_model.getNumSpecies()):
+            sp = sbml_model.getSpecies(i)
+            factor = self._species_unit_factor.get(sp.getId(), 1.0)
+            value = self._species_initial_value(sp) * factor
+            values[sp.getId()] = (
+                float(value) if np.isfinite(value) and value > 0.0 else 0.0)
+        return values
+
+    def _compute_nominal_state_scale(self, nominal_values):
         """The magnitude this model's state lives at, in bngsim's units (#546).
 
-        The scale the CVODE *absolute* tolerance is measured against
-        (:meth:`_effective_tolerances`), answered as the **median** strictly-positive
-        nominal species value. Read from the parsed document rather than from a loaded
-        engine model, so it costs nothing on top of the parse
-        ``_extract_sbml_structure`` already pays -- and so it is a property of the model
-        text, not of the fit point or of whether this evaluation took the cached-clone or
-        the structural-reload path. ``_species_unit_factor`` puts an amount-declared
-        species into the concentration units bngsim integrates in, exactly as the
-        in-place value paths do.
+        The scale the *scalar* CVODE absolute tolerance is measured against, answered as
+        the **median** strictly-positive nominal species value. Under ADR-0103 that scalar
+        was the integration tolerance; under ADR-0105 it is the steady-state convergence
+        cutoff whenever the per-species vector is in force (see
+        :meth:`_run_tolerance_kwargs`), and still the integration tolerance on every path
+        the vector does not reach.
 
         Median rather than minimum, which is the version of this that had to be
         withdrawn. A biochemical model routinely carries one transient intermediate
@@ -419,15 +509,9 @@ class BngsimSbmlModelNoTimeout(Model):
         limit on what this can detect, not an error: an undetected small scale leaves the
         tolerance exactly where it is today.
         """
-        if self._unsafe_volume:
+        if nominal_values is None:
             return None
-        values = []
-        for i in range(sbml_model.getNumSpecies()):
-            sp = sbml_model.getSpecies(i)
-            factor = self._species_unit_factor.get(sp.getId(), 1.0)
-            value = self._species_initial_value(sp) * factor
-            if np.isfinite(value) and value > 0.0:
-                values.append(value)
+        values = [v for v in nominal_values.values() if v > 0.0]
         return float(np.median(values)) if values else None
 
     @staticmethod
@@ -1584,13 +1668,20 @@ class BngsimSbmlModelNoTimeout(Model):
             raise ModelError(str(exc)) from exc
 
     def _effective_tolerances(self, sim):
-        """The ``(rtol, atol)`` every deterministic run of this model uses (#546).
+        """The ``(rtol, scalar atol)`` pair this model is measured in (#546).
 
         ``sbml_rtol`` / ``sbml_atol`` win outright when stated. Otherwise rtol is the
         backend's own default (read off the constructed ``Simulator`` so this tracks
         bngsim rather than a copy of its constant) and atol is derived from the model's
         typical species magnitude by :func:`_derive_atol` -- which can only tighten, so a
         model of order-one scale keeps the default pair exactly.
+
+        Under ADR-0105 this scalar is no longer always the *integration* tolerance: when
+        the per-species vector is in force it becomes the steady-state convergence cutoff
+        instead (:meth:`_run_tolerance_kwargs`), which is the one place a single number
+        about the model's magnitude is still the right shape. It remains the integration
+        tolerance everywhere the vector does not reach -- an older bngsim, an explicit
+        ``sbml_atol``, a model with no nominal state to read.
 
         The scale is the model's **nominal** one (``_compute_nominal_state_scale``, read
         off the document at load), not the state this run is about to integrate, so the
@@ -1625,6 +1716,121 @@ class BngsimSbmlModelNoTimeout(Model):
         self._tolerance_cache = (float(rtol), float(atol))
         return self._tolerance_cache
 
+    def _per_species_atol(self, sim, engine_model):
+        """The per-species ``atol`` vector for this model, or ``None`` (ADR-0105).
+
+        ``None`` means "there is nothing here a scalar does not already say", and every
+        route to it leaves ADR-0103's behaviour untouched:
+
+        * **the backend cannot take one** -- ``BNGSIM_HAS_PER_SPECIES_ATOL`` is a name
+          probe rather than a version floor, because the build that first carried
+          lanl/bngsim#196 declares the same version string as the wheel 25 commits behind
+          it;
+        * **``sbml_atol`` is stated** -- an explicit scalar is the documented off-switch
+          for this whole change, and it pins the pre-#196 ``CVodeSStolerances`` path
+          bit-for-bit, ulp included;
+        * **there is no nominal state to read** (a non-constant compartment volume makes
+          the unit factors parameter-dependent), so there is nothing to derive from;
+        * **the engine model's species do not line up** with the document's, so the
+          vector could not be ordered without guessing -- a mis-ordered vector assigns
+          one species' tolerance to another and nothing downstream would say so;
+        * **the vector is elementwise the scalar** -- true of 19 of the 23 subset-I
+          slugs, which is what "ADR-0103 had nothing to give back here" looks like: a
+          model the scalar derivation left at the backend default has no over-tightening
+          to undo. Handing CVODE a constant vector instead of the constant it already has
+          buys nothing and costs the ~1 ulp ``cvEwtSetSS``/``cvEwtSetSV`` difference #196
+          documents, so those models keep the scalar call they make today, byte for byte.
+          Measured: the same 100 box points under a uniform vector and under the scalar
+          fail identically, 39 and 39.
+
+        Ordered to the *engine* model's ``species_names`` rather than the document's:
+        those are the names bngsim indexes its state by, and are what the unit-factor
+        table is already keyed on elsewhere in this class. ``normalize_atol_vector``
+        (lanl/bngsim#212) takes the length/position contract here, once at setup, rather
+        than at the first ``run()`` -- which on a fit is a long way from where the vector
+        was built. Memoized against the ordering it was built for, so a later action with
+        a different species list rebuilds rather than silently reusing.
+        """
+        if not BNGSIM_HAS_PER_SPECIES_ATOL or getattr(self, '_config_atol', None) is not None:
+            return None
+        names = tuple(getattr(engine_model, 'species_names', None) or ())
+        cached = getattr(self, '_atol_vector_cache', None)
+        if cached is not None and cached[0] == names:
+            return cached[1]
+        vector = self._derive_per_species_atol(sim, names)
+        self._atol_vector_cache = (names, vector)
+        return vector
+
+    def _derive_per_species_atol(self, sim, names):
+        """Build (and validate, and log) the vector :meth:`_per_species_atol` memoizes.
+
+        The "says nothing a scalar does not" test is taken *before* the ordering one, so
+        the models that only ever reach the ordering fallback -- ones whose species are
+        all at or above one, where the vector is elementwise the default -- fall back
+        silently rather than warning about a difference that would not have existed.
+        """
+        nominal = getattr(self, '_nominal_species_values', None)
+        model_name = getattr(self, 'name', None)
+        if not names or not nominal:
+            return None
+        rtol, scalar_atol = self._effective_tolerances(sim)
+        default_atol = float(getattr(sim, '_atol', _BNGSIM_DEFAULT_ATOL))
+        by_species = dict(zip(nominal, _derive_atol_vector(
+            list(nominal.values()), scalar_atol, rtol, default_atol)))
+        if all(atol == scalar_atol for atol in by_species.values()):
+            return None
+        missing = set(names) - set(by_species)
+        if missing:
+            # Not a failure worth raising over -- the scalar is a correct tolerance for
+            # this model, just a less discriminating one -- but not silent either, because
+            # the alternative reading ("the vector is on") would be wrong. bngsim renames a
+            # species whose SBML id collides with an Antimony reserved word, which is how
+            # Smith_BMCSystBiol2013 gets here: its ``NULL``/``null`` load as
+            # ``_ant_NULL``/``_ant_null``.
+            logger.warning(
+                'bngsim SBML model %s: the engine model integrates %d species the SBML '
+                'document does not declare under those names (%s), so the per-species '
+                'absolute tolerance cannot be ordered against the state without guessing; '
+                'integrating at the scalar tolerance instead.',
+                model_name, len(missing), ', '.join(sorted(missing)[:4]))
+            return None
+        vector = [by_species[name] for name in names]
+        moved = sum(1 for atol in vector if atol != scalar_atol)
+        logger.debug(
+            'bngsim SBML model %s: per-species ODE absolute tolerance over %d species, '
+            '%d of them away from the %g a scalar derivation gives the whole model; '
+            'range [%g, %g], steady-state cutoff %g.',
+            model_name, len(vector), moved, scalar_atol, min(vector), max(vector),
+            scalar_atol)
+        return bngsim.normalize_atol_vector(
+            vector, len(names), names, where='the derived per-species sbml_atol')
+
+    def _run_tolerance_kwargs(self, sim, engine_model):
+        """The tolerance kwargs one deterministic ``Simulator.run`` takes (ADR-0105).
+
+        A vector ``atol`` travels with an explicit ``steady_state_tol``, and that pairing
+        is the whole of why this is not two independent decisions. bngsim falls its
+        steady-state cutoff back to the *scalar* atol when unset, "also when a per-species
+        atol is in force (issue #196): the criterion is a single norm over every species
+        and has no per-species reading to take" -- and the scalar it falls back to is the
+        Simulator's own ``1e-8``, not anything derived from the vector. Left alone, that
+        silently reverts ADR-0103's steady-state fix: on a model whose states are ~1e-8,
+        ``||dx/dt|| < 1e-8`` holds *at t = 0*, so every ``time = inf`` measurement
+        (ADR-0086) and every pre-equilibration phase (ADR-0052/0104) would return the
+        initial state and call it equilibrium -- looking, as it did before, like a
+        modelling problem rather than a tolerance one.
+
+        So ADR-0103's median-derived scalar does not retire. It stops being the
+        integration tolerance and becomes the convergence criterion, which keeps one
+        statement about the model's magnitude governing both and reproduces today's
+        steady-state behaviour exactly.
+        """
+        rtol, scalar_atol = self._effective_tolerances(sim)
+        vector = self._per_species_atol(sim, engine_model)
+        if vector is None:
+            return {'rtol': rtol, 'atol': scalar_atol}
+        return {'rtol': rtol, 'atol': vector, 'steady_state_tol': scalar_atol}
+
     def _run_simulation(self, engine_model, end_time, n_points, *, method='ode',
                         seed=None, timeout=None, sample_times=None, steady_state=False,
                         suffix=None, sim=None, carry_sensitivities=False):
@@ -1644,9 +1850,9 @@ class BngsimSbmlModelNoTimeout(Model):
         if carry_sensitivities:
             run_kwargs['carry_sensitivities'] = True
         if method != 'ssa':
-            # CVODE tolerances (#546). A stochastic run has none to set, so the ssa path
-            # is byte-identical to before.
-            run_kwargs['rtol'], run_kwargs['atol'] = self._effective_tolerances(sim)
+            # CVODE tolerances (#546, ADR-0105). A stochastic run has none to set, so the
+            # ssa path is byte-identical to before.
+            run_kwargs.update(self._run_tolerance_kwargs(sim, engine_model))
         if steady_state:
             # A steady-state measurement (ADR-0086, #521): relax to equilibrium
             # (early-stop on ||dx/dt||) with ``end_time`` only the max-time bound, rather

--- a/tests/test_sbml_solver_tolerances.py
+++ b/tests/test_sbml_solver_tolerances.py
@@ -52,6 +52,34 @@ old default. Its closed-form solution gives an exact sensitivity oracle, which i
 stronger than finite differences: the tests below assert the tensor against the true
 derivative, and assert that pinning ``sbml_atol`` back to the old default reproduces the
 original error.
+
+**The median charged the whole model for one end of it, and #549 gives that back**
+(ADR-0105). A scalar ``atol`` says one thing about a state that may span decades, so it
+over-tightens the large species while still not resolving the small one that pulled it
+down: ``Brannmark_JBC2010`` holds ``IR``/``IRS``/``X`` at ~10 to 3.3e-10, which is
+3.3e-11 *relative*, three decades tighter than the ``rtol`` that governs them.
+lanl/bngsim#196 routes a per-species vector to ``CVodeSVtolerances``, so each species can
+be given back what it never needed.
+
+**Only that, and it took a measurement to find out.** The reading #549 proposes -- resolve
+each species to ``rtol`` of its own magnitude, full stop -- puts ``IRp`` at 1.76e-17, and
+over 100 points of Brannmark's own fit box, with the fit's sensitivity request applied,
+that killed **91 of 100** simulations against the scalar's 39; the ``1e-16`` floor the
+issue asks about changed nothing (91 either way). It is ADR-0103's withdrawn *minimum*
+rule reappearing one species at a time. Clamped below by the model's own scalar -- so the
+vector can only ever *release* a species, never tighten one -- the same 100 points give
+**33**, in 428 s against 576 s. ``test_the_vector_gives_back_the_over_tightening_and
+_nothing_else`` and ``test_no_species_is_ever_integrated_more_tightly_than_it_is_today``
+are that decision; ``test_the_vector_does_not_resolve_what_adr_0103_declined_to`` is the
+boundary it leaves in place, which needs a trajectory-following tolerance
+(lanl/bngsim#213) rather than one read off initial values.
+
+The vector is derived once from the model's *nominal* state, never from the fit point --
+``test_the_vector_is_a_constant_of_the_model_not_of_the_fit_point`` is that requirement,
+and bngsim's ``AUTO`` token is what it rules out. ``_WIDE_SPREAD_SBML`` is this half's
+fixture (the mechanism, in steps: 288 against 377); the scalar tests above did not move,
+and now also cover the fallback path -- an older bngsim, an explicit ``sbml_atol``, a
+model with no over-tightening to undo, which is 19 of the 23 subset-I slugs.
 """
 
 from pathlib import Path
@@ -60,9 +88,10 @@ import numpy as np
 import pytest
 
 import pybnf.bngsim_sbml_model as bngsim_sbml_model
-from pybnf._bngsim_caps import BNGSIM_HAS_OUTPUT_SENS
+from pybnf._bngsim_caps import BNGSIM_HAS_OUTPUT_SENS, BNGSIM_HAS_PER_SPECIES_ATOL
 from pybnf.bngsim_sbml_model import (
     _BNGSIM_DEFAULT_ATOL, _BNGSIM_DEFAULT_RTOL, _DERIVED_ATOL_FLOOR, _derive_atol,
+    _derive_atol_vector,
 )
 from pybnf.printing import PybnfError
 from pybnf.pset import FreeParameter, PSet, TimeCourse
@@ -75,6 +104,11 @@ pytestmark = pytest.mark.bngsim_sbml
 _needs_output_sens = pytest.mark.skipif(
     not BNGSIM_HAS_OUTPUT_SENS,
     reason='needs a bngsim build with the output_sensitivities feature')
+
+_needs_per_species_atol = pytest.mark.skipif(
+    not BNGSIM_HAS_PER_SPECIES_ATOL,
+    reason='needs a bngsim build whose Simulator.run takes a per-species atol '
+           '(lanl/bngsim#196, exported by lanl/bngsim#212)')
 
 
 # --- fixture: a three-stage piecewise-in-time decay, seeded below the old atol -- #
@@ -157,8 +191,66 @@ _ONE_TINY_TRANSIENT_SBML = _PIECEWISE_SBML.replace(
     'hasOnlySubstanceUnits="false" boundaryCondition="true" constant="false"/>\n'
     '      <species id="X" compartment="c" initialConcentration="1.0"')
 
+# --- fixture: the Brannmark_JBC2010 shape, where the median over-tightens ------- #
+# The same decay, run long, with ``X`` raised to 10 and two inert species pinning the
+# median down: {10, 1e-2, 1e-9} has median 1e-2, so ADR-0103's scalar is 1e-10 for
+# every state including the one at 10. That is the over-tightening ADR-0105 undoes --
+# ``X`` is entitled to the 1e-8 backend default and is being held two decades under it.
+#
+# The cost only becomes visible once ``X`` has decayed FAR below its nominal value,
+# which is why this fixture runs to t = 80 (``X`` ends at ~7e-17): an ``atol`` beneath
+# ``rtol*|y_i|`` is inert until then, and what it demands afterwards is that a species
+# which has decayed into nothing be resolved as if it had not.
+_WIDE_SPREAD_SBML = _PIECEWISE_SBML.replace(
+    '<species id="X" compartment="c" initialConcentration="1e-8"',
+    '<species id="Mid" compartment="c" initialConcentration="1e-2" '
+    'hasOnlySubstanceUnits="false" boundaryCondition="true" constant="false"/>\n'
+    '      <species id="Tiny" compartment="c" initialConcentration="1e-9" '
+    'hasOnlySubstanceUnits="false" boundaryCondition="true" constant="false"/>\n'
+    '      <species id="X" compartment="c" initialConcentration="10"')
+
+# A peer carrying two scales and nothing inert: ``X`` at 1e-8 plus an order-one ``Big``
+# decaying slowly and independently, median 0.5, so ADR-0103's scalar is 5e-9. Used for
+# the structural tests -- ordering, the steady-state cutoff, the off-switches -- and for
+# the boundary this change does NOT cross (see
+# ``test_the_vector_does_not_resolve_what_adr_0103_declined_to``).
+_TWO_SCALE_SBML = _PIECEWISE_SBML.replace(
+    '<species id="X" compartment="c" initialConcentration="1e-8" '
+    'hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>',
+    '<species id="X" compartment="c" initialConcentration="1e-8" '
+    'hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>\n'
+    '      <species id="Big" compartment="c" initialConcentration="1.0" '
+    'hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>'
+).replace(
+    '<parameter id="t2" value="5" constant="true"/>',
+    '<parameter id="t2" value="5" constant="true"/>\n'
+    '      <parameter id="kb" value="0.001" constant="true"/>'
+).replace(
+    '    </listOfReactions>',
+    """      <reaction id="degBig" reversible="false" fast="false">
+        <listOfReactants><speciesReference species="Big" stoichiometry="1" constant="true"/></listOfReactants>
+        <kineticLaw><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><times/><ci>kb</ci><ci>Big</ci></apply></math></kineticLaw>
+      </reaction>
+    </listOfReactions>""")
+
+# The same two scales with a third species seeded at exactly zero, for the rule that
+# decides what a species with no magnitude of its own is measured against.
+_ZERO_SEEDED_SBML = _TWO_SCALE_SBML.replace(
+    '<species id="Big" compartment="c" initialConcentration="1.0" ',
+    '<species id="Empty" compartment="c" initialConcentration="0" '
+    'hasOnlySubstanceUnits="false" boundaryCondition="true" constant="false"/>\n'
+    '      <species id="Big" compartment="c" initialConcentration="1.0" ')
+
 K0, K1, K2, T1, T2, X0 = 0.7, 0.2, 0.5, 2.0, 5.0, 1e-8
+KB, BIG0 = 1e-3, 1.0
 T_END, N_STEPS = 8.0, 32
+
+# ADR-0103's scalar for _TWO_SCALE_SBML (median {1e-8, 1} times rtol, clamped) and for
+# _WIDE_SPREAD_SBML (median {10, 1e-2, 1e-9}). Each is what PyBNF ran on a model of that
+# shape until #549, and each is what the steady-state cutoff stays at under ADR-0105.
+_TWO_SCALE_SCALAR = 5e-9
+_WIDE_SPREAD_SCALAR = 1e-10
+_WIDE_T_END = 80.0
 
 
 def _stage_widths(t):
@@ -186,20 +278,37 @@ def _exact_sensitivities(t, x0=X0):
     return np.stack([-w * x for w in _stage_widths(t)], axis=1)
 
 
+def _exact_big(t):
+    """``Big(t)``: the slow independent decay in the two-scale fixture."""
+    return BIG0 * np.exp(-KB * np.asarray(t))
+
+
 def _write(tmp_path, text, name):
     xml = Path(tmp_path) / name
     xml.write_text(text)
     return str(xml)
 
 
-def _piecewise_model(tmp_path, *, text=_PIECEWISE_SBML, name='pw.xml', rtol=None, atol=None):
-    """A :class:`BngsimSbmlModelNoTimeout` over the piecewise fixture."""
+def _piecewise_model(tmp_path, *, text=_PIECEWISE_SBML, name='pw.xml', rtol=None, atol=None,
+                     extra=()):
+    """A :class:`BngsimSbmlModelNoTimeout` over the piecewise fixture.
+
+    ``extra`` adds ``(name, value)`` free parameters to the fit point, which is how the
+    tests that move a species' *initial condition* are written -- a species id is a
+    fittable name here, exactly as it is on a PEtab problem that estimates one.
+    """
     xml = _write(tmp_path, text, name)
-    ps = PSet([FreeParameter(p, 'uniform_var', 1e-4, 10., value=v)
-               for p, v in (('k0', K0), ('k1', K1), ('k2', K2))])
+    ps = PSet([FreeParameter(p, 'uniform_var', 1e-9, 10., value=v)
+               for p, v in (('k0', K0), ('k1', K1), ('k2', K2)) + tuple(extra)])
     action = TimeCourse({'time': str(T_END), 'step': str(T_END / N_STEPS)})
     return bngsim_sbml_model.BngsimSbmlModelNoTimeout(
         xml, xml, pset=ps, actions=(action,), rtol=rtol, atol=atol)
+
+
+def _tolerance_kwargs(model):
+    """``(engine model, the tolerance kwargs one deterministic run takes)``."""
+    engine = model._engine_model_for_action()
+    return engine, model._run_tolerance_kwargs(model._make_simulator(engine, 'ode'), engine)
 
 
 # --- the boundaries are already handed to CVODE -------------------------------- #
@@ -356,6 +465,300 @@ def test_a_stochastic_run_sets_no_tolerances(tmp_path, monkeypatch):
     assert 'atol' not in captured
 
 
+# --- the per-species vector (ADR-0105) ------------------------------------------- #
+@pytest.mark.parametrize('nominal, scalar_atol, expected', [
+    # The Brannmark shape. The species at 10 is released from the model-wide 3.3e-10 to
+    # the backend default; the two at or under the model's own scale keep it, including
+    # the 1e-2 one whose own rtol*y (1e-10) is TIGHTER than the scalar.
+    ([10.0, 1e-2, 1.8e-9], 3.3e-10,
+     [_BNGSIM_DEFAULT_ATOL, 3.3e-10, 3.3e-10]),
+    # Only ever tightens relative to the backend default, per species.
+    ([1.0, 1e6], _BNGSIM_DEFAULT_ATOL, [_BNGSIM_DEFAULT_ATOL, _BNGSIM_DEFAULT_ATOL]),
+    # A species with no magnitude of its own is measured against the model's.
+    ([0.0, 1e-3], 1e-11, [1e-11, 1e-11]),
+])
+def test_the_vector_gives_back_the_over_tightening_and_nothing_else(
+        nominal, scalar_atol, expected):
+    """``atol_i = clamp(rtol*y_i, scalar_atol, default)`` -- both clamps load-bearing.
+
+    Read literally, "resolve each species to ``rtol`` of its own magnitude" would put
+    ``Brannmark_JBC2010``'s ``IRp`` (nominal 1.76e-9) at 1.76e-17. That rule was
+    implemented and measured over 100 points of that model's own fit box, with the fit's
+    sensitivity request applied: it killed **91 of 100** simulations against the scalar's
+    39, which is ADR-0103's withdrawn *minimum* rule reappearing one species at a time.
+    The ``1e-16`` floor #549 asks about rescued nothing -- 91 either way -- because the
+    damage is done well above it.
+
+    So the lower clamp is the model's own scalar, and what the vector does is give back
+    ADR-0103's over-tightening to the species that never needed it. That measured 33 of
+    100, against the scalar's 39, in 428 s rather than 576 s.
+
+    The last case is the corpus's other decision: ``derive_atol``'s own default
+    substitutes the smallest strictly positive entry for a species seeded at zero, which
+    on ``Giordano_Nature2020`` -- this change's control -- would tighten its four
+    zero-seeded species 22x for no measured reason. ``rtol * 0`` clamping up to the
+    model's scalar leaves them exactly where ADR-0103 puts them, and needs no rule of
+    its own.
+    """
+    got = _derive_atol_vector(nominal, scalar_atol, _BNGSIM_DEFAULT_RTOL,
+                              _BNGSIM_DEFAULT_ATOL)
+
+    np.testing.assert_allclose(got, expected, rtol=1e-12)
+
+
+@pytest.mark.parametrize('nominal', [
+    [10.0, 1e-2, 1.8e-9], [1.0, 1e6], [0.0, 1e-3], [1e-8, 1.0], [1e-30, 1e30, 0.0],
+])
+def test_no_species_is_ever_integrated_more_tightly_than_it_is_today(nominal):
+    """The safety property the whole change rests on, asserted as a property.
+
+    Every entry lies in ``[scalar_atol, default_atol]``: never tighter than what PyBNF
+    already integrates this model at, never looser than the backend default. The first
+    half is what makes it impossible for a model that runs today to start failing --
+    which is not a hypothetical, since the unclamped version of this derivation more than
+    doubled ``Brannmark_JBC2010``'s dead simulations. The second half is ADR-0103's
+    only-ever-tighten promise, now per species.
+    """
+    scale = float(np.median([v for v in nominal if v > 0.0]))
+    scalar_atol = _derive_atol(scale, _BNGSIM_DEFAULT_RTOL, _BNGSIM_DEFAULT_ATOL)
+    got = _derive_atol_vector(nominal, scalar_atol, _BNGSIM_DEFAULT_RTOL,
+                              _BNGSIM_DEFAULT_ATOL)
+
+    assert np.all(got >= scalar_atol)
+    assert np.all(got <= _BNGSIM_DEFAULT_ATOL)
+
+
+@_needs_per_species_atol
+def test_only_ever_tighten_is_pybnfs_to_apply_not_the_backends():
+    """bngsim's own ``derive_atol`` has no upper clamp; PyBNF's vector does.
+
+    Worth pinning against the library rather than asserting PyBNF's arithmetic twice: a
+    species at order ten comes back from ``bngsim.derive_atol`` *looser* than the backend
+    default, and shipping that would loosen trajectories ADR-0103 promised never to
+    loosen. ``Brannmark_JBC2010``'s ``X`` is the measured case, at 1.0e-07.
+    """
+    import bngsim
+
+    theirs = bngsim.derive_atol([10.0], _BNGSIM_DEFAULT_RTOL)
+    ours = _derive_atol_vector([10.0], 1e-10, _BNGSIM_DEFAULT_RTOL, _BNGSIM_DEFAULT_ATOL)
+
+    assert theirs[0] > _BNGSIM_DEFAULT_ATOL
+    assert ours[0] == _BNGSIM_DEFAULT_ATOL
+
+
+@_needs_per_species_atol
+def test_releasing_the_over_tightened_species_costs_cvode_fewer_steps(tmp_path):
+    """The mechanism, measured on a fixture: the same model, integrated in fewer steps.
+
+    This is what #549 is actually worth, reduced to something a test can hold. ``X`` sits
+    at 10 while the model's median sits at 1e-2, so ADR-0103 hands it 1e-10 -- 1e-11
+    *relative*, three decades tighter than the ``rtol`` that governs it. That is inert
+    until ``X`` decays far below its nominal value, and then it demands that a species
+    which has decayed into nothing be resolved as if it had not.
+
+    Under the vector ``X`` gets the 1e-8 backend default it was always entitled to, and
+    the other two species keep the scalar exactly. Measured here: 288 steps against 377,
+    which is the fixture-scale version of ``Brannmark_JBC2010``'s 33 dead box points
+    against 39. The threshold is set well inside that gap rather than at a bare
+    inequality, so a second platform's CVODE cannot flip it on a step or two.
+    """
+    model = _piecewise_model(tmp_path, text=_WIDE_SPREAD_SBML, name='wide.xml')
+    engine, kwargs = _tolerance_kwargs(model)
+    assert dict(zip(engine.species_names, kwargs['atol'])) == pytest.approx(
+        {'X': _BNGSIM_DEFAULT_ATOL, 'Mid': _WIDE_SPREAD_SCALAR,
+         'Tiny': _WIDE_SPREAD_SCALAR})
+
+    def steps(atol):
+        fresh = model._engine_model_for_action()
+        sim = model._make_simulator(fresh, 'ode')
+        result = sim.run(t_span=(0.0, _WIDE_T_END), n_points=81,
+                         rtol=_BNGSIM_DEFAULT_RTOL, atol=atol)
+        return int(result.solver_stats['n_steps'])
+
+    # A fresh engine model per run: a second run() on the same Simulator continues from
+    # where the first one left off (ADR-0104), which would make these two incomparable.
+    assert steps(kwargs['atol']) < 0.9 * steps(_WIDE_SPREAD_SCALAR)
+
+
+@_needs_per_species_atol
+def test_a_cross_species_spread_reaches_the_run_call_as_a_vector(tmp_path):
+    """Two scales in one model resolve separately, ordered to the engine's species.
+
+    The ordering is asserted **by name** rather than by position, because a vector
+    assigned to the wrong species is exactly as silent as the bug #546 opened on: every
+    entry is a plausible tolerance, so nothing downstream can tell.
+    """
+    model = _piecewise_model(tmp_path, text=_TWO_SCALE_SBML, name='pw_two.xml')
+    engine, kwargs = _tolerance_kwargs(model)
+
+    by_name = dict(zip(engine.species_names, kwargs['atol']))
+    assert by_name == pytest.approx(
+        {'X': _TWO_SCALE_SCALAR, 'Big': _BNGSIM_DEFAULT_ATOL})
+    assert kwargs['rtol'] == _BNGSIM_DEFAULT_RTOL
+
+
+@_needs_per_species_atol
+def test_the_steady_state_cutoff_is_stated_rather_than_inherited(tmp_path):
+    """A vector ``atol`` travels with an explicit ``steady_state_tol`` (ADR-0103's scalar).
+
+    bngsim falls its steady-state cutoff back to the *scalar* atol when unset, "also when
+    a per-species atol is in force (issue #196): the criterion is a single norm over every
+    species and has no per-species reading to take" -- and the scalar it falls back to is
+    the Simulator's own 1e-8, not anything derived from the vector. Left alone that
+    silently reverts ADR-0103's steady-state fix: on a model whose states are ~1e-8,
+    ``||dx/dt|| < 1e-8`` holds at t = 0, so every ``time = inf`` measurement (ADR-0086)
+    and every pre-equilibration phase (ADR-0052/0104) returns the initial state and calls
+    it equilibrium.
+    """
+    model = _piecewise_model(tmp_path, text=_TWO_SCALE_SBML, name='pw_two_ss.xml')
+    _, kwargs = _tolerance_kwargs(model)
+
+    # The median of [1e-8, 1.0] is 0.5, so ADR-0103's scalar clamps to 5e-9 -- which is
+    # what the relaxation test is measured in, and is NOT the 1e-8 bngsim would fall back
+    # to on its own.
+    assert kwargs['steady_state_tol'] == pytest.approx(_TWO_SCALE_SCALAR)
+    assert model._effective_tolerances(object())[1] == pytest.approx(_TWO_SCALE_SCALAR)
+
+
+@_needs_per_species_atol
+def test_the_vector_is_a_constant_of_the_model_not_of_the_fit_point(tmp_path):
+    """A fitted initial condition does not move the tolerance.
+
+    The trap #549 names: bngsim's ``AUTO`` token derives from the state the next ``run()``
+    would start from, which on a fit is the fit point, so ``atol`` would become a function
+    of the search position. That puts a step in the objective everywhere the derivation
+    crosses a rounding boundary -- invisible in the usual way, since the objective still
+    looks correct and only the search behaves oddly -- and it breaks the requirement that
+    a gradient fit's line-search evaluations be integrated to the same accuracy as the
+    sensitivities they are compared against. So the vector is read off the *document*.
+
+    The fitted point really does move here, which is what makes the assertion mean
+    something: the engine model integrates ``X`` from 1e-3 while its tolerance stays the
+    one the nominal 1e-8 asked for.
+    """
+    nominal = _piecewise_model(tmp_path, text=_TWO_SCALE_SBML, name='pw_two_nom.xml')
+    moved = _piecewise_model(tmp_path, text=_TWO_SCALE_SBML, name='pw_two_fit.xml',
+                             extra=[('X', 1e-3)])
+    nominal_engine, nominal_kwargs = _tolerance_kwargs(nominal)
+    moved_engine, moved_kwargs = _tolerance_kwargs(moved)
+
+    assert float(nominal_engine.get_concentration('X')) == pytest.approx(X0)
+    assert float(moved_engine.get_concentration('X')) == pytest.approx(1e-3)
+    assert moved_kwargs == nominal_kwargs
+
+
+@_needs_per_species_atol
+def test_a_zero_seeded_species_takes_the_models_scale(tmp_path):
+    """A species with nothing to measure lands exactly where ADR-0103 leaves it today.
+
+    bngsim's ``derive_atol`` substitutes the smallest strictly positive entry instead --
+    here 1e-8, giving 1e-16. On ``Giordano_Nature2020``, the slug this change uses as its
+    control, that rule would tighten its four zero-seeded species 22x for no measured
+    reason. The model's own scalar leaves them untouched.
+    """
+    model = _piecewise_model(tmp_path, text=_ZERO_SEEDED_SBML, name='pw_zero.xml')
+    engine, kwargs = _tolerance_kwargs(model)
+
+    by_name = dict(zip(engine.species_names, kwargs['atol']))
+    assert by_name['Empty'] == pytest.approx(_TWO_SCALE_SCALAR)
+    assert by_name['X'] == pytest.approx(_TWO_SCALE_SCALAR)
+
+
+@_needs_per_species_atol
+def test_a_model_of_one_scale_keeps_the_scalar_call(tmp_path):
+    """A vector saying nothing a scalar does not is not sent (19 of the 23 subset-I slugs).
+
+    That is what "ADR-0103 had nothing to give back here" looks like: a model the scalar
+    derivation left at the backend default has no over-tightening to undo, so every entry
+    of its vector is that default. Handing CVODE a constant vector instead of the constant
+    it already has buys nothing and costs the ~1 ulp ``cvEwtSetSS``/``cvEwtSetSV``
+    difference lanl/bngsim#196 documents, so they keep the call they make today byte for
+    byte -- ``steady_state_tol`` included, since bngsim's own fallback to the run's scalar
+    atol is already correct there. Measured: 100 points of ``Brannmark_JBC2010``'s fit box
+    fail identically under a uniform vector and under the scalar, 39 and 39.
+    """
+    model = _piecewise_model(tmp_path, text=_ORDER_ONE_SBML, name='pw_one_v.xml')
+    _, kwargs = _tolerance_kwargs(model)
+
+    assert kwargs == {'rtol': _BNGSIM_DEFAULT_RTOL, 'atol': _BNGSIM_DEFAULT_ATOL}
+
+
+@_needs_per_species_atol
+def test_an_explicit_sbml_atol_pins_the_scalar_path(tmp_path):
+    """``sbml_atol`` is the documented off-switch, and switches the vector off entirely.
+
+    Stating it pins the pre-#196 ``CVodeSStolerances`` path, ulp included, on a model
+    that would otherwise take a vector.
+    """
+    model = _piecewise_model(tmp_path, text=_TWO_SCALE_SBML, name='pw_two_off.xml',
+                             atol=1e-12)
+    _, kwargs = _tolerance_kwargs(model)
+
+    assert kwargs == {'rtol': _BNGSIM_DEFAULT_RTOL, 'atol': 1e-12}
+
+
+def test_an_older_bngsim_keeps_adr_0103s_scalar(tmp_path, monkeypatch):
+    """Without the capability the backend runs every fit it runs today, unchanged.
+
+    ``BNGSIM_HAS_PER_SPECIES_ATOL`` is a *name* probe rather than a version floor because
+    the build that first carried lanl/bngsim#196 declares the same version string as the
+    wheel 25 commits behind it, so a floor would report present on an install without it.
+    """
+    monkeypatch.setattr(bngsim_sbml_model, 'BNGSIM_HAS_PER_SPECIES_ATOL', False)
+    model = _piecewise_model(tmp_path, text=_TWO_SCALE_SBML, name='pw_two_old.xml')
+    _, kwargs = _tolerance_kwargs(model)
+
+    assert kwargs == {'rtol': _BNGSIM_DEFAULT_RTOL,
+                      'atol': pytest.approx(_TWO_SCALE_SCALAR)}
+
+
+@_needs_per_species_atol
+def test_a_species_the_document_does_not_name_falls_back_and_says_so(tmp_path, caplog):
+    """An unorderable vector is refused, out loud, rather than mis-assigned.
+
+    bngsim renames a species whose SBML id collides with an Antimony reserved word, which
+    is how ``Smith_BMCSystBiol2013`` reaches this path: its ``NULL``/``null`` load as
+    ``_ant_NULL``/``_ant_null``. A vector ordered past a rename would hand one species'
+    tolerance to another and nothing downstream would say so, so the scalar -- correct
+    here, just less discriminating -- is used instead.
+    """
+    model = _piecewise_model(tmp_path, text=_TWO_SCALE_SBML, name='pw_two_ren.xml')
+
+    class _RenamedEngine:
+        species_names = ('X', '_ant_Big')
+
+    with caplog.at_level('WARNING'):
+        kwargs = model._run_tolerance_kwargs(object(), _RenamedEngine())
+
+    assert kwargs == {'rtol': _BNGSIM_DEFAULT_RTOL,
+                      'atol': pytest.approx(_TWO_SCALE_SCALAR)}
+    assert any('_ant_Big' in r.message for r in caplog.records)
+
+
+@_needs_per_species_atol
+def test_the_vector_reaches_the_bngsim_run_call(tmp_path, monkeypatch):
+    """The resolved vector, and its steady-state cutoff, are what ``run`` is called with."""
+    model = _piecewise_model(tmp_path, text=_TWO_SCALE_SBML, name='pw_two_run.xml')
+    engine = model._engine_model_for_action()
+    captured = {}
+
+    class _CapturingSim:
+        _rtol = _BNGSIM_DEFAULT_RTOL
+        _atol = _BNGSIM_DEFAULT_ATOL
+
+        def run(self, **kwargs):
+            captured.update(kwargs)
+            raise RuntimeError('stop here')
+
+    monkeypatch.setattr(model, '_make_simulator', lambda engine_model, method: _CapturingSim())
+    with pytest.raises(RuntimeError, match='stop here'):
+        model._run_simulation(engine, 1.0, 2, method='ode')
+
+    assert dict(zip(engine.species_names, captured['atol'])) == pytest.approx(
+        {'X': _TWO_SCALE_SCALAR, 'Big': _BNGSIM_DEFAULT_ATOL})
+    assert captured['steady_state_tol'] == pytest.approx(_TWO_SCALE_SCALAR)
+
+
 # --- the oracle ----------------------------------------------------------------- #
 def test_piecewise_in_time_trajectory_matches_the_closed_form(tmp_path):
     """The scalar path resolves the sub-default trajectory it could not before.
@@ -407,6 +810,67 @@ def test_piecewise_in_time_sensitivities_match_the_analytic_oracle(tmp_path):
     for j, name in enumerate(('k0', 'k1', 'k2')):
         err = np.max(np.abs(got[:, j] - oracle[:, j])) / np.max(np.abs(oracle[:, j]))
         assert err < 1e-4, f'{name} column off by {err:.2e}'
+
+
+@_needs_per_species_atol
+def test_the_released_species_still_integrates_to_its_closed_form(tmp_path):
+    """Giving a species back the backend default does not cost it its answer.
+
+    The other half of the step-count test: the release has to be free where it matters,
+    not merely cheap. ``X`` is the species handed from 1e-10 back to 1e-8, and over the
+    stretch of its trajectory that is well clear of that tolerance it still matches the
+    closed form -- measured at 2.0e-05 against the scalar run's 4.0e-07, which is exactly
+    what ``atol/|y|`` predicts at ``|y|`` ~ 1e-3 and is a tolerance question rather than a
+    correctness one.
+
+    The comparison is restricted to where the exact solution is above 1e-3 on purpose.
+    Below that ``X`` is approaching the noise floor ``atol`` declares for it, and asking
+    it to be relatively accurate there is asking the absolute tolerance not to be an
+    absolute tolerance.
+    """
+    model = _piecewise_model(tmp_path, text=_WIDE_SPREAD_SBML, name='wide_traj.xml')
+    engine = model._engine_model_for_action()
+    sim = model._make_simulator(engine, 'ode')
+    result = sim.run(t_span=(0.0, _WIDE_T_END), n_points=81,
+                     **model._run_tolerance_kwargs(sim, engine))
+
+    t = np.asarray(result.time)
+    got = np.asarray(result.species[:, list(engine.species_names).index('X')])
+    exact = _exact_x(t, 10.0)
+    clear = exact > 1e-3
+    np.testing.assert_allclose(got[clear], exact[clear], rtol=1e-3)
+
+
+@_needs_per_species_atol
+def test_the_vector_does_not_resolve_what_adr_0103_declined_to(tmp_path):
+    """The boundary of this change, asserted rather than left to be discovered.
+
+    It is tempting to read "one tolerance per species" as "every species is finally
+    resolved against its own magnitude". It is not, and the difference is the whole of
+    what the measurement decided: the unclamped rule would put ``X`` here at 1e-16 and
+    ``Brannmark_JBC2010``'s ``IRp`` at 1.76e-17, and over 100 points of Brannmark's fit
+    box that killed 91 simulations against the scalar's 39.
+
+    So a species below the model's own scale keeps the compromise ADR-0103 struck for it,
+    and ``X`` -- 1e-8 in a model whose scale is 0.5 -- is still integrated at 5e-9 and
+    still buried under it. Reaching that case needs a tolerance that follows the
+    *trajectory* rather than one read off initial values (lanl/bngsim#213), which is a
+    different construct and a different issue.
+    """
+    model = _piecewise_model(tmp_path, text=_TWO_SCALE_SBML, name='pw_two_edge.xml')
+    engine, kwargs = _tolerance_kwargs(model)
+    assert dict(zip(engine.species_names, kwargs['atol']))['X'] == pytest.approx(
+        _TWO_SCALE_SCALAR)
+
+    data = model.execute(str(tmp_path), 'pw_two_edge', 0)['time_course']
+    t = np.asarray(data['time'])
+    x_err = np.max(np.abs(np.asarray(data['X']) - _exact_x(t)) / _exact_x(t))
+    big_err = np.max(np.abs(np.asarray(data['Big']) - _exact_big(t)) / _exact_big(t))
+
+    # 1.2e-01 measured. The threshold sits a decade under it rather than just beneath, so
+    # a second platform's CVODE cannot flip the test.
+    assert x_err > 1e-2, f'expected X to still be buried, got {x_err:.2e}'
+    assert big_err < 1e-5, f'expected Big to be unaffected, got {big_err:.2e}'
 
 
 @_needs_output_sens


### PR DESCRIPTION
Closes #549. Supersedes ADR-0103 with **ADR-0105**.

## What this does

ADR-0103 derived one absolute tolerance for a whole SBML model, from the median species value,
because bngsim's `Simulator.run` took only a scalar. lanl/bngsim#196 lifted that constraint, so the
over-tightening a single number forces on the large species can be given back per species:

```
atol_i = clamp(rtol * y_i, the model's own scalar, the backend default)
```

`Brannmark_JBC2010` is the case: it reads `3.3e-10`, which holds `IR`/`IRS`/`X` at ~10 to `3.3e-11`
*relative* — three decades tighter than the `rtol` that governs them — to buy a resolution for a
`1.76e-9` transient that ADR-0103 had already decided not to chase.

## The rule is narrower than the issue proposes, and the measurement is why

#549 asks for `atol_i = rtol * y_i`, each species resolved to its own magnitude, full stop. That was
implemented first and measured on 100 points sampled from Brannmark's own fit box the way a
multi-start start is sampled, with the fit's union sensitivity request applied — the isolate #549
asks for under "claim A", no optimizer in the loop:

| rule | dead simulations / 100 | CVODES `mxstep` lines | wall clock |
|---|---:|---:|---:|
| ADR-0103's scalar | **39** | 3542 | 576 s |
| the same scalar, sent as a uniform *vector* | **39** | 3957 | 587 s |
| per-species, floored at `1e-16` (#549 as written) | **91** | 6220 | 985 s |
| per-species, no floor at all | **91** | — | — |
| **per-species, floored at the model's own scalar** | **33** | 2930 | 428 s |

Every failure in every row is a solver failure; none is a `wall_time_sim` kill. (The first round ran
the regimes concurrently and had to be discarded and re-run serially — a 10 s per-simulation budget
on a contended machine kills points the tolerance had nothing to do with.)

Three things follow, and two of them answer open questions in the issue:

- **The literal rule more than doubles the deaths on the slug it was filed from.** It is ADR-0103's
  withdrawn *minimum* rule reappearing one species at a time, and the reasoning that withdrew it did
  not stop being true when the tolerance became a vector.
- **The `1e-16` floor — #549's "one genuinely open design question" — is moot.** 91 either way: the
  damage is done well above it, by the species landing at `1.1e-13` and `1.6e-12`. Under the clamp
  adopted here nothing reaches `1e-16` at all.
- **The uniform-vector control lands exactly on the baseline, 39 = 39**, so the vector plumbing and
  the `CVodeSVtolerances`-vs-`SStolerances` switch are a non-event and the rest of the table is
  attributable to the tolerance *values*.

Why the tightening hurts: a tolerance below `rtol*|y_i|` is inert until `|y_i|` falls far below its
*nominal* value, and what it then demands is that a species which has decayed into nothing be
resolved as if it had not. Initial values cannot tell that apart from a species that genuinely lives
down there — that needs the trajectory, which is lanl/bngsim#213's shape, not this one.

So the vector **only ever releases** a species, never tightens one. Every entry lands in
`[scalar, default]`, which makes it impossible for a model that simulates today to start failing —
asserted as a property, not left as a hope.

## Also in here

- **ADR-0103's scalar does not retire; it becomes the steady-state cutoff.** bngsim's
  `_resolve_atol` returns the *Simulator's own* `1e-8` as the `steady_state_tol` fallback when a
  vector is in force, so a vector passed alone would silently revert ADR-0103's steady-state fix —
  on a model whose states are ~1e-8, `||dx/dt|| < 1e-8` holds at `t = 0`, and every `time = inf`
  measurement (ADR-0086) and every pre-equilibration phase (ADR-0052/0104) would return the initial
  state and call it equilibrium. It is now passed explicitly.
- **`AUTO` is deliberately not used.** It derives from the model's live state, which on a fit is the
  fit point; the vector is read off the document at load and held for the whole fit.
- **`sbml_atol` stays scalar-only** and remains the off-switch, pinning the pre-#196 path
  bit-for-bit.
- **The capability probe is a name, not a version floor** — the build that first carried #196
  declares the same version string as the wheel 25 commits behind it.

## Corpus effect

| slug | ADR-0103 scalar | vector `[min, max]` | released |
|---|---:|---|---:|
| `Armistead_CellDeathDis2024` | 4.94e-09 | `[4.944e-09, 1.000e-08]` | 2 of 4 |
| `Bertozzi_PNAS2020` | 5.00e-09 | `[5.000e-09, 9.000e-09]` | 1 of 3 |
| `Brannmark_JBC2010` | 3.30e-10 | `[3.302e-10, 1.000e-08]` | 4 of 9 |
| `Giordano_Nature2020` | 3.67e-15 | `[3.667e-15, 1.000e-08]` | 4 of 13 |

The other 19 take the scalar call unchanged — the shape of a refund, since only a model that was
charged can receive one. **`Raia_CancerResearch2011` does not move**, so #549's "the 19 that
ADR-0103 left untouched should be unchanged" holds literally rather than needing its
report-and-explain carve-out. `Smith_BMCSystBiol2013` reaches the ordering fallback and logs it:
bngsim renames its `NULL`/`null` species to `_ant_NULL`/`_ant_null`, and a vector ordered past a
rename would assign one species' tolerance to another silently.

## Verification

- **Nothing moves that should not.** `nominal_check.py` over all 23 slugs, run twice in one process
  against the same bngsim build with the capability forced off and on — a cleaner control than the
  committed `nominal_check.json`, whose values predate this wheel. **20 bit-identical** (including
  `Giordano`, which takes a vector and does not move because its released species are already
  relative-term-governed); 3 move, in the 8th significant digit or beyond.
- **`Giordano_Nature2020` does not regress.** Assembled gradient vs central differences, worst
  relative error over all 50 fitted columns:

  | | `h = 1e-3` | `h = 3e-3` | `h = 1e-2` |
  |---|---:|---:|---:|
  | scalar | 5.89e-04 | 2.45e-03 | 1.50e-03 |
  | vector | 8.57e-04 | 2.56e-04 | 1.11e-03 |

  Both rows move with `h` by more than they differ from each other and the ordering flips, so by the
  corpus README's own rule (a real defect does not move with `h`; FD noise does) this instrument
  resolves no difference between them. A single `h` would have supported a confident wrong statement
  in either direction.
- **Fixtures** in `tests/test_sbml_solver_tolerances.py`: the mechanism in steps (288 against 377),
  the released species still matching its closed form, the safety property as a property, and an
  explicit test for the boundary this change *does not* cross. The existing scalar tests did not
  move and now also cover the fallback path.
- **Full default suite against the same suite on the base commit** — run by stashing the working
  tree, because PyBNF is installed editable and pinned to this checkout, so a second worktree would
  have run the base commit's *tests* against this branch's *code*. 263 failed / 35 errors on both,
  298 `FAILED`/`ERROR` lines byte-identical, 21 more passing here — exactly the number of tests
  added. (Those 263 are this machine's BNG2.pl-dependent tests.)

## Claim B is deliberately not made

That `Brannmark_JBC2010` now *solves* — final `OG` under 1.92 rather than 3.21 — needs a real fit and
is a claim about the benchmark corpus rather than about PyBNF's tolerance handling. It belongs to
wshlavacek/BNGL-Models#38, where the 16-of-23 count is tracked.

## Unrelated, but noticed

Three tests in `tests/test_bngsim_sbml_bridge.py` (sensitivity-source warm counting) fail
identically on the base commit `e008d345` with the locally built bngsim wheel carrying #196/#213 —
they are in the 263 above, and are not touched by this change. Worth a separate look at whether that
build changed the codegen behaviour they assert on.
