### PR TITLE
fix(sbml): a hasOnlySubstanceUnits species' column is its amount, not amount/volume (#553)

### DIFF
--- a/pybnf/bngsim_sbml_model.py
+++ b/pybnf/bngsim_sbml_model.py
@@ -1285,6 +1285,26 @@ class BngsimSbmlModelNoTimeout(Model):
     def _data_with_headers(arr, headers):
         return Data.from_columns(arr, headers)
 
+    def _species_value_factors(self, species_names):
+        """Row of divisors taking a bngsim *concentration* to the PyBNF species value (#553).
+
+        The reciprocal of :attr:`_species_unit_factor`, broadcast over a trajectory's species
+        axis: the compartment size for an amount-declared (``hasOnlySubstanceUnits``) species
+        and ``1.0`` for every other one. bngsim reports every species column as a
+        concentration, but an amount-declared species' symbol *means its amount* -- in an SBML
+        formula and equally in the PEtab observable formulas PyBNF evaluates against these
+        columns -- so the column has to come back out of concentration units before anything
+        reads it.
+
+        This mirrors the single-value getter, which already returns
+        ``get_concentration(name) / self._species_unit_factor[name]``. Every factor is 1.0
+        for a concentration-valued species or a unit compartment, which is why this is a
+        no-op on every model that was already correct.
+        """
+        return np.array(
+            [self._species_unit_factor.get(name, 1.0) for name in species_names],
+            dtype=float)[np.newaxis, :]
+
     def _result_to_data(self, result, *, stochastic=False):
         """Convert a bngsim Result to a PyBNF Data object.
 
@@ -1299,7 +1319,7 @@ class BngsimSbmlModelNoTimeout(Model):
         species = np.asarray(result.species, dtype=float)
         arr = np.zeros((result.n_times, 1 + species.shape[1]))
         arr[:, 0] = result.time
-        arr[:, 1:] = species
+        arr[:, 1:] = species / self._species_value_factors(result.species_names)
         headers = ['time'] + list(result.species_names)
         data = self._data_with_headers(arr, headers)
         if self._sensitivity_request is not None and getattr(
@@ -1309,17 +1329,22 @@ class BngsimSbmlModelNoTimeout(Model):
         return data
 
     def _initial_state_derivative(self, engine_model, base_state, mut, name):
-        """Numerically differentiate initialized concentrations with respect to ``name``.
+        """Numerically differentiate the initialized state with respect to ``name``.
 
         SBML ``initialAssignment`` expressions are evaluated while an engine model is
         prepared, before bngsim's ODE sensitivity system starts. Re-prepare the model at
         two nearby values so a t=0-only experiment retains those assignment derivatives
         (for example ``Rec2(0) = ini_R1 * ini_R2fold`` in Schwen_PONE2014).
+
+        Both sides are converted out of concentration units before differencing (#553), so
+        the result is ``d(PyBNF species value)/d(name)`` and matches the units ``base_state``
+        arrives in -- which matters for the one-sided branches, where the two are mixed.
         """
         value = self._get_engine_value_if_present(engine_model, name)
         if value is None:
             return np.zeros_like(base_state)
         step = np.sqrt(np.finfo(float).eps) * max(1.0, abs(value))
+        value_factors = self._species_value_factors(engine_model.species_names)[0]
 
         states = {}
         for direction in (-1.0, 1.0):
@@ -1329,7 +1354,7 @@ class BngsimSbmlModelNoTimeout(Model):
                 state = np.asarray([
                     perturbed.get_concentration(species)
                     for species in engine_model.species_names
-                ], dtype=float)
+                ], dtype=float) / value_factors
                 if np.all(np.isfinite(state)):
                     states[direction] = state
             except Exception:
