### PR TITLE
fix(check): job_type = check dies in setup on a method-chain record it has no res_dir for (#569)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to PyBNF are documented below. This project adheres to
 ## [Unreleased]
 
 ### Fixed
+- **`job_type = check` runs again (#569).** #564's method-chain record was built from
+  `alg.res_dir` on a line that ran before the `job_type != 'check'` branch nine lines below it, so
+  every check run died in setup with `AttributeError: 'ModelCheck' object has no attribute
+  'res_dir'` — no objective value at all, not merely a noisy tail. `ModelCheck` deliberately does
+  not subclass `Algorithm`, so it has no `res_dir`, and none of `stop_reason`,
+  `completed_simulations` or `trajectory` either; the fit-phase recording that reads all three was
+  above the branch too. Both now sit inside it, with the boundary stated in a comment so the next
+  addition to `main()` lands on the correct side of it. A check run still writes no
+  `method_chain.json`: it is one evaluation of the parameters as given, not a chain of search
+  phases. The regression test that was missing — a `job_type = check` job driven end to end
+  through `main()` — now guards the path; every existing check test called `run_check()` directly,
+  which is why two commits landed on top of the break.
 - **`wall_time_fit` no longer silently downgrades `refine = 1` to no refine at all (#564,
   ADR-0107).** `refine = 1` requests a *method* — search globally, then polish the result with a
   local optimizer — but a wall-clock-budgeted search runs until the clock stops, so it has no

--- a/pybnf/pybnf.py
+++ b/pybnf/pybnf.py
@@ -661,33 +661,40 @@ def main():
                           config.config['wall_time_refine_frac'],
                           format_duration(alg.budget.limit - alg.budget.reserve)))
 
-        # The record of which methods this run actually executes (#564/ADR-0107). Kept
-        # on the algorithm beside the budget, and written after every phase, so it is
-        # complete on disk even if a later phase raises.
-        alg.method_chain = method_chain.chain_for_run(alg.res_dir, config.config,
-                                                      budget=alg.budget, version=__version__)
-
         # Override configuration values if provided on command line
         if cmdline_args.cluster_type:
             config.config['cluster_type'] = cmdline_args.cluster_type
         if cmdline_args.scheduler_file:
             config.config['scheduler_file'] = cmdline_args.scheduler_file
 
+        # Everything inside this branch is Algorithm surface. ``ModelCheck``
+        # (``job_type = check``) deliberately does not subclass Algorithm -- it has no
+        # res_dir, no trajectory, no completed_simulations and no stop_reason -- so a
+        # line that reads any of those belongs here and not above the branch, where it
+        # would run on both paths and take the checker down before it ever evaluated
+        # the model (#569).
         if config.config['fit_type'] != 'check':
+            # The record of which methods this run actually executes (#564/ADR-0107). Kept
+            # on the algorithm beside the budget, and written after every phase, so it is
+            # complete on disk even if a later phase raises.
+            alg.method_chain = method_chain.chain_for_run(alg.res_dir, config.config,
+                                                          budget=alg.budget, version=__version__)
             # Set up cluster
             cluster = Cluster(config, log_prefix, debug, cmdline_args.log_level)
             # Run the algorithm!
             logger.debug('Algorithm initialization')
             alg.run(cluster.client, resume=pending, debug=debug)
+
+            fit_status, fit_reason = _phase_status(alg)
+            _record_phase(alg, 'fit', config.config['fit_type'], fit_status, reason=fit_reason,
+                          simulations=alg.completed_simulations,
+                          best_objective=alg.trajectory.best_score() if len(alg.trajectory) else None)
         else:
-            # Run model checking
+            # Run model checking. No method chain: a check is one evaluation of the
+            # parameters as given, not a chain of search phases, and ModelCheck holds no
+            # res_dir to write the record into.
             logger.debug('Model checking initialization')
             alg.run_check(debug=debug)
