### PR TITLE
fix(cmaes): the TolFun stagnation threshold is an absolute objective range with its own key, not a bar that rises as the fit improves (#550)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,32 @@ All notable changes to PyBNF are documented below. This project adheres to
   wheel that predates it.
 
 ### Fixed
+- **The CMA-ES restart battery's TolFun trigger no longer gets more eager as the fit gets better
+  (#550, ADR-0106, amends ADR-0082).** ADR-0082 made TolFun's stagnation threshold *relative* to the
+  current objective, `frange <= cmaes_stop_tol * max(1, |f|)`. PyBNF minimizes a negative
+  log-likelihood, which is unbounded below, so `|f|` **grows** as the fit improves and that threshold
+  rises as CMA-ES approaches the optimum — while Hansen's window `10 + ceil(30N/lambda)` shrinks as
+  IPOP grows the population (30 generations at `lambda = 32`, 11 at `lambda ≈ 1900`). The two move in
+  opposite directions and compound, so a late restart must improve by *more* within *fewer*
+  generations than an early one, and IPOP's large-population restarts — the ones grown to do the
+  heavy lifting — were the ones cut off mid-descent. On `Elowitz_Nature2000` (Grein subset-I, k=21)
+  restart 3 was descending `OG` 53.0 → 26.4 → 5.105 and was killed at the bottom of that descent
+  because `0.001/generation × 11 generations = 0.0105` fell just under `1e-4 × 121.06 = 0.0121`;
+  across two fits **all 14 restarts** fired on TolFun and not one run ever converged. TolFun now
+  compares an **absolute** range in objective units, as Hansen's `tolfun` does (pycma's relative
+  variant `tolfunrel` normalizes by the run's *initial* median, a scale that does not drift with fit
+  quality either; neither reference form uses the current `|f|`). On that fit the threshold becomes
+  the configured `1e-4` and the descent clears it by a factor of 100.
+  **TolFun also gains its own key, `cmaes_tolfun`.** `cmaes_stop_tol` is a step length in the
+  parameter sampling space and TolFun is a range in objective units; no single value is right for
+  both, and reaching a TolFun that fired at all on the fit above meant declaring the search
+  distribution converged at `1e-4` in `u`, seven orders looser than the default. Unset, `cmaes_tolfun`
+  follows `cmaes_stop_tol`, so an existing config keeps the threshold magnitude it had — the only
+  change is dropping the `|f|` factor, which can only make TolFun fire less, and a fit whose
+  objective satisfies `|f| <= 1` is unchanged outright. The restart reason now also reports the
+  tolerance it used (`range 0.0105 over the last 11 generations, tolerance 0.0001`), so a restart's
+  arithmetic is checkable from the log. `cmaes_restarts = 0` (the default) is untouched: the battery
+  is still restart-gated (ADR-0070).
 - **A PEtab v1 problem whose parameter table merely *has* a prior column no longer loses its log
   estimation scale (#548).** `petab1to2_preserve_scale` re-injects the `parameterScale` that
   `petab.v2.petab1to2` drops, skipping any row that already carries a prior so a scale petab1to2

--- a/docs/adr/0082-the-cmaes-restart-trigger-becomes-hansens-stopping-battery-tolfun-tolx-conditioncov-so-ipop-bipop-also-restarts-on-ill-conditioned-basins-where-the-principal-step-test-plateaus-above-cmaes-stop-tol.md
+++ b/docs/adr/0082-the-cmaes-restart-trigger-becomes-hansens-stopping-battery-tolfun-tolx-conditioncov-so-ipop-bipop-also-restarts-on-ill-conditioned-basins-where-the-principal-step-test-plateaus-above-cmaes-stop-tol.md
@@ -48,7 +48,11 @@ it is still a valid convergence signal) — and, **only when `cmaes_restarts > 0
 
 * **TolFun** — the best objective has stagnated: the range (max − min) of the best-per-generation value
   over the last `10 + ceil(30 N / lambda)` generations of *this run* is within `cmaes_stop_tol`
-  (relative, with an absolute floor of 1). This is the workhorse: it is **start-point- and
+  (relative, with an absolute floor of 1). **Amended by ADR-0106 / issue #550:** the relative form is
+  wrong on an objective that is unbounded below — `|f|` grows as the fit improves, so the threshold
+  rises as the run approaches the optimum and cuts off descending large-population restarts. The
+  threshold is now an absolute range in objective units, carried by its own key `cmaes_tolfun`
+  (defaulting to `cmaes_stop_tol`), as in the reference implementation. This is the workhorse: it is **start-point- and
   conditioning-independent**, firing precisely when the run stops improving even though the elongated
   principal step has plateaued above `cmaes_stop_tol`. It is what fires on the reproduction problems.
 * **TolX** — every coordinate standard deviation `sigma * sqrt(diag C)` and evolution-path component
@@ -80,7 +84,10 @@ as before.
 
 The tolerances are all "how small is negligible," so the battery reuses the existing `cmaes_stop_tol`:
 as the relative threshold for TolFun and the absolute (u-space) threshold for TolX — the same units and
-the same `1e-11` default as the principal-step test it complements. The two *structural* constants are
+the same `1e-11` default as the principal-step test it complements. (**Amended by ADR-0106 / issue
+#550:** they are not the same units. TolX and the principal-step test measure a length in the sampling
+space `u`; TolFun measures a range in objective units, and only the relative form disguised that. TolFun
+gains its own key, `cmaes_tolfun`, defaulting to `cmaes_stop_tol` so existing configs are unaffected.) The two *structural* constants are
 not user tuning knobs and are hardcoded to Hansen's standard values: the TolFun window
 `10 + ceil(30 N / lambda)`, and the ConditionCov threshold `1e14` (a float64-conditioning limit, the
 class constant `_COND_COV_MAX`). This keeps the config surface unchanged — the golden effective-config

--- a/docs/adr/0106-the-cmaes-tolfun-threshold-is-an-absolute-objective-range-carried-by-its-own-key-so-a-likelihood-fits-growing-f-no-longer-raises-the-bar-its-late-large-population-restarts-are-measured-against.md
+++ b/docs/adr/0106-the-cmaes-tolfun-threshold-is-an-absolute-objective-range-carried-by-its-own-key-so-a-likelihood-fits-growing-f-no-longer-raises-the-bar-its-late-large-population-restarts-are-measured-against.md
@@ -1,0 +1,179 @@
+# The CMA-ES TolFun threshold is an absolute objective range carried by its own key, so a likelihood fit's growing `|f|` no longer raises the bar its late, large-population restarts are measured against (issue #550)
+
+**Status: Accepted and implemented (2026-08-10). Amends ADR-0082.** ADR-0082 (issue #506) made
+TolFun — best-objective stagnation over a window — the workhorse of the CMA-ES restart battery, and
+gave it a threshold **relative to the current objective value**:
+`frange <= cmaes_stop_tol * max(1.0, abs(recent[-1]))`. On a likelihood objective that is the wrong
+normalizer, and wrong in the direction that costs the most: the objective is unbounded below, so
+`|f|` *grows* as the fit improves and the absolute stagnation threshold rises as CMA-ES approaches
+the optimum. This ADR makes TolFun what the reference implementation makes it — an **absolute** range
+in objective units — and gives it **its own key**, `cmaes_tolfun`, because an objective range and a
+step length in sampling space have no common scale and cannot share one well-set value. Everything
+else about the battery, including its restart-mode gate, is unchanged.
+
+## The defect
+
+ADR-0082 described TolFun's threshold as "relative, with an absolute floor". The floor is the
+`max(1.0, ...)`; the relative part is the defect. PyBNF's default framing minimizes a negative
+log-likelihood, which for continuous data is unbounded below, so a *better* fit has a *larger* `|f|`
+— and the threshold the run is measured against grows with it. The trigger becomes most eager
+exactly where firing it is most expensive.
+
+That would be tolerable on its own. It compounds with the window. `_tolfun_window()` is Hansen's
+`10 + ceil(30 N / lambda)`, which **shrinks** as IPOP grows the population: 30 generations at
+`lambda = 32`, 11 at `lambda ≈ 1900`. The two move in opposite directions, so a late restart must
+improve by *more* within *fewer* generations than an early one — on a problem where late-stage
+progress per generation is by nature smaller. IPOP's large-population restarts, the ones the
+schedule grows in order to do the heavy lifting, are the ones most likely to be cut off mid-descent.
+This is the **opposite failure of the same trigger** ADR-0082 fixed: #506 was "the restart never
+fires"; #550 is "it fires on runs that are still descending".
+
+### Observed
+
+`Elowitz_Nature2000` from the Grein subset-I collection (k=21, n=58, `sbml_backend = bngsim`), PyBNF
+`e008d345`. Restart 3 (`population 702`) was in a sustained descent — `OG` 53.0 → 26.4 → 5.105 over
+roughly 150 generations — and TolFun terminated it at the bottom of that descent:
+
+| quantity | value |
+|---|---|
+| `cmaes_stop_tol` | `1e-4` |
+| `abs(recent[-1])` at the good point | 121.06 |
+| effective threshold | **0.0121** |
+| window at `lambda = 702` | **11 generations** |
+| observed descent rate | ~0.001 / generation |
+| ⇒ achievable range in the window | ~0.011 |
+| observed `frange` | **0.0105** — just under |
+
+The run was descending at a healthy rate for a narrow valley and was killed because
+`0.001 * 11 < 1e-4 * 121`. Earlier in the same fit, at `|f| = 87.6`, the threshold was 0.0088: the
+run's improving objective is what raised the bar it was then measured against. Across two fits on
+this problem **every one of 14 restarts fired on TolFun** (ranges 0.0025–0.0113), and not one run
+ever terminated by actually converging.
+
+### What this is not
+
+It is not "make TolFun less eager". A control run on the same problem — single run, no restarts,
+`cmaes_stop_tol = 1e-11` — sat at `OG = 72.51` for 541 generations, barely moved from `72.52` at
+generation 48. That run was genuinely converged and restarting it would have been right. The
+distinction that matters is that at `OG = 72.5` the run was stagnant and at `OG = 5.1` it was
+descending at ~0.001/generation, and **a threshold that scales with `|f|` cannot separate those two
+cases** — it gets the second one wrong precisely because the second one is the better fit.
+
+## The decision
+
+### 1. TolFun compares an absolute objective range, as the reference implementation does
+
+Checked against pycma at `master` (`cma/evolution_strategy.py`, `CMAStopDict._update`;
+`cma/options_parameters.py` for the defaults), because ADR-0082 claims Hansen's battery and this is
+the point at which the claim was not true:
+
+* `tolfun` (default `1e-11`) — **absolute**: fires when the current generation's fitness range *and*
+  the historic range are both below it.
+* `tolfunhist` (default `1e-12`) — **absolute** on the historic range alone.
+* `tolfunrel` (default `0`, i.e. off) — relative, but normalized by
+  `median0 - median_min`: the median objective **at the run's start** minus the best median since.
+  A scale fixed by where the run began, not by where it currently is.
+
+Neither reference form normalizes by the current objective value. PyBNF's `frange` is exactly
+pycma's `historic_fitness_range` — the same `10 + 30 N / lambda`-truncated best-per-generation
+history — so the fix is to drop the `max(1.0, abs(recent[-1]))` factor and compare the range against
+a fixed tolerance. `tolfunrel`'s normalizer was considered and not adopted (see Alternatives).
+
+### 2. TolFun gets its own key, `cmaes_tolfun`
+
+ADR-0082 decided "No new config keys; reuse `cmaes_stop_tol`", on the grounds that the battery's
+tolerances are all "how small is negligible" and share units. Two of the three do: the principal-step
+test and TolX both measure a length in the sampling space `u`. TolFun does not — it measures a range
+in objective units, whose natural magnitude is set by the data, the noise model and the number of
+scored points, and has nothing to do with the parameterization. The relative form is what allowed one
+number to stand in for both, and the relative form is the defect.
+
+The Elowitz fit is the demonstration. Getting a TolFun that fires at all required
+`cmaes_stop_tol = 1e-4`, seven orders looser than the default — which is simultaneously a claim that
+the search distribution has converged once its principal step drops below `1e-4` in `u`. That is not
+a claim anyone intended to make; it is the price of the shared key.
+
+So `cmaes_tolfun` is the TolFun tolerance, an absolute range in objective units. **Unset it falls
+back to `cmaes_stop_tol`**, so an existing config keeps the threshold magnitude it had today and no
+fit silently changes tolerance; the only behavioral difference for such a config is the removal of
+the `|f|` factor, which can only make TolFun fire *less*.
+
+### 3. The reason string reports the threshold it used
+
+The entire diagnosis in #550 was carried out from a restart log line that reported the range and the
+window but not the number they were compared against — the reporter had to reconstruct
+`1e-4 * 121.06` by hand. The reason now reads
+`best objective stagnated (range 0.0105 over the last 11 generations, tolerance 0.0001)`, so the
+arithmetic of a restart is checkable from the log alone.
+
+## What is deliberately not changed
+
+* **The window stays Hansen's `10 + ceil(30 N / lambda)`.** It is budget-normalized: `30 N`
+  *evaluations* of flat history plus a floor of 10 generations, so a large population needs
+  proportionally fewer generations because each one buys proportionally more information. With the
+  `|f|` drift gone only one of the two terms moves, and it moves the way Hansen intended. A fit that
+  wants its late restarts left alone now has a knob that says so directly.
+* **The battery stays restart-gated.** `cmaes_restarts == 0` remains byte-identical to the
+  pre-restart optimizer (ADR-0070); nothing here touches that.
+* **pycma's second TolFun conjunct is not adopted.** Hansen's `tolfun` also requires the *current
+  generation's* fitness range to be below the tolerance, which would make TolFun strictly harder to
+  fire and would sharpen the distinction this ADR is about — a descending population still spans a
+  range, a converged one does not. It is not adopted because PyBNF scores a failed simulation `inf`
+  (`base.py`, `add_to_trajectory`): one dead candidate in a generation makes the current-generation
+  range `inf` permanently, and TolFun — the trigger #506 exists for — would then never fire on
+  exactly the models whose parameter space contains failing points. A robust spread (over the `mu`
+  parents, or a quantile) would work around that, but it is a second, unmeasured change to the same
+  trigger in the same release, and #550 does not need it.
+
+## Consequences
+
+* **A descending run survives.** On the reported fit the threshold drops from `0.0121` to the
+  configured `1e-4`, and the `0.0105` descent clears it by a factor of 100. The trigger no longer
+  tightens as the fit improves, so a late large-population restart is held to the same standard as
+  an early one.
+* **Stagnation is still caught.** The absolute test is the reference implementation's; the control
+  run's flat history trips it exactly as before, and the unit tests pin both directions at the
+  decision point.
+* **Existing configs keep their magnitude.** `cmaes_tolfun` unset is `cmaes_stop_tol`. A fit whose
+  objective satisfies `|f| <= 1` is byte-identical, since the `max(1.0, ...)` floor already governed
+  there.
+* **`cmaes_restarts == 0` is untouched**, and the end-to-end #506 guard
+  (`test_cmaes_ipop_restart_battery_fires_and_escapes_an_ill_conditioned_trap`) stays green: on that
+  trap the battery still fires and IPOP still escapes to the global mode.
+* **One new config key.** `cmaes_tolfun` joins the schema (`Optional[float]`, `ge=0`), the parse
+  float-token list, and the golden effective-config corpus, which moves by that one key.
+* **What a user should set.** With `cmaes_restarts > 0` on a likelihood fit, set `cmaes_tolfun` to
+  the smallest objective improvement per window you still consider progress, and leave
+  `cmaes_stop_tol` at the convergence step you actually mean.
+
+## Alternatives considered
+
+* **pycma's `tolfunrel` normalizer (`median0 - median_min`).** Rejected. It removes the drift with
+  `|f|`, but replaces it with a scale set by how bad the run's random start happened to be — and in
+  box mode *every* restart starts from a fresh uniform draw, so the threshold would swing by orders
+  of magnitude between restarts of one fit for reasons that have nothing to do with the landscape
+  near the optimum. It is also defined on the current-generation range, which the `inf`-scored
+  failed simulation rules out (above). Hansen ships it off by default and `tolfun` on.
+* **A per-generation improvement-rate test** (`frange / window` against a rate tolerance), as #550
+  suggests. Not adopted now. It would additionally decouple the trigger from the window length,
+  which is a real property worth having; but on the reported evidence it separates the stagnant and
+  descending cases by the same factor the absolute range does (both cases were measured over the
+  same window), it is not what the reference implementation does, and Hansen's window constant was
+  designed for a range test. If a fit is later shown to need window-independence, the only thing
+  that changes is the units of `cmaes_tolfun`.
+* **Keep one key and re-tune it.** Rejected: that is what produced the failure. No value of
+  `cmaes_stop_tol` is simultaneously a sensible converged-distribution step and a sensible objective
+  stagnation range, and the relative form's whole purpose was to paper over the gap.
+* **Drop TolFun, or raise its tolerance globally.** Rejected: the control run shows TolFun firing is
+  often exactly right, and ADR-0082's ill-conditioned reproduction needs it.
+
+## References
+
+* Issue #550 (this defect) and the reproduction write-up wshlavacek/BNGL-Models#38
+  (`Elowitz_Nature2000`, Grein subset-I).
+* pycma `master`: `cma/evolution_strategy.py` (`CMAStopDict._update` — `tolfun` / `tolfunhist` /
+  `tolfunrel`), `cma/options_parameters.py` (their defaults `1e-11` / `1e-12` / `0`).
+* N. Hansen, A. Ostermeier (2001), *Completely Derandomized Self-Adaptation in Evolution Strategies*;
+  A. Auger, N. Hansen (2005), *A Restart CMA Evolution Strategy With Increasing Population Size*.
+* ADR-0082 (the battery this amends, #506), ADR-0070 (the IPOP/BIPOP restart machinery and its
+  byte-identity contract, #498), ADR-0085 (the per-run generation cap, #507).

--- a/docs/algorithms.rst
+++ b/docs/algorithms.rst
@@ -759,6 +759,14 @@ the global ``max_iterations`` budget. It is unset by default, preserving the exi
 unbounded-per-run behavior; BIPOP small runs keep their own automatic, possibly smaller,
 evaluation-balancing cap.
 
+A run also finishes when it stops improving: ``cmaes_tolfun`` is the stagnation
+tolerance, the smallest range of the best objective across the last
+``10 + ceil(30 × (number of parameters) / population_size)`` generations that still
+counts as progress. Because it measures the objective and ``cmaes_stop_tol`` measures a
+step in parameter space, the two have no common scale — set ``cmaes_tolfun`` to the
+objective improvement per window you consider alive, and leave ``cmaes_stop_tol`` at the
+convergence step you actually mean. Unset, ``cmaes_tolfun`` follows ``cmaes_stop_tol``.
+
 
 .. _alg-gradient:
 

--- a/docs/config_keys.rst
+++ b/docs/config_keys.rst
@@ -1505,13 +1505,22 @@ These settings for the :ref:`CMA-ES <alg-cmaes>` optimizer apply both to ``job_t
     * ``cmaes_sigma0 = 0.5``
 
 **cmaes_stop_tol**
-  Stop when the largest principal standard deviation of the search distribution falls below this value.
+  Stop when the largest principal standard deviation of the search distribution falls below this value. This is a step length in the parameter sampling space, and in restart mode (``cmaes_restarts > 0``) it is also the threshold below which every individual coordinate step counts as collapsed. The stagnation threshold on the *objective* is ``cmaes_tolfun``.
 
   Default: 1e-11
 
   Example:
 
     * ``cmaes_stop_tol = 1e-8``
+
+**cmaes_tolfun**
+  Stagnation tolerance on the objective, used only in restart mode (``cmaes_restarts > 0``): a run is declared finished — and yields to the next restart — when the range of its best objective over the last ``10 + ceil(30 × (number of parameters) / population_size)`` generations falls to this value or below. It is an absolute range in the units of your objective function, unlike ``cmaes_stop_tol``, which is a step length in the parameter sampling space; set it to the smallest objective improvement per window that you still consider progress. Unset, it follows ``cmaes_stop_tol``, which is rarely what you want if you rely on stagnation restarts: a value loose enough to detect a stalled run is far looser than a converged search distribution.
+
+  Default: unset (follows ``cmaes_stop_tol``)
+
+  Example:
+
+    * ``cmaes_tolfun = 1e-3``
 
 **cmaes_restarts**
   Maximum number of IPOP / BIPOP restarts for multimodal search. A single CMA-ES run descends into the one basin its start lands in, so on a multimodal objective it reaches only a local minimum. With ``cmaes_restarts > 0``, whenever a run *finishes* by converging (its search distribution shrinks below ``cmaes_stop_tol``, or its step size degenerates) or reaching ``cmaes_run_maxgen`` — as distinct from exhausting the generation budget ``max_iterations`` — CMA-ES reinitializes from a fresh random point in the prior box with a rescaled population and keeps searching, up to this many restarts, keeping the global best across all runs. Requires the box / global-start mode (bounded ``uniform_var`` / ``loguniform_var`` priors), which provides the box restarts resample from. ``0`` (the default) is a single run.

--- a/pybnf/algorithms/optimizers/cmaes.py
+++ b/pybnf/algorithms/optimizers/cmaes.py
@@ -103,9 +103,11 @@ class CMAESConfig(PyBNFConfigModel):
     interpreted relative to the start the fit actually uses. ``cmaes_stop_tol``
     ends the run when the largest principal standard deviation of the search
     distribution shrinks below it; in restart mode (``cmaes_restarts > 0``) it is also
-    the tolerance for the restart battery (#506) -- the relative TolFun (best-objective)
-    stagnation threshold and the absolute TolX coordinate-step threshold. The population
-    size ``lambda`` is the global
+    the TolX coordinate-step threshold of the restart battery (#506), which is the same
+    quantity in the same units. ``cmaes_tolfun`` is the battery's TolFun
+    (best-objective stagnation) tolerance, which is *not*: it is a range in objective
+    units, so it gets its own knob (#550, ADR-0106) and falls back to ``cmaes_stop_tol``
+    when unset. The population size ``lambda`` is the global
     ``population_size`` (consistent with de/pso/sa), and ``max_iterations`` remains
     the global generation budget across all runs. ``cmaes_run_maxgen`` optionally
     adds a smaller per-run generation cap; unset means no user cap.
@@ -124,6 +126,7 @@ class CMAESConfig(PyBNFConfigModel):
 
     cmaes_sigma0: float = 0.3
     cmaes_stop_tol: float = 1e-11
+    cmaes_tolfun: Optional[float] = Field(default=None, ge=0.0)
     cmaes_restarts: int = 0
     cmaes_restart_strategy: str = 'ipop'
     cmaes_ipop_factor: float = 2.0
@@ -151,6 +154,14 @@ class CMAESAlgorithm(StartPointOptimizer):
         self.sigma0 = config.config['cmaes_sigma0']
         self.base_sigma0 = self.sigma0     # un-perturbed sigma0 (BIPOP varies it per restart)
         self.stop_tol = config.config['cmaes_stop_tol']
+        # The restart battery's TolFun tolerance (#550, ADR-0106). It is a range in
+        # OBJECTIVE units, where stop_tol is a step length in sampling space u, so the
+        # two have no common scale and cannot share one well-set value. Unset it falls
+        # back to stop_tol -- the single knob TolFun used before -- so an existing
+        # config keeps the threshold magnitude it had, without the |f| scaling.
+        configured_tolfun = config.config['cmaes_tolfun']
+        self.tolfun = (self.stop_tol if configured_tolfun is None
+                       else float(configured_tolfun))
         self.max_generations = config.config['max_iterations']
 
         # Restart schedule (#498, ADR-0070). cmaes_restarts == 0 (the default) is a
@@ -414,11 +425,17 @@ class CMAESAlgorithm(StartPointOptimizer):
         (#506), each a per-run termination string or None:
 
         * **TolFun** -- the best objective has stagnated: its range over the last
-          ``_tolfun_window`` generations of *this* run is within ``cmaes_stop_tol``
-          (relative, with an absolute floor). This is start-point- and
+          ``_tolfun_window`` generations of *this* run is within ``cmaes_tolfun``
+          (Hansen's absolute tolerance on the range of recent best objective values; it
+          defaults to ``cmaes_stop_tol``). This is start-point- and
           conditioning-independent -- it fires when the run stops improving even though
           the (ill-conditioned) principal step has plateaued above ``cmaes_stop_tol`` --
-          and is the trigger the reproduction problems need.
+          and is the trigger the reproduction problems need. The threshold is a fixed
+          objective-unit range and deliberately does **not** scale with the current
+          ``|f|`` (#550, ADR-0106): on an objective that is unbounded below -- every
+          likelihood fit -- ``|f|`` grows as the fit improves, so a relative threshold
+          rises fastest exactly where firing it costs the most, cutting off the late,
+          large-population restarts that are meant to do the heavy lifting.
         * **TolX** -- every coordinate standard deviation and evolution-path component is
           below ``cmaes_stop_tol``: the whole distribution has collapsed (the classic
           "converged" signal, complementary to the largest-principal-axis test).
@@ -433,9 +450,9 @@ class CMAESAlgorithm(StartPointOptimizer):
         if len(hist) >= window:
             recent = hist[-window:]
             frange = max(recent) - min(recent)
-            if frange <= self.stop_tol * max(1.0, abs(recent[-1])):
+            if frange <= self.tolfun:
                 return ('best objective stagnated (range %.3g over the last %i '
-                        'generations)' % (frange, window))
+                        'generations, tolerance %g)' % (frange, window, self.tolfun))
         coord_std = self.sigma * np.sqrt(np.maximum(np.diag(self.C), 0.0))
         if (np.all(coord_std < self.stop_tol)
                 and np.all(self.sigma * np.abs(self.pc) < self.stop_tol)):

--- a/pybnf/parse.py
+++ b/pybnf/parse.py
@@ -71,6 +71,10 @@ numkeys_float = ['min_objective', 'cognitive', 'social', 'particle_weight',
                  'rhat_threshold', 'snooker_prob', 'kalman_burnin_frac',
                  'powell_step', 'powell_line_tol', 'powell_stop_tol',
                  'cmaes_sigma0', 'cmaes_stop_tol',
+                 # CMA-ES restart battery (job_type = cmaes, #550/ADR-0106): the TolFun
+                 # best-objective stagnation tolerance, a range in objective units
+                 # (unset it follows cmaes_stop_tol).
+                 'cmaes_tolfun',
                  # CMA-ES restart (job_type = cmaes, #498/ADR-0070): the IPOP / BIPOP
                  # geometric population-growth factor per restart (2.0 = doubling).
                  'cmaes_ipop_factor',

--- a/tests/golden_configs/effective_config_golden.json
+++ b/tests/golden_configs/effective_config_golden.json
@@ -5542,6 +5542,10 @@
     1e-11
    ],
    [
+    "cmaes_tolfun",
+    null
+   ],
+   [
     "constraint_scale",
     1.0
    ],
@@ -5866,6 +5870,10 @@
    [
     "cmaes_stop_tol",
     1e-11
+   ],
+   [
+    "cmaes_tolfun",
+    null
    ],
    [
     "constraint_scale",
@@ -6893,6 +6901,10 @@
    [
     "cmaes_stop_tol",
     1e-11
+   ],
+   [
+    "cmaes_tolfun",
+    null
    ],
    [
     "constraint_scale",

--- a/tests/test_optimizer_integration.py
+++ b/tests/test_optimizer_integration.py
@@ -515,6 +515,88 @@ def test_cmaes_restart_battery_conditioncov_fires_on_ill_conditioning(tmp_path):
     assert reason is not None and 'ill-conditioned' in reason
 
 
+# --------------------------------------------------------------------------- #
+# TolFun is an absolute objective range with its own knob (#550, ADR-0106)
+# --------------------------------------------------------------------------- #
+# #506 shipped TolFun as a RELATIVE test, frange <= cmaes_stop_tol * max(1, |f|). On a
+# likelihood objective -- unbounded below, so |f| GROWS as the fit improves -- that makes
+# the absolute threshold rise as the run gets better, and IPOP's late large-population
+# restarts (whose Hansen window 10 + ceil(30N/lambda) is simultaneously SHRINKING) are cut
+# off mid-descent: the trigger is most eager exactly where firing it costs the most. The
+# threshold is now an absolute range in objective units, carried by its own key -- TolFun
+# measures an objective range while cmaes_stop_tol measures a step length in sampling
+# space u, so no single value can be right for both.
+
+
+def _tolfun_state(alg, history):
+    """Put ``alg`` in an ill-conditioned polishing state where TolFun is the only battery
+    trigger that can fire -- the principal step and every coordinate step sit far above
+    the tolerance and the condition number stays below _COND_COV_MAX -- with
+    ``history`` as this run's best-per-generation record."""
+    alg.sigma = 1e-3
+    alg.d = np.array([1e4, 1e-2])          # principal = 10; cond = 1e12 < 1e14
+    alg.C = np.diag(alg.d ** 2)            # coord std = [10, 1e-5], not all below tol
+    alg.pc = np.zeros(alg.n)
+    alg.run_generation = 200
+    alg.run_maxgen = np.inf
+    alg._run_best_history = list(history)
+
+
+def test_cmaes_tolfun_does_not_scale_with_the_objective_magnitude(tmp_path):
+    """The #550 defect, at the decision point, in the reported arithmetic. A run in
+    sustained descent -- the best objective falling steadily by 0.0105 across the window
+    -- is NOT stagnant, but under the relative form its own quality raised the bar it was
+    measured against: at |f| = 121.06 with cmaes_stop_tol = 1e-4 the threshold was
+    1e-4 * 121.06 = 0.0121, above the 0.0105 the run had just achieved, so TolFun fired
+    and killed the descent. Against an absolute 1e-4 the same history is 100x clear of
+    the tolerance and the run keeps going."""
+    alg = _battery_alg(tmp_path, cmaes_restarts=3, cmaes_stop_tol=1e-4)
+    # A negative log-likelihood descending past -121: unbounded below, so |f| grows as
+    # the fit improves -- the framing every problem in the benchmark collection uses.
+    hist = np.linspace(-121.0495, -121.06, alg._tolfun_window())
+    _tolfun_state(alg, hist)
+
+    frange = float(max(hist) - min(hist))
+    assert frange == pytest.approx(0.0105, abs=1e-6)
+    # The relative form would have fired on exactly this descent...
+    assert frange <= alg.stop_tol * max(1.0, abs(float(hist[-1])))
+    # ...and the absolute one does not: the threshold no longer follows |f| upward.
+    assert alg.tolfun == alg.stop_tol
+    assert alg._battery_stop_reason() is None
+    assert alg._run_stop_reason() is None
+
+
+def test_cmaes_tolfun_still_fires_on_a_genuinely_flat_history(tmp_path):
+    """The other half of #550: this is not "make TolFun less eager". At the same |f| and
+    the same tolerance, a run that has actually stopped improving -- a range three orders
+    below the tolerance rather than two above it -- still trips the trigger, and the
+    reason string now reports the threshold it was measured against, so the arithmetic of
+    a restart is checkable from the log."""
+    alg = _battery_alg(tmp_path, cmaes_restarts=3, cmaes_stop_tol=1e-4)
+    _tolfun_state(alg, np.linspace(-121.0599993, -121.06, alg._tolfun_window()))
+
+    reason = alg._battery_stop_reason()
+    assert reason is not None and 'stagnated' in reason and 'tolerance' in reason
+
+
+def test_cmaes_tolfun_is_a_knob_of_its_own(tmp_path):
+    """cmaes_stop_tol is a step length in sampling space u; TolFun's is a range in
+    objective units. Sharing one key forced a fit that wanted a meaningful stagnation
+    threshold to loosen its convergence test by the same seven orders of magnitude (or
+    the reverse). cmaes_tolfun separates them: a stagnation threshold of 1e-3 in
+    objective units alongside the default 1e-11 convergence step."""
+    alg = _battery_alg(tmp_path, cmaes_restarts=3, cmaes_stop_tol=1e-11,
+                       cmaes_tolfun=1e-3)
+    assert alg.stop_tol == 1e-11 and alg.tolfun == 1e-3
+    # A range of 1e-4: stagnant on the objective, while the search distribution is
+    # nowhere near the 1e-11 convergence step the same key used to have to serve.
+    _tolfun_state(alg, np.linspace(-121.0599, -121.06, alg._tolfun_window()))
+
+    reason = alg._battery_stop_reason()
+    assert reason is not None and 'stagnated' in reason
+    assert alg.sigma * float(np.max(alg.d)) > alg.stop_tol   # not converged, by far
+
+
 # A shallow, strongly ANISOTROPIC local mode at the box center: steep along p1
 # (variance 0.01), and along p2 an enormous variance (1e5) so that within the box the
 # objective is essentially FLAT along p2 -- the run cannot converge that direction, its


### PR DESCRIPTION
Fixes #550.

## The defect

ADR-0082 (#506) made TolFun the workhorse of the CMA-ES restart battery and gave it a threshold **relative to the current objective value**:

```python
frange <= self.stop_tol * max(1.0, abs(recent[-1]))
```

PyBNF minimizes a negative log-likelihood, which is unbounded below, so `|f|` **grows** as the fit improves and the threshold rises as CMA-ES approaches the optimum. It compounds with the window: Hansen's `10 + ceil(30N/lambda)` **shrinks** as IPOP grows the population (30 generations at `lambda=32`, 11 at `lambda~1900`). A late restart must therefore improve by *more* within *fewer* generations than an early one — on a problem where late-stage progress per generation is by nature smaller — so IPOP's large-population restarts, the ones the schedule grows in order to do the heavy lifting, are the ones cut off mid-descent.

On `Elowitz_Nature2000` (Grein subset-I, k=21) restart 3 was in a sustained descent, `OG` 53.0 → 26.4 → 5.105 over ~150 generations, and TolFun killed it at the bottom of that descent: at `|f| = 121.06` with `cmaes_stop_tol = 1e-4` the threshold was `0.0121`, and 0.001/generation over an 11-generation window is `0.0105` — just under. Across two fits **all 14 restarts** fired on TolFun and not one run ever converged.

This is the opposite failure of the same trigger #506 fixed.

## The change

**TolFun compares an absolute range in objective units**, as the reference implementation does. Checked against pycma `master` (`cma/evolution_strategy.py`, `cma/options_parameters.py`): `tolfun` (`1e-11`) is absolute on both the current-generation and historic fitness ranges; `tolfunhist` (`1e-12`) is absolute; `tolfunrel` (default `0`, off) normalizes by `median0 - median_min`, the median at the run's *start*. Neither reference form uses the current `|f|`. PyBNF's `frange` is exactly pycma's `historic_fitness_range` — the same `10 + 30N/lambda`-truncated best history — so the fix is dropping the `max(1.0, abs(recent[-1]))` factor.

**TolFun gains its own key, `cmaes_tolfun`.** ADR-0082 reused `cmaes_stop_tol` on the grounds that the battery's tolerances share units. Two of the three do — the principal-step test and TolX are lengths in the sampling space `u` — but TolFun is a range in objective units, and only the relative form disguised that. Getting a TolFun that fired at all on the fit above required `cmaes_stop_tol = 1e-4`, which is simultaneously a claim that the search distribution has converged once its principal step drops below `1e-4` in `u`. Unset, `cmaes_tolfun` follows `cmaes_stop_tol`.

**The restart reason reports the tolerance it used** (`range 0.0105 over the last 11 generations, tolerance 0.0001`), so a restart's arithmetic is checkable from the log — which is how #550 was diagnosed.

## Compatibility

- `cmaes_tolfun` unset = `cmaes_stop_tol`, so an existing config keeps its threshold magnitude. The only behavioral change is removing the `|f|` factor, which can only make TolFun fire **less**; a fit whose objective satisfies `|f| <= 1` is unchanged outright (the `max(1.0, ...)` floor already governed there).
- `cmaes_restarts = 0` (the default) is byte-identical — the battery is still restart-gated (ADR-0070).
- One new config key; the golden effective-config corpus moves by that key and nothing else.

## Deliberately not changed

- **The window stays Hansen's `10 + ceil(30N/lambda)`.** It is budget-normalized (30N *evaluations* plus a 10-generation floor), and with the `|f|` drift gone only one of the two terms moves. A per-generation rate test (issue suggestion 3) would additionally decouple the trigger from window length; on the reported evidence it separates the stagnant and descending cases by the same factor the absolute range does, it is not what the reference implementation does, and if a fit later needs it the only thing that changes is the units of `cmaes_tolfun`.
- **pycma's second TolFun conjunct** — the current generation's fitness range must also be below the tolerance — is not adopted. PyBNF scores a failed simulation `inf` (`add_to_trajectory`), so one dead candidate would make that range `inf` permanently and TolFun would never fire on exactly the models whose parameter space contains failing points.
- **`tolfunrel`'s normalizer** is not adopted either: in box mode every restart starts from a fresh uniform draw, so a threshold scaled by `median0` would swing by orders of magnitude between restarts of one fit for reasons unrelated to the landscape near the optimum.

## Tests

Three unit tests at the decision point (`tests/test_optimizer_integration.py`):

- the reported descent (range `0.0105` at `|f| = 121.06`, tolerance `1e-4`) no longer fires — and the test asserts the relative form *would* have fired on exactly that history;
- a genuinely flat history at the same `|f|` and the same tolerance still fires, with the threshold in the reason string (this is not "make TolFun less eager");
- `cmaes_tolfun = 1e-3` alongside `cmaes_stop_tol = 1e-11` fires on stagnation while the search distribution is nowhere near the convergence step the one key used to have to serve.

The end-to-end #506 guard (`test_cmaes_ipop_restart_battery_fires_and_escapes_an_ill_conditioned_trap`) is unchanged and green: the battery still fires on the ill-conditioned ridge and IPOP still escapes to the global mode.

Full default tier: 3659 passed, 32 skipped, 0 failed (with `BNGPATH` set, against a bngsim wheel built from the local checkout at `eb956a4`). `-m slow` CMA-ES tier: 6 passed.

## Docs

ADR-0106 (amending ADR-0082, which gains inline amendment notes at both points it now gets wrong), `docs/config_keys.rst`, `docs/algorithms.rst`, CHANGELOG.