@@ -1356,9 +1381,11 @@ class BngsimSbmlModelNoTimeout(Model):
         differentiated through that expression by re-preparing the initialized model.
         """
         species_names = list(engine_model.species_names)
+        # Same concentration -> PyBNF-value conversion the integrated path applies (#553).
+        value_factors = self._species_value_factors(species_names)[0]
         state = np.asarray([
             engine_model.get_concentration(name) for name in species_names
-        ], dtype=float)
+        ], dtype=float) / value_factors
         data = self._data_with_headers(
             np.concatenate(([0.0], state))[np.newaxis, :], ['time'] + species_names)
 
@@ -1390,7 +1417,10 @@ class BngsimSbmlModelNoTimeout(Model):
                     d_ic[0, :, axis] = self._initial_state_derivative(
                         engine_model, state, mut, name)
                 elif name in species_index:
-                    d_ic[0, species_index[name], axis] = self._species_unit_factor[name]
+                    # d(PyBNF species value)/d(PyBNF IC value) for the species itself. The
+                    # concentration carries the unit factor and the reported value divides it
+                    # straight back out (#553), so the identity column is 1.0 in both units.
+                    d_ic[0, species_index[name], axis] = 1.0
         data.output_sensitivities = OutputSensitivities(
             selectors=selectors, param_names=list(req.params), ic_species=list(req.ic),
             d_param=d_param, d_ic=d_ic)
@@ -1411,10 +1441,15 @@ class BngsimSbmlModelNoTimeout(Model):
         selectors = ['species:%s' % name for name in species_names]
         param_names = list(result.sensitivity_params)
         ic_species = list(result.sensitivity_ic_species)
+        # ∂(concentration)/∂θ -> ∂(PyBNF species value)/∂θ, down the species axis, so the
+        # tensor stays in the units _result_to_data hands the value columns over in (#553).
+        value_factors = self._species_value_factors(species_names)[0][
+            np.newaxis, :, np.newaxis]
         d_param = None
         if param_names:
             d_param = np.asarray(
                 result.output_sensitivities(selectors, axis='parameter'), dtype=float)
+            d_param = d_param / value_factors
         d_ic = None
         if ic_species:
             d_ic = np.asarray(
@@ -1423,6 +1458,7 @@ class BngsimSbmlModelNoTimeout(Model):
             ic_factors = np.array(
                 [self._species_unit_factor[s] for s in ic_species], dtype=float)
             d_ic = d_ic * ic_factors[np.newaxis, np.newaxis, :]
+            d_ic = d_ic / value_factors
         return OutputSensitivities(
             selectors=selectors, param_names=param_names, ic_species=ic_species,
             d_param=d_param, d_ic=d_ic,

--- a/tests/test_bngsim_sbml_bridge.py
+++ b/tests/test_bngsim_sbml_bridge.py
@@ -1486,6 +1486,51 @@ def test_amount_species_column_reports_the_declared_amount(tmp_path, _clear_engi
 
 
 @pytest.mark.bngsim_sbml
+def test_amount_species_column_agrees_with_sbml_math_on_the_same_symbol(
+        tmp_path, _clear_engine_cache):
+    """The bridge's column for an amount species equals what SBML math says the symbol is (#553).
+
+    bngsim's ``Result`` carries both readings of the same species: ``species`` is its raw
+    concentration, while ``observables`` is the quantity the symbol denotes -- the amount for a
+    ``hasOnlySubstanceUnits`` species, the concentration otherwise. The second is produced by
+    bngsim's own SBML math and is untouched by anything the bridge does, so it is an oracle
+    for which of the two a PyBNF column should carry.
+
+    This is what justifies the changed expectation in
+    :func:`test_amount_species_initial_assignment_recompute_with_units`. That test asserted the
+    concentration ``initialAmount(2*k_init)/size(2) = k_init``; an ``initialAssignment`` on a
+    ``hasOnlySubstanceUnits`` species sets an *amount*, so the symbol is ``2*k_init`` and the
+    old expectation was the defect written down. Rather than argue from the spec, read it off
+    the model: bngsim reports 6.0 for the symbol where its raw concentration is 3.0.
+    """
+    import bngsim
+
+    xml_path = tmp_path / 'amt_ia_oracle.xml'
+    xml_path.write_text(_AMOUNT_IA_SBML)
+    xml_path = str(xml_path)
+    action = pset.TimeCourse({'time': '3', 'step': '3', 'method': 'ode'})
+
+    model = bngsim_sbml_model.BngsimSbmlModelNoTimeout(
+        xml_path, xml_path, pset=pset.PSet([]), actions=(action,),
+    )
+    assert model._species_unit_factor['S2'] == 0.5      # 1 / size(=2)
+    out = model.execute(str(tmp_path), 'amt_ia_oracle', 3)['time_course']
+
+    # The oracle, read off bngsim's own Result rather than through the bridge.
+    raw = bngsim.Simulator(bngsim.Model.from_sbml(xml_path)).run([0.0, 3.0])
+    idx = list(raw.species_names).index('S2')
+    symbol_value = float(np.asarray(raw.observables)[0][idx])
+    concentration = float(np.asarray(raw.species)[0][idx])
+
+    # k_init = 3, so the initialAssignment sets S2's AMOUNT to 6; the concentration is 3.
+    assert symbol_value == pytest.approx(6.0, rel=1e-9)
+    assert concentration == pytest.approx(3.0, rel=1e-9)
+    # The bridge's column must carry what the symbol means, not the raw concentration.
+    npt.assert_allclose(
+        np.asarray(out['S2'], dtype=float), symbol_value, rtol=1e-9)
+
+
+@pytest.mark.bngsim_sbml
 def test_variable_volume_compartment_forces_reload(tmp_path, _clear_engine_cache):
     """An amount-based species in a non-constant-volume compartment can't be
     safely unit-converted in place, so the bridge falls back to a full reload --