-
-        fit_status, fit_reason = _phase_status(alg)
-        _record_phase(alg, 'fit', config.config['fit_type'], fit_status, reason=fit_reason,
-                      simulations=alg.completed_simulations,
-                      best_objective=alg.trajectory.best_score() if len(alg.trajectory) else None)
 
         _refine_best_fit(config, alg, cluster, debug)
 

--- a/tests/test_model_check.py
+++ b/tests/test_model_check.py
@@ -32,11 +32,16 @@ that was correct but brittle and has since been made explicit. The score is
 unchanged: an empty pset means the fallback loop never ran anyway.)
 ``test_objective_call_uses_explicit_four_arg_convention`` pins the call shape.
 """
+import json
 import logging
 import os
+import sys
 
+import pytest
 
-from .context import algorithms, pset
+from .context import algorithms, printing, pset
+
+import pybnf.pybnf as pybnf_main
 
 
 # --------------------------------------------------------------------------- #
@@ -428,3 +433,69 @@ def test_constraints_counted_reported_and_itemized(monkeypatch, capsys):
     # Each cset itemized against (simdata, sim_dir).
     for cset in csets:
         assert cset.itemized_calls == [(result.simdata, '/the/sim/dir')]
+
+
+# =========================================================================== #
+# main(): the whole check path, end to end
+# =========================================================================== #
+def _write_check_job(tmp_path):
+    """A complete, simulator-free ``job_type = check`` job in ``tmp_path``.
+
+    The model is an ``AnalyticalModel`` menu target scored through ``objective =
+    score`` (edition 2's spelling of ``objfunc = direct_pass``), so the run needs no
+    BNGL/SBML backend -- and it is zero-dimensional, which is the honest shape for a
+    checker: a check job has no free parameters, so there are no coordinates to bind,
+    and the NLL is an exact 0.0. That makes the objective the run reports a fixed
+    number the test can assert on.
+    """
+    (tmp_path / 'g.target').write_text(
+        json.dumps({'type': 'gaussian', 'mean': [], 'variance': []}))
+    (tmp_path / 'target.exp').write_text('# index\tscore\n0\t0\n')
+    (tmp_path / 'check.conf').write_text('edition = 2\n'
+                                         'model = g.target : target.exp\n'
+                                         'output_dir = out\n'
+                                         'objective = score\n'
+                                         'job_type = check\n')
+
+
+def test_a_check_job_run_through_main_reports_an_objective_value(tmp_path, monkeypatch, capsys):
+    """#569: ``main()`` built the run's method-chain record (#564) unconditionally,
+    from ``alg.res_dir`` -- an ``Algorithm`` attribute ``ModelCheck`` does not have,
+    and never will, since it deliberately does not subclass ``Algorithm``. The line
+    sat *above* the ``fit_type != 'check'`` branch, so the check path reached it first
+    and died in setup with an ``AttributeError``: the job produced no objective value
+    at all, and two commits landed on top of the break.
+
+    Driven through ``main()`` on purpose. Every other test in this file calls
+    ``run_check()`` directly, which is exactly why nothing caught a fit type that
+    could no longer start -- ``run_check`` was never the part that was broken.
+    """
+    _write_check_job(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    # -L none keeps the run from writing a log file; -o skips the overwrite prompt.
+    monkeypatch.setattr(sys, 'argv', ['pybnf', '-c', 'check.conf', '-o', '-L', 'none'])
+    # main() writes both of these as a side effect. Setting them through monkeypatch
+    # first registers the undo, so one end-to-end test cannot change the verbosity or
+    # the live-sim registry that every later test in the session runs under.
+    monkeypatch.setattr(printing, 'verbosity', printing.verbosity)
+    monkeypatch.setenv('PYBNF_SIM_REGISTRY', '')
+    # main()'s teardown rm -rf's ~/dask-worker-space. Nothing in this run creates one,
+    # and a test has no business reaching into the developer's home directory.
+    monkeypatch.setattr(pybnf_main, '_cleanup_dask_workspace', lambda: None)
+    root = logging.getLogger()
+    handlers, level = root.handlers[:], root.level
+
+    try:
+        with pytest.raises(SystemExit) as exit_info:
+            pybnf_main.main()
+    finally:
+        # init_logging attaches a handler and drops the root level to DEBUG.
+        root.handlers[:] = handlers
+        root.setLevel(level)
+
+    # Exit 0, not the exit 1 an unhandled exception in main() produces.
+    assert exit_info.value.code == 0
+    out = capsys.readouterr().out
+    assert 'Objective value is 0.0' in out
+    assert 'unknown error occurred' not in out
+


### PR DESCRIPTION
Fixes #569.

`job_type = check` has not started since #565 landed. Every run dies in setup:

```
Sorry, an unknown error occurred: AttributeError: 'ModelCheck' object has no attribute 'res_dir'
```

#564's method-chain record is built at `pybnf.py:667` from `alg.res_dir`, on a line that runs unconditionally — nine lines *above* the `fit_type != 'check'` branch that exists precisely because the check path is not an algorithm run. The check path reaches the record first and dies there, so the job produces no objective value at all. It is not a noisy tail; the fit type does not start.

## Two crash sites, not one

Guarding line 667 alone only moves the failure nine lines down. The fit-phase recording added by the same commit reads three more `Algorithm` attributes:

```python
        fit_status, fit_reason = _phase_status(alg)          # alg.stop_reason
        _record_phase(alg, 'fit', config.config['fit_type'], fit_status, reason=fit_reason,
                      simulations=alg.completed_simulations,
                      best_objective=alg.trajectory.best_score() if len(alg.trajectory) else None)
```

`ModelCheck` deliberately does not subclass `Algorithm` — its docstring says so, and the branch in `main()` is the consequence — so it has none of the four:

```
>>> [hasattr(alg, a) for a in ('res_dir', 'stop_reason', 'completed_simulations', 'trajectory')]
[False, False, False, False]
```

Both sites now sit inside the branch, with the boundary stated in a comment so the next addition to `main()` lands on the correct side of it.

## What is deliberately unchanged

**A check run still writes no `method_chain.json`.** It is one evaluation of the parameters as given, not a chain of search phases; its `phases` / `simulations` / `best_objective` / `stop_reason` would all be empty or invented. #564 exists to make provenance assertable, not to pad it.

**`alg.budget` stays where it is.** It is not a latent copy of the same bug: assigning an attribute to a `ModelCheck` is legal, and `Configuration._strip_uncheckable_keys` pops `wall_time_fit` before the defaults are applied, so `from_config` returns `None` and the budget block below it is skipped — no misleading "Wall-time budget for this fit" line on a job with no run to budget. That same strip is what keeps `_refine_best_fit` and `_run_bootstrapping` no-ops on the check path, which is why neither of them broke.

## Why nothing caught it

`job_type = check` has tests, and every one of them calls `run_check()` directly — which was never the part that broke. `tests/full_tests/T6-check/` is referenced by no test module and no workflow. So two commits (35a2dc04, b8c05769) landed on top of a fit type that could not start.

The regression test added here drives a `job_type = check` job end to end through `main()` and asserts it exits 0 and reports its objective value. It needs no simulator: the model is a zero-dimensional analytical menu target scored through `objective = score`, which makes the reported objective an exact `0.0` the test can assert on. Verified to fail on b8c05769 with the reported `AttributeError` and to pass here.

## Verification

* `tests/test_model_check.py::test_a_check_job_run_through_main_reports_an_objective_value` — fails on the parent commit, passes with the fix.
* Full default-tier suite: **3776 passed, 20 skipped, 186 deselected** (13:57), with `BNGPATH` set.
* `ruff check` clean.
