### PR TITLE
test(sbml): re-derive the ADR-0103 loose-tolerance guard from both ends of the bngsim range, not the one release that drew it (#566)

### DIFF
--- a/tests/test_sbml_solver_tolerances.py
+++ b/tests/test_sbml_solver_tolerances.py
@@ -879,9 +879,34 @@ def test_the_backend_default_atol_is_what_corrupted_those_sensitivities(tmp_path
 
     The other half of the regression: without this, a future change that quietly stopped
     deriving the tolerance would leave the test above passing on some unrelated accuracy
-    margin. Here the same model, same roots, same difference-quotient sensitivity path,
-    integrated at the old default, is wrong by more than 10% on every column -- the same
-    order as the 26% #546 measured on Giordano's worst.
+    margin. Same model, same roots, same difference-quotient sensitivity path (``k`` is
+    still declined for the analytic RHS -- "uses unsupported construct: if() conditional"
+    -- so this is the CVODES internal quotient inheriting the state solve's accuracy),
+    integrated at the old default instead of the derived one.
+
+    **Two claims, because one number is not portable across backend versions (#566).**
+    At least one column is corrupted outright -- 3.8e-01 measured, the order #546 saw on
+    Giordano's worst (26%) -- and it is not one unlucky column: *every* column blows the
+    sibling's ``< 1e-4`` budget by more than two decades, which is what makes the pair a
+    pair. Neither half can be satisfied by an accuracy regime that satisfies the other.
+
+    The thresholds are re-derived rather than inherited, because the original single
+    ``min(errs) > 0.1`` never had the margin this file asks for. Measured::
+
+        bngsim 0.12.2   [1.28e-01, 1.41e-01, 3.84e-01]    min 1.28e-01
+        bngsim 0.13.0   [8.50e-02, 3.95e-02, 3.79e-01]    min 3.95e-02
+
+    A ``> 0.1`` bar cleared 0.12.2's tightest column by **1.28x**. Anything that improved
+    the state solve was going to flip it, and 0.13.0 did: it lands the integrator step
+    *on* a fixed time discontinuity so its root can fire (lanl/bngsim#305) instead of
+    stepping over it -- a real improvement to precisely this shape, a rate law switching
+    at fixed times. Both versions still decline the analytic RHS, so the path under test
+    is unchanged and nothing here is being papered over; the loose-tolerance case is
+    simply less catastrophic than it was.
+
+    So each threshold now sits a decade under the *worse* of the two measurements -- the
+    rule the two-scale test above states -- and both hold across the declared
+    ``bngsim>=0.12.2,<1`` range rather than on the one release that drew them.
     """
     model = _piecewise_model(tmp_path, atol=_BNGSIM_DEFAULT_ATOL)
     model.enable_output_sensitivities(params=['k0', 'k1', 'k2'])
@@ -893,7 +918,11 @@ def test_the_backend_default_atol_is_what_corrupted_those_sensitivities(tmp_path
 
     errs = [np.max(np.abs(got[:, j] - oracle[:, j])) / np.max(np.abs(oracle[:, j]))
             for j in range(3)]
-    assert min(errs) > 0.1, f'expected the old default to be badly wrong, got {errs}'
+    # 3.8e-01 measured on the worst column.
+    assert max(errs) > 1e-2, f'expected the old default to corrupt a column, got {errs}'
+    # 3.9e-02 measured on the tightest -- still 390x the 1e-4 the derived tolerance is
+    # held to next door, so no single accuracy regime can satisfy both halves.
+    assert min(errs) > 1e-3, f'expected every column to blow the 1e-4 budget, got {errs}'
 
 
 # --- config surface -------------------------------------------------------------- #


### PR DESCRIPTION
Closes #566. Unblocks CI on `main` (and therefore on #565, which is otherwise green).

`tests/test_sbml_solver_tolerances.py::test_the_backend_default_atol_is_what_corrupted_those_sensitivities` fails on every bngsim-enabled leg of `tests`, and has since `8e17e7f8` (`chore(release): 1.7.0`) — run [31649784519](https://github.com/lanl/PyBNF/actions/runs/31649784519). It is independent of any open PR; the bngsim-less leg passes because `_needs_output_sens` skips it there.

## What the guard is for

It is the second half of the #546 pair. The first half asserts the *derived* `sbml_atol` puts the piecewise model's difference-quotient sensitivities under `1e-4`. This one pins `sbml_atol` back to the backend's old `1e-8` default and asserts the result is wrong — so that a future change which quietly stopped deriving the tolerance cannot leave the first half passing on some unrelated accuracy margin.

## Why it broke

Same fixture, same code path, two backend releases:

|              | derived (ADR-0105) | old default `1e-8`                | min      |
|--------------|--------------------|-----------------------------------|----------|
| bngsim 0.12.2 | max 1.18e-06      | `[1.28e-01, 1.41e-01, 3.84e-01]`  | 1.28e-01 |
| bngsim 0.13.0 | max 1.12e-06      | `[8.50e-02, 3.95e-02, 3.79e-01]`  | 3.95e-02 |

The bar was `min(errs) > 0.1`. It cleared 0.12.2's tightest column by **1.28×**. This file's own convention — stated next door as *"the threshold sits a decade under it rather than just beneath, so a second platform's CVODE cannot flip the test"* — was never applied here, so anything that improved the state solve was going to flip it.

0.13.0 is that improvement: it lands the integrator step **on** a fixed time discontinuity so its root can fire ([lanl/bngsim#305](https://github.com/lanl/bngsim)) rather than stepping over it. That is precisely this fixture's shape — a rate law switching at fixed times. CI installs `bngsim==0.13.0` from PyPI; a checkout still on 0.12.2 sees the whole suite green, which is why this reached `main`.

## Nothing is being papered over

I checked the two ways this could have been a real regression in disguise:

* **The path under test is unchanged.** Both versions still decline the analytic sensitivity RHS — 0.13.0 reports `k` as *"uses unsupported construct: if() conditional"*, 0.12.2 as *"calls unsupported function(s): and"* — so it is still CVODES' internal difference quotient inheriting the state solve's accuracy, which is what the test claims to exercise.
* **The separation is intact.** Derived tolerance lands at `1.1e-06` against the old default's `3.9e-02` on the *least* affected column: a 35,000× separation, and 340,000× on the worst.

## The change

One over-fitted bar becomes two claims, each a decade under the **worse** of the two measurements:

```python
# 3.8e-01 measured on the worst column.
assert max(errs) > 1e-2, ...
# 3.9e-02 measured on the tightest -- still 390x the 1e-4 the derived tolerance is
# held to next door, so no single accuracy regime can satisfy both halves.
assert min(errs) > 1e-3, ...
```

This is strictly more informative than the original: it separates "at least one column is corrupted outright" from "and it is not one unlucky column", and the second is what makes the pair a pair. The docstring records both measurements, the 1.28× margin that made the old bar fragile, and the bngsim change that flipped it.

## Verification

* Green on **0.12.2** and on **0.13.0** — the ends of the declared `bngsim>=0.12.2,<1` range — rather than on the one release that drew the threshold. That portability is the actual fix.
* Full CI command on this branch (`pytest -m "not slow and not recovery" -n auto`, bngsim 0.13.0): **3681 passed, 10 skipped**. `ruff` (pinned CI mirror) clean.

Test-only, no CHANGELOG — same shape as `0bcb8712`, the last CI unbreak on this file.