--- a/tests/test_bngsim_sbml_bridge.py
+++ b/tests/test_bngsim_sbml_bridge.py
@@ -1451,6 +1451,41 @@ def test_amount_species_nonunit_compartment_matches_reload(tmp_path, _clear_engi
 
 
 @pytest.mark.bngsim_sbml
+def test_amount_species_column_reports_the_declared_amount(tmp_path, _clear_engine_cache):
+    """A ``hasOnlySubstanceUnits`` species' column is its AMOUNT, not amount/size (#553).
+
+    bngsim reports every species column as a concentration, but such a species' symbol
+    denotes its amount -- in SBML math and equally in the PEtab observable formulas PyBNF
+    evaluates against these columns -- so the bridge has to divide the unit factor back out
+    on the way in.
+
+    This pins the absolute value, which is the gap that let the defect through:
+    :func:`test_amount_species_nonunit_compartment_matches_reload` asserts the in-place and
+    reload paths agree, and they did -- both in concentration units, both off by ``1/size``.
+    Agreement between two paths cannot see a units error common to both.
+    """
+    xml_path = tmp_path / 'amt_units.xml'
+    xml_path.write_text(_AMOUNT_CONST_VOL_SBML)
+    xml_path = str(xml_path)
+    action = pset.TimeCourse({'time': '3', 'step': '3', 'method': 'ode'})
+
+    model = bngsim_sbml_model.BngsimSbmlModelNoTimeout(
+        xml_path, xml_path, pset=pset.PSet([]), actions=(action,),
+    )
+    assert model._unsafe_volume is False
+    assert model._species_unit_factor['S2'] == 0.5      # 1 / size(=2)
+
+    out = model.execute(str(tmp_path), 'amt_units', 3)['time_course']
+
+    # S2 is declared initialAmount="4" in a size-2 compartment and is a boundary
+    # species, so it holds that amount for the whole run. Its concentration is 2.0;
+    # reading 2.0 here is the #553 regression.
+    npt.assert_allclose(np.asarray(out['S2'], dtype=float), 4.0, rtol=1e-9)
+    # Control: a concentration-declared species is untouched by the conversion.
+    assert abs(float(out['S0'][0]) - 10.0) < 1e-9
+
+
+@pytest.mark.bngsim_sbml
 def test_variable_volume_compartment_forces_reload(tmp_path, _clear_engine_cache):
     """An amount-based species in a non-constant-volume compartment can't be
     safely unit-converted in place, so the bridge falls back to a full reload --
@@ -1504,8 +1539,11 @@ def test_amount_species_initial_assignment_recompute_with_units(tmp_path, _clear
         assert fast_model._needs_structural_reload() is False
         assert fast_model._changes_touch_initials() is True
         fast = fast_model.execute(str(tmp_path), f'amt_ia_{int(k)}', 3)['time_course']
-        # S2(0) concentration = initialAmount(2*k_init) / size(2) = k_init.
-        assert abs(float(fast['S2'][0]) - k) < 1e-9
+        # S2 is hasOnlySubstanceUnits, so its column is the AMOUNT its
+        # initialAssignment sets: 2*k_init. (Before #553 this read the concentration
+        # amount/size = k_init; bngsim still stores the concentration internally, but
+        # the bridge divides the unit factor back out on the way into the Data.)
+        assert abs(float(fast['S2'][0]) - 2.0 * k) < 1e-9
 
         ref_model = _force_full_reload(bngsim_sbml_model.BngsimSbmlModelNoTimeout(
             xml_path, xml_path, pset=ps, actions=(action,),


### PR DESCRIPTION
Fixes #553.

## The defect

bngsim reports every species column as a **concentration** — a uniform internal convention that this
bridge already depends on and documents. But a `hasOnlySubstanceUnits="true"` species' symbol denotes
its **amount**, in SBML math and equally in the PEtab observable formulas PyBNF evaluates against
these columns. `_result_to_data` copied the concentration straight through, so every observable
reading such a species came out wrong by `1/size`.

The bridge already computed the factor it needed. `_species_unit_factor` was applied on the way *in*,
when reading a single value back, and on the forward-sensitivity IC axis — everywhere except the
trajectory columns:

| path | before |
|---|---|
| set a species value | `value * self._species_unit_factor[name]` |
| read one value back | `get_concentration(name) / self._species_unit_factor[name]` |
| forward-sensitivity IC axis | `d_ic * ic_factors` |
| **trajectory value columns** | **nothing** |

## The change

`_species_value_factors` divides that factor back out in `_result_to_data` and in the two t=0-only
paths that build a state row from `get_concentration`, so every path hands over PyBNF species values.

The sensitivity tensor moves with them — `d_param` and `d_ic` are scaled down the species axis, so
the gradient stays in the units the value columns are in. `_initial_state_derivative` converts both
sides before differencing, which its one-sided branches need since they mix a perturbed state with
`base_state`. The t=0 IC identity column becomes `1.0`: the concentration carries the unit factor and
the reported value divides it straight back out, so it is 1.0 in both units.

Every factor is 1.0 for a concentration-declared species or a unit compartment, so this is a **no-op
on every model that was already correct**.

## Why the existing tests did not catch it

`test_amount_species_nonunit_compartment_matches_reload` asserts the in-place and reload paths agree —
and they did, both in concentration units, both off by `1/size`. Agreement between two paths cannot
see a units error common to both. Nothing pinned the absolute value.

`test_amount_species_column_reports_the_declared_amount` does: a species declared `initialAmount="4"`
in a size-2 compartment must read **4.0**, not 2.0.

## One existing expectation changed — and it is settled by the model, not by argument

`test_amount_species_initial_assignment_recompute_with_units` asserted
`S2(0) concentration = initialAmount(2*k_init) / size(2) = k_init`. Its species is
`hasOnlySubstanceUnits`, so an `initialAssignment` on it sets an **amount**: the symbol is
`2*k_init`, the assertion encoded the defect, and it now reads `2.0 * k`. The rest of that test —
in-place/reload agreement, the unit factor, the initial-recompute machinery — is untouched.

That reinterpretation is not left as a spec argument for a reviewer to adjudicate.
`test_amount_species_column_agrees_with_sbml_math_on_the_same_symbol` derives it from the model:
bngsim's `Result` carries **both** readings of the same species — `species` is the raw
concentration, `observables` is the quantity the symbol denotes. The second is bngsim's own SBML
math, which nothing in this bridge can influence. On the existing `_AMOUNT_IA_SBML` fixture:

```
raw.species    S2 = 3.0      <- concentration
raw.observables S2 = 6.0     <- what the symbol means, = 2*k_init
```

The changed expectation is the second number, independently derived. The test asserts the bridge's
column matches it, so if bngsim and the bridge ever disagree about a symbol this fails rather than
drifting.

## Verification

**Full suite, this branch vs. unmodified `15b2fd9c`, same machine:**

| | failed | passed |
|---|---:|---:|
| baseline `15b2fd9c` | 260 | 3316 |
| this branch | 260 | **3317** |

The two failure sets are **byte-identical — not one test differs**. Those 260 are pre-existing in this
environment and all come from BioNetGen not being installed (562 "BioNetGen is not..." messages plus
`KeyError: 'BNGPATH'`); they are the BNGL-path suites, and this change touches only the SBML bridge.
The single delta is the new test.

Targeted suites all green: `test_gradient_sbml.py`, `test_bngsim_output_sensitivities.py`,
`test_gradient_events.py` (73 passed), plus `test_sbml_model.py`, `test_petab_sbml_layer.py`,
`test_petab_sbml_scanner.py`, `test_preequilibration_sbml.py`, `test_steady_state_experiment.py`,
`test_sbml_solver_tolerances.py`, `test_bngsim_antimony_bridge.py`, `test_bngsim_bridge.py`,
`test_sbml_runner_reuse.py`, `test_gradient_routing.py` (373 passed). Note
`test_sbml_fd_oracle_amount_species_seed` passes — that is the oracle covering an amount-species seed.

**Gradient consistency.** A finite-difference check of the assembled gradient against central
differences of the objective, on `Smith_BMCSystBiol2013` at its PEtab nominal point (25 free
parameters, a point far from the optimum so the gradient has real magnitude):

```
worst relative error: 8.30e-05        no structurally-zero columns
```

This is the check that the two halves agree: scaling the value columns without scaling the tensor
would put every affected column off by `1/V`.

**Benchmark corpus.** Re-evaluating all 23 Benchmark-Models-PEtab subset-I problems at their PEtab
nominal points leaves **22 bit-identical** and moves only `Smith_BMCSystBiol2013` — the one model with
both `hasOnlySubstanceUnits` species and non-unit compartments. Its paper-scale NLL goes from
**6.85e+32 to 8.88e+05**.

That model is the reason this surfaced: all 133 species are amount-declared and its compartments run
to `6.4e-14`, so observables were inflated by ~1.6e13. Multiplying the old predictions by their
compartment volume recovers the measured data almost exactly:

| observable | compartment | old prediction | × V | data | ratio |
|---|---|---:|---:|---:|---:|
| `PI3K_activity__2B` | cytoplasm | 3.1212e+13 | 515 | 515 | 1.000 |
| `IRSYp__2C` | cytoplasm | 1.3333e+13 | 220 | 220 | 1.000 |
| `Glucose_uptake__2B` | cellsurface | 3.5782e+15 | 229 | 230 | 0.996 |
| `Cell_Bound_Ins__2B` | cellsurface | 2.1931e+15 | 140.4 | 142 | 0.988 |

The control: `PTP_activ__2D` is a ratio within one compartment, where the volume cancels — and it was
the one observable already correct at that point (0.0619 vs 0.05).

The practical consequence was that the problem could not be fitted at all: absorbing `1/V ≈ 1e13`
would need its PEtab scale parameters to reach ~1e-15 against a box of `[1e-4, 1e4]`, and in a
100-start `gntr` run six of the nine pinned hard at the lower bound.
