### PR TITLE
feat(shooting): the multiple-shooting consumer of the transcription layer (#563, ADR-0110)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,44 @@ All notable changes to PyBNF are documented below. This project adheres to
   *and* the polish did has two facts to report, not one that replaces the other.
 
 ### Added
+- **Multiple shooting, `job_type = ms` (#563, ADR-0110).** The consumer of the
+  constrained-transcription layer below, and the thing #563 was actually asking for. Each scored
+  experiment's time course is cut at knots; segment *j* is integrated from its own start state —
+  segment 0's is the model's own initial conditions, and each interior knot carries an auxiliary
+  state that is searched, bounded and differentiated but is **never** a reported fit result — and
+  continuity `Phi_j(z_j, theta) - z_{j+1} = 0` is enforced by an augmented Lagrangian whose
+  subproblem is solved by `gntr`'s own Gauss-Newton trust-region step machine. Every reported
+  score comes from discarding the auxiliary states, re-simulating theta with ordinary single
+  shooting, and scoring *that*, so a run that leaves continuity unconverged scores as what it
+  actually is — and every certified iterate lands in the ordinary trajectory at that score, so
+  `sorted_params`, the best-fit simulations, the information criteria and the inference-data
+  sidecar are produced by the same code every other `job_type` uses.
+  Why it is worth the machinery: on `Borghans_BiophysChem1997` a correctly-shaped oscillator whose
+  period is wrong by more than about 3 % scores *worse than fitting no dynamics at all*, so under
+  single shooting the flat line is the ceiling on essentially the whole box and fifteen
+  independent global searches terminate at it. Over one short segment a period error cannot
+  accumulate: the information moves out of a residual term that saturates and into continuity
+  defects, which carry a direction.
+  The prototype's structural finding is what keeps the implementation small — a segment-start
+  state is an `IC` route with chain-rule factor 1, so the existing gradient/Fisher assembly builds
+  its column with no new residual math, and each segment is presented to it as an ordinary
+  *experiment*. The continuity block is the only new assembly surface. Knots are named by their
+  exact fraction of the horizon, so a coarser rung recognises a finer one's knots and the `4-2-1`
+  ladder *continues* rather than reseeds.
+  New keys `ms_segments`, `ms_coarsening`, `ms_penalty`, `ms_penalty_growth`, `ms_max_penalty`,
+  `ms_feasibility_tol`, `ms_optimality_tol`, `ms_inner_iterations`, `ms_aux_decades`,
+  `ms_max_iterations`, defaulted from ADR-0109's measurements rather than from taste. Requires the
+  bngsim SBML/Antimony backend (a knot carries the model's *state*, which the `.net` path's
+  observable columns cannot supply) and refuses, by name, a fit whose scored quantity is a
+  function of a whole series — an analytic per-series scale, a data normalization, a
+  cumulative-to-incident difference — since cutting the series would change it. An analytically
+  profiled noise scale (ADR-0108) is deliberately fine: it is profiled over pooled residuals, so
+  the segments pool the same ones, and the constraint terms never enter the likelihood.
+  What is *not* claimed: that multiple shooting improves the typical fit (48 paired starts:
+  24–24, medians tied at every radius, at 2–7x the simulations), or that it solves Borghans from
+  an uninformed start (0/24). The measured case is the tail and the robustness. Segment
+  simulations run serially on the master in this cut; parallelising them, and the acceptance
+  benchmark, are the follow-on work.
 - **A constrained-transcription layer, `pybnf.transcription` (#563, ADR-0109).** Infrastructure for
   restating a fit as a larger, better-conditioned problem with internal auxiliary variables and
   equality constraints that tie them back together — the reusable half of multiple shooting, which

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,8 +81,11 @@ All notable changes to PyBNF are documented below. This project adheres to
   New keys `ms_segments`, `ms_coarsening`, `ms_penalty`, `ms_penalty_growth`, `ms_max_penalty`,
   `ms_feasibility_tol`, `ms_optimality_tol`, `ms_inner_iterations`, `ms_aux_decades`,
   `ms_max_iterations`, defaulted from ADR-0109's measurements rather than from taste. Requires the
-  bngsim SBML/Antimony backend (a knot carries the model's *state*, which the `.net` path's
-  observable columns cannot supply) and refuses, by name, a fit whose scored quantity is a
+  bngsim SBML/Antimony backend — a knot carries the model's *state*, and that is the one PyBNF
+  backend whose trajectory columns and sensitivity selectors are the species; a `.net` model has
+  the same kind of state and bngsim will return it, but PyBNF's net adapter does not ask for it,
+  so extending `ms` there is adapter work rather than a modelling obstacle — and refuses, by
+  name, a fit whose scored quantity is a
   function of a whole series — an analytic per-series scale, a data normalization, a
   cumulative-to-incident difference — since cutting the series would change it. An analytically
   profiled noise scale (ADR-0108) is deliberately fine: it is profiled over pooled residuals, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,11 +81,13 @@ All notable changes to PyBNF are documented below. This project adheres to
   New keys `ms_segments`, `ms_coarsening`, `ms_penalty`, `ms_penalty_growth`, `ms_max_penalty`,
   `ms_feasibility_tol`, `ms_optimality_tol`, `ms_inner_iterations`, `ms_aux_decades`,
   `ms_max_iterations`, defaulted from ADR-0109's measurements rather than from taste. Requires the
-  bngsim SBML/Antimony backend — a knot carries the model's *state*, and that is the one PyBNF
-  backend whose trajectory columns and sensitivity selectors are the species; a `.net` model has
-  the same kind of state and bngsim will return it, but PyBNF's net adapter does not ask for it,
-  so extending `ms` there is adapter work rather than a modelling obstacle — and refuses, by
-  name, a fit whose scored quantity is a
+  bngsim backend — a knot carries the model's *state*, so both a generated network (`.net`) and
+  an SBML/Antimony model are supported, through two backends that differ only in what a
+  simulation returns: on the SBML path the columns an experiment scores and the columns a
+  continuity row differences are the same columns, and on the `.net` path they are not, so that
+  backend asks for the observable and species selector families together and one integration
+  still serves both (#577). A network-free (NFsim) model enumerates no state and is refused. It
+  also refuses, by name, a fit whose scored quantity is a
   function of a whole series — an analytic per-series scale, a data normalization, a
   cumulative-to-incident difference — since cutting the series would change it. An analytically
   profiled noise scale (ADR-0108) is deliberately fine: it is profiled over pooled residuals, so

--- a/docs/adr/0110-a-segment-is-an-experiment-whose-start-state-is-an-ic-route-with-factor-1-so-multiple-shooting-adds-a-continuity-block-rather-than-a-second-gradient-assembly.md
+++ b/docs/adr/0110-a-segment-is-an-experiment-whose-start-state-is-an-ic-route-with-factor-1-so-multiple-shooting-adds-a-continuity-block-rather-than-a-second-gradient-assembly.md
@@ -152,27 +152,10 @@ Beyond the gradient path's own (edition 2, a forward-sensitivity backend, differ
 dynamics), three classes are refused, each because segmenting would change *what is being
 fitted* rather than how it is searched:
 
-* **A model whose state this cut's backend cannot surface.** The state at a knot is the ODE
-  state vector, and of PyBNF's backends only the bngsim SBML/Antimony one puts species
-  columns and initial-condition sensitivities on the same run.
-
-  This is a limit of the adapter, not of the model, and the ADR is explicit about which
-  because the distinction changes where the follow-on work goes. A `.net` file is a reaction
-  network with exactly the same kind of state as an SBML model, and bngsim returns both its
-  species trajectory and `d(species)/d(species_0)` when asked — verified directly against
-  bngsim 0.12.2 on `tests/bngl_files/e2e_ode_decay.net`, where
-  `output_sensitivities(['species:S()'], axis='ic')` comes back fine. What is missing is on
-  PyBNF's side: `BngsimModel._build_data` assembles `time + observables + expressions`, and
-  the net backend's sensitivity request names `observable:` / `expression:` selectors, so a
-  segment simulation would carry neither the state at the knot nor its derivative.
-
-  Closing it is an adapter change, and not a free one: an experiment scores *observables*,
-  so a net segment needs both selector families on one run, and on a combinatorially expanded
-  network the auxiliary block is `(m - 1) x n_species` wide while the initial-condition
-  sensitivity system is `n_species` wide — so the transcription's cost scales with the
-  expanded species count rather than with the number of fitted parameters, which is a real
-  reason to scope it deliberately rather than assume it. This cut does not do it, and the
-  gate says so in those terms rather than telling a user their model has no state.
+* **A model with no enumerated state to restart from.** The state at a knot is the ODE state
+  vector. A network-free (NFsim) model never enumerates one, and a non-bngsim backend
+  exposes neither the state nor its forward sensitivities. Both bngsim paths are supported —
+  see decision 8.
 * **An experiment that is not a plain measured time course.** A dose-response scan has no
   time axis to cut; a pre-equilibration protocol's measured phase already begins from a
   carried state that is not the model's own; a relaxation to steady state has no fixed
@@ -217,6 +200,45 @@ shooting's median run ended after **8 simulations** because its start point did 
 — comes from the transcription, not from partial scoring: a short span integrates at
 parameter points where the whole horizon does not. An evaluation is still all-or-nothing,
 exactly as the prototype's was.
+
+### 8. Two backends, differing only in what a simulation returns (#577)
+
+The first cut of this ADR refused the `.net` path, and justified it with a claim that was
+simply wrong: that a rule-based model's observables are "sums over species, from which the
+state is not recoverable", and that its state "is not a vector a fit can carry at every
+knot". A `.net` file is a fully expanded reaction network with exactly the same kind of ODE
+state an SBML model has, and bngsim returns both its species trajectory and
+`d(species)/d(species_0)` when asked. Probed directly on
+`tests/bngl_files/e2e_ode_decay.net`, a mixed selector list comes back from one run:
+
+```
+output_sensitivities(['observable:Stot', 'species:S()'], axis='parameter')  ->  (11, 2, 1)
+output_sensitivities(['observable:Stot', 'species:S()'], axis='ic')         ->  (11, 2, 1)
+```
+
+The real asymmetry was one level down, and is the whole of what the second backend exists
+for: **on the SBML path the columns an experiment scores and the columns a continuity row
+differences are the same columns; on the `.net` path they are not.** `_build_data` assembles
+`time + observables + expressions` and the net backend's sensitivity request names
+`observable:` / `expression:` selectors, so a segment carried neither the state at the knot
+nor its derivative — because nothing asked.
+
+`pybnf/shooting/net_backend.py` asks, for both families together. One tensor carries the
+observable/expression rows the data terms read and the species rows the continuity block
+reads, requested in a single call so a segment is still **one integration**; the segment's
+`Data` carries the species columns alongside the observable ones, with a collision refused
+rather than silently overwritten (a species column shadowing an observable would change what
+the fit scores). Nothing in the net backend is modified — this composes `_build_data`, the
+engine clone, the mutant copy and the species-initializer sync from outside — so every
+ordinary `.net` fit is untouched.
+
+What remains true, and is the model's property rather than the method's: the auxiliary block
+is `(m - 1) x n_species` wide and the initial-condition sensitivity system is `n_species`
+wide, so the transcription scales with the **expanded** species count rather than with the
+number of fitted parameters. `egfr_ground.net` (356 species) at `m = 4` adds ~1068 auxiliary
+variables. That is inherent to writing multiple shooting on the state of a rule-based model;
+this cut reports the added width when a run starts rather than letting a user infer it from
+the run time, and leaves a size policy to measurement.
 
 ## What this is not
 
@@ -296,6 +318,19 @@ Jacobian or a mis-routed auxiliary column would move the answer. The decay model
 reproduce the ordinary answer on a problem where the ordinary transcription was never the
 difficulty. Its setup half (experiment resolution, request widening, ladder construction, and
 one gate) runs in default CI; the fit itself is in the opt-in `recovery` tier.
+
+`tests/test_shooting_net.py` — 11 tests, the `.net` peer (#577). Its own three primitives (a
+mid-trajectory restart rejoining to `1e-6`, the end-knot `d_ic` / `d_param` against the closed
+form, a feasible seeded transcription scoring its own certificate), the assembled gradient and
+continuity Jacobian against central differences, and the property that is specific to this
+backend: one segment's `Data` carries the observable columns *and* the species columns, its
+tensor carries both selector families, and the observable columns are the net backend's own
+and unchanged — checked against the analytic decay, because a segment that quietly rescored
+something else would still look self-consistent. Plus the scalar path staying tensor-free, the
+action resolution and its refusals (non-ODE, `continue=>1`), and the request widening. And
+**end to end**: `job_type = ms` on a BNGL model — BNGL → BNG2.pl → `.net` → `BngsimModel`, the
+genuine net path — recovering `k` and `S(0)` to better than 2 %, ladder `4-2-1`, certified
+`1.16e-12`.
 
 What is **not** verified here: an `ms` fit on the motivating model. That is the acceptance
 benchmark, which is separate work, and no claim about Borghans is made from this change.

--- a/docs/adr/0110-a-segment-is-an-experiment-whose-start-state-is-an-ic-route-with-factor-1-so-multiple-shooting-adds-a-continuity-block-rather-than-a-second-gradient-assembly.md
+++ b/docs/adr/0110-a-segment-is-an-experiment-whose-start-state-is-an-ic-route-with-factor-1-so-multiple-shooting-adds-a-continuity-block-rather-than-a-second-gradient-assembly.md
@@ -152,12 +152,27 @@ Beyond the gradient path's own (edition 2, a forward-sensitivity backend, differ
 dynamics), three classes are refused, each because segmenting would change *what is being
 fitted* rather than how it is searched:
 
-* **A model whose state a knot cannot carry.** The state at a knot is the ODE state vector,
-  and only the bngsim SBML/Antimony path reports species columns with initial-condition
-  sensitivities on the same axis. The `.net` path reports `observable:` selectors —
-  observables are sums *over* species, from which the state is not recoverable — and a
-  rule-based model's state is not a vector a fit can carry at every knot. Refused by name
-  rather than discovered later as a missing selector.
+* **A model whose state this cut's backend cannot surface.** The state at a knot is the ODE
+  state vector, and of PyBNF's backends only the bngsim SBML/Antimony one puts species
+  columns and initial-condition sensitivities on the same run.
+
+  This is a limit of the adapter, not of the model, and the ADR is explicit about which
+  because the distinction changes where the follow-on work goes. A `.net` file is a reaction
+  network with exactly the same kind of state as an SBML model, and bngsim returns both its
+  species trajectory and `d(species)/d(species_0)` when asked — verified directly against
+  bngsim 0.12.2 on `tests/bngl_files/e2e_ode_decay.net`, where
+  `output_sensitivities(['species:S()'], axis='ic')` comes back fine. What is missing is on
+  PyBNF's side: `BngsimModel._build_data` assembles `time + observables + expressions`, and
+  the net backend's sensitivity request names `observable:` / `expression:` selectors, so a
+  segment simulation would carry neither the state at the knot nor its derivative.
+
+  Closing it is an adapter change, and not a free one: an experiment scores *observables*,
+  so a net segment needs both selector families on one run, and on a combinatorially expanded
+  network the auxiliary block is `(m - 1) x n_species` wide while the initial-condition
+  sensitivity system is `n_species` wide — so the transcription's cost scales with the
+  expanded species count rather than with the number of fitted parameters, which is a real
+  reason to scope it deliberately rather than assume it. This cut does not do it, and the
+  gate says so in those terms rather than telling a user their model has no state.
 * **An experiment that is not a plain measured time course.** A dose-response scan has no
   time axis to cut; a pre-equilibration protocol's measured phase already begins from a
   carried state that is not the model's own; a relaxation to steady state has no fixed

--- a/docs/adr/0110-a-segment-is-an-experiment-whose-start-state-is-an-ic-route-with-factor-1-so-multiple-shooting-adds-a-continuity-block-rather-than-a-second-gradient-assembly.md
+++ b/docs/adr/0110-a-segment-is-an-experiment-whose-start-state-is-an-ic-route-with-factor-1-so-multiple-shooting-adds-a-continuity-block-rather-than-a-second-gradient-assembly.md
@@ -1,0 +1,304 @@
+# A segment is an experiment whose start state is an `IC` route with chain-rule factor 1, so multiple shooting adds a continuity block rather than a second gradient assembly — and a segment is not a parameter-set evaluation, so `job_type = ms` drives its own search (issue #563)
+
+**Status: Accepted and implemented (2026-08-13).** The consumer ships as `pybnf/shooting/`
+plus the `ms` fit type. ADR-0109 landed the reusable half — the augmented variable layout,
+the equality residual/Jacobian interface, the optimizer-agnostic augmented-Lagrangian outer
+loop, the segment homotopy, and best-iterate certification — with no simulator call, no
+configuration key and no `fit_type`. This is the other half: what it takes to state *this*
+fit as that kind of problem.
+
+## The problem
+
+ADR-0109 recorded the motivation and will not be restated here beyond the one number that
+decides it: on `Borghans_BiophysChem1997` a correctly-shaped oscillator whose period is
+wrong by more than about 3 % scores *worse than fitting no dynamics at all*, so under single
+shooting the flat line is the ceiling on essentially the whole box, and fifteen independent
+BIPOP-CMA-ES runs terminate at it within 1.74 NLL units of each other. The #563 prototype
+solved that problem by multiple shooting, at `OG = -1.282656`.
+
+What ADR-0109 left open is the consumer, and it named four pieces: knot placement, the
+`IC`-routed segment assembly through bngsim, `Simulator` reuse across parameter and IC
+changes, parallel segment simulation, and the config surface. This ADR records the first,
+second, third and fifth; the fourth is deferred and said so below.
+
+## The decisions
+
+### 1. A segment is presented to the gradient assembly as an *experiment*
+
+This is the decision the whole consumer is small because of, and it follows from the
+prototype's structural finding: a segment-start state enters the data fit as an `IC` route
+with chain-rule factor **1** (`sensitivity_ic` is `dy(t)/dy0`, and the transcription sets
+`y0` directly). So to `assemble_gradient_and_fisher_hessian` an auxiliary variable is an
+ordinary free parameter with an ordinary route, and the assembly already sums across
+experiments.
+
+Each segment therefore becomes one item of the `experiments` list: its own simulated `Data`,
+its own slice of the observations, its own `ExperimentRouting`. The segmented data fit is
+the unsegmented one rearranged, and its gradient *and* Fisher block come out over the
+augmented column list in one pass. There is no second residual assembly, no per-segment
+Jacobian arithmetic, and no new chain rule — a condition's factor, a multi-column route, a
+per-measurement formula, and a profiled noise scale all reach a segment exactly as they
+reach an ordinary experiment, because it is the same code.
+
+Two things the rearrangement has to get right, and both are structural rather than cosmetic.
+
+**Segment `j > 0` does not read the model's own initial conditions.** They were overridden
+by `z_j`. A reported free parameter that *is* a fitted initial condition therefore has no
+effect on that segment, and its `IC` contribution is dropped from that segment's routing.
+Keeping it would credit `init_Z_state` with a derivative it does not have on `m - 1` of the
+`m` segments — a column scaled wrongly, which no fit can detect from its own objective.
+Segment 0 keeps it, which is exactly how a fitted initial condition reaches the first
+continuity row.
+
+**Every other segment's auxiliary block gets an *empty* route, not no route.** The assembly
+indexes routes by name into the augmented column list, so an absent block would leave an
+uninitialised column rather than a structural zero.
+
+### 2. The continuity block is the only new assembly surface
+
+`c_j = Phi_j(z_j, theta) - z_{j+1}`, in the model's own state units, with three Jacobian
+blocks per knot: `dPhi/dtheta` over the reported columns, `dPhi/dz_j` over that segment's own
+block (the `IC` route again), and the constant `-I` over the next knot's block. The reported
+half is folded from the *same* routing the segment's data rows were assembled through — one
+helper, so a condition factor cannot reach the data and miss the constraints.
+
+The rows are read off the **same run** that produced the data rows, because the segment's
+output grid ends at its knot. A segment costs one integration, not two.
+
+**Constraint scales are fixed per stage, from the state's own magnitude.** ADR-0109 requires
+strictly positive scales so that one penalty means one thing across states of different
+magnitude — the corner that matters most here, since with one observed state of three the
+unobserved segment-start states are determined by continuity alone and the conditioning of
+the constraint block *is* the conditioning of the inner problem. The scale is the larger of
+the model's declared nominal and the largest value the stage's seeding trajectory actually
+reaches, per state. Declared nominals alone understate a species that starts empty and grows
+— on an oscillator, most of them. Fixed per stage rather than recomputed per evaluation, so
+`lambda` and `rho` mean one thing throughout a solve.
+
+### 3. Knots are named by their exact fraction of the horizon
+
+`AugmentedLayout.carry_over` transfers an auxiliary block iff the next stage declares a block
+of the same **name and size**; the layer never learns what a knot is. So the naming is
+load-bearing: a knot must get the same name at every segment count that has it, or the
+`4 -> 2 -> 1` ladder reseeds instead of continuing and the coarsening — the mechanism —
+buys nothing.
+
+`'<experiment>@<fraction>'` with an exact `Fraction` does it: at `m = 4` the knots are
+`1/4, 1/2, 3/4`; at `m = 2`, `1/2`; and `Fraction(2, 4) == Fraction(1, 2)`, so the surviving
+knot carries its solved state down while the others are discarded. Exact rationals rather
+than rounded floats, so `1/3` and `0.333333` can never be two names for one knot.
+
+Knots are placed at **equal time**, which is what the prototype solved the problem with. The
+obvious refinements — knots at the data's quantiles, or at the features of a nominal
+trajectory — are start-point dependent: they place the transcription's structure using a
+trajectory the fit has not established, and on the motivating problem that trajectory is
+exactly what is in question. Equal spans use only the experiment's own time axis.
+
+A data point lying exactly on a knot belongs to the **later** segment, so it is read at
+`dt = 0` from that knot's own auxiliary state. The alternative reads it through the previous
+segment's whole span, which is the same number only once continuity has converged.
+
+### 4. The inner solver is `gntr`'s runner, driven synchronously
+
+ADR-0109 ships no inner solver on purpose and measured why the choice is not free: over 30
+data seeds x 2 starts on the offline shooting problem, a trust-region least-squares solver
+converged **60/60** while a quasi-Newton one converged 36/60. So this consumer steps from the
+Gauss-Newton form — which is exactly the `(gradient, PSD hessian)` pair `job_type = gntr`
+already consumes, and `_GNTRRunner` is already a headless, backend-free step machine over it
+(ridge-regularise, eigen-factor into the pseudo-Jacobian, run `trf`'s Coleman-Li reflective
+accept/reject state machine). `pybnf/shooting/solver.py` is a *driver*, not a method: the
+step math is `gntr`'s, unchanged and not separately tuned.
+
+The outer loop's `omega_k` becomes the runner's `grad_tol`, floored: `omega` decays
+geometrically and will eventually pass below what any solver can demonstrate, past which the
+runner would spend its whole budget every outer iteration — the same waste ADR-0109 finding
+5.1 measured on a too-loose penalty, reached from the other side.
+
+The import is deliberately lazy. A library reaching into a fit type runs against the usual
+dependency direction, and importing `pybnf.algorithms` at module scope would register `ms`,
+which imports this package, closing the cycle at import time. Deferring it keeps
+`pybnf.shooting` importable on its own — which is what lets the whole package be exercised
+against a closed-form backend with no fit type in the picture.
+
+### 5. `job_type = ms` drives its own search
+
+Every other optimizer plugs into the shared propose/score loop. Multiple shooting's unit of
+work is not a `PSet` evaluation: a segment is one span integrated **from a state that is in
+no parameter set** — the auxiliary variable ADR-0109 keeps structurally out of the reported
+fit results — and one augmented-model evaluation is `m` such spans whose forward
+sensitivities have to be assembled together, on one machine, before a step can be taken. The
+layer's inner-solver contract is a blocking call for the same reason.
+
+So `ms` overrides `run()`, as `job_type = hmc` does and for the same class of reason
+(ADR-0059: "the gradient cannot survive the per-pset dask round-trip"). ADR-0007's contract —
+the run loop is shared, not pluggable — is about not *forking* the loop, and this does not:
+`Algorithm.run`'s tail is extracted as `_finalize_run()` and called unchanged.
+
+**Every certified outer iterate is entered in the ordinary trajectory at its ordinary
+single-shoot score.** That is what makes the override cheap rather than a second reporting
+path: `sorted_params`, the best-fit simulations, the information criteria, the profiled-noise
+report and the inference-data sidecar are produced by the same code every other fit type
+uses, from numbers that mean the same thing. It is also how the run reports its **best
+certified** iterate rather than its last (ADR-0109 finding 5.3) without a ranking rule of its
+own — `trajectory.best_fit()` already is that rule.
+
+A `-r` resume is refused rather than silently ignored: there is no checkpointed step machine
+to continue from, and a resumed run that quietly restarted from scratch would be worse than
+one that says it cannot.
+
+### 6. The gates refuse what the transcription would silently change
+
+Beyond the gradient path's own (edition 2, a forward-sensitivity backend, differentiable
+dynamics), three classes are refused, each because segmenting would change *what is being
+fitted* rather than how it is searched:
+
+* **A model whose state a knot cannot carry.** The state at a knot is the ODE state vector,
+  and only the bngsim SBML/Antimony path reports species columns with initial-condition
+  sensitivities on the same axis. The `.net` path reports `observable:` selectors —
+  observables are sums *over* species, from which the state is not recoverable — and a
+  rule-based model's state is not a vector a fit can carry at every knot. Refused by name
+  rather than discovered later as a missing selector.
+* **An experiment that is not a plain measured time course.** A dose-response scan has no
+  time axis to cut; a pre-equilibration protocol's measured phase already begins from a
+  carried state that is not the model's own; a relaxation to steady state has no fixed
+  horizon; a `t = 0`-only experiment has nothing to segment.
+* **A quantity that is a function of a whole series** — an analytic per-series scale
+  (ADR-0066), a `Data`-level normalization (ADR-0053/0102), a cumulative-to-incident
+  difference (ADR-0051), and BPSL constraints, which are stated over a trajectory that does
+  not join up until the run converges.
+
+An analytically profiled **noise scale** (ADR-0108) is deliberately *not* in that list, and
+that is the invariant ADR-0109 built the layer around: it is profiled over the pooled
+residuals of every supplied experiment, so cutting one series into `m` pieces pools exactly
+the same residuals and yields exactly the same `sigma_hat`. Since the constraint terms never
+enter `f`, an estimated sigma cannot absorb continuity violation as measurement noise, and
+the certified score stays comparable to a single-shoot one. 13 of the 23 slugs in the
+motivating corpus estimate at least one noise scale.
+
+A rung the data cannot support — a segment count above an experiment's own measurement count
+— is dropped and **reported**. A silent cap would read as "we ran the ladder you asked for".
+
+### 7. One engine model and one simulator per parameter point
+
+The prototype measured that constructing a sensitivity-bearing `Simulator` costs ~230 ms cold
+and ~17 ms warm against ~50 ms for the integration itself, so at `m` segments per evaluation
+construction would dominate — and it verified the fix: mutating the model behind an existing
+`Simulator` and `save_concentrations()` + `reset()`-ing gives bit-identical states *and*
+sensitivities. The backend keeps one of each per parameter point, keyed on the `PSet`'s
+identity (the caller builds one `PSet` per augmented evaluation and simulates every segment
+from it), and restarts them at each knot. The restart is what distinguishes this from the
+pre-equilibration protocol (ADR-0052/0104), which runs its second phase on the same simulator
+*without* a reset precisely so the state carries over.
+
+A segment that does not integrate is handed back as a failed *segment*, not an error: the
+local model comes back non-finite, the trust region shrinks, and the search backs off — the
+same handling the gradient path already gives a non-integrable point (#492/#528), and more
+honest than the prototype's large-constant residual. One unusable segment ends that point's
+pass, since the rest of its segments are work whose answer is already decided.
+
+Note what this does *not* claim. The robustness the prototype measured — a median of
+`-166.95` from an uninformed box draw against single shooting's `-105.50`, where single
+shooting's median run ended after **8 simulations** because its start point did not integrate
+— comes from the transcription, not from partial scoring: a short span integrates at
+parameter points where the whole horizon does not. An evaluation is still all-or-nothing,
+exactly as the prototype's was.
+
+## What this is not
+
+* **Not parallel segment simulation.** This cut runs its segments serially on the master.
+  Segment simulation is embarrassingly parallel and nothing in the interface prevents
+  scheduling it; nothing here schedules it. Stated rather than discovered.
+* **Not condensing.** ADR-0109 kept the block structure so a condensation can be added; the
+  linear algebra is still dense, at dimension `k + sum_j dim(z_j)`.
+* **Not a claim about Borghans, and not the acceptance benchmark.** The prototype's solve
+  came from a `radius = 0.4` perturbation of the PEtab nominal point — privileged
+  information, so a basin measurement. The benchmark, framed on the tail and robustness the
+  paired sweeps measured rather than on the median they did not move, is the next piece of
+  work.
+* **Not a claim that multiple shooting improves the typical fit.** 48 paired
+  convergence-region starts: **24-24**, medians tied at every radius, at 2-7x the
+  simulations. The measured case is the tail.
+* **Not support for a point-dependent chain-rule factor** (#530). A seed derivative that
+  reads other model symbols has to be re-evaluated at every fit point; `ms` refuses such a
+  fit and points at `gntr`, rather than differentiating a stale factor.
+* **Not resumable**, per decision 5.
+
+## Verification
+
+`tests/test_shooting.py` — 30 tests, no simulator, ~3 s, against a closed-form backend for
+`y' = k y`, `w' = -k w` with only `y` observed. That last part is the point: `w` carries no
+data term, so half the auxiliary variables are determined by continuity alone, which is the
+motivating problem's hard corner reproduced at a size that can be checked exactly.
+
+* **Knot identity** — `m = 4` declares `1/4, 1/2, 3/4` and `m = 2` declares `1/2`, a subset
+  by name; a solved knot state survives `carry_over` at its solved value rather than being
+  reseeded; `1/3` at `m = 3` is the same name as at `m = 6`.
+* **The derivatives**, all against central differences at a point whose knots are
+  deliberately stale (so the defects are nonzero and the `-I` half of the continuity block is
+  tested against something other than zero): the objective gradient over reported *and*
+  auxiliary columns, the constraint Jacobian, and the whole augmented gradient at nonzero
+  multipliers and a raised penalty. Each is run in **both** parameterisations — a linear
+  reported block and a `loguniform_var` one — because the `d theta/d u` factor is applied by
+  the gradient assembly for the objective's columns and by this package for the continuity
+  block's, and only a log-scaled parameter tells the two apart (the factor is 1 for a linear
+  one). Plus the least-squares invariant `0.5||rho||^2 == value` over the segmented
+  trajectory.
+* **The `IC`-route rule** — `y0`'s route is present on segment 0 and empty on every later
+  segment; it has a nonzero column in the *first* knot's continuity block and an exactly zero
+  one in the rest; and only a segment's own block routes to its states.
+* **The unobserved-state corner** — `w`'s auxiliary columns get exactly zero objective
+  gradient and nonzero continuity columns. Both halves have to hold, or the fit is silently
+  unconstrained in them.
+* **Feasibility at iteration zero** — a seeded stage has zero continuity defect.
+* **Certification** — the certificate is the ordinary single-shoot score, recomputed
+  independently in the test, and is *not* the augmented objective; a reconstruction that does
+  not simulate is rejected rather than scored.
+* **The load-bearing claim** — at `m = 2` and `m = 4`, in both parameterisations, and from a
+  start whose knots are stale by a large factor, the run recovers a single-shoot optimum
+  computed **independently** by `scipy.least_squares` on the unsegmented residual, to `1e-4`.
+  The full ladder runs `m=4 -> m=2 -> m=1` and its best certified score is no worse than that
+  optimum.
+
+`tests/test_shooting_sbml.py` — 9 tests through a real bngsim SBML solve, covering what the
+offline suite cannot reach. Three of them are the prototype's own primitives, restated as
+tests of PyBNF's backend: a segment restarted from an overridden state at `t = 5` rejoins the
+uninterrupted trajectory to `1e-7` relative; the end-knot `d_ic` and `d_param` match the
+closed form; a transcription seeded from a continuous trajectory has zero continuity defect
+*and* an objective equal to its own single-shoot certificate. Plus the assembled objective
+gradient and continuity Jacobian against central differences through the real
+forward-sensitivity tensor; the simulator-reuse invariant (one simulator per point, a new one
+for a new point); and the request-widening one — a state no free parameter binds gets no `ic`
+column from the ordinary routing and does get one from the fit type, which is the failure the
+rest of the suite could not see, since its only species happens to be a fitted initial
+condition.
+
+**End to end**, through the real `Configuration`, the real scheduler seam, and the real
+end-of-fit path: `job_type = ms` on a decay SBML model recovers `k` and `S(0)` from
+zero-noise data to better than 2 %, running the `4-2-1` ladder and reporting a certified
+objective of `4.5e-12`. A tight assertion rather than a smoke bound — a wrong continuity
+Jacobian or a mis-routed auxiliary column would move the answer. The decay model does not
+*need* multiple shooting, which is the point: a method that changes the transcription has to
+reproduce the ordinary answer on a problem where the ordinary transcription was never the
+difficulty. Its setup half (experiment resolution, request widening, ladder construction, and
+one gate) runs in default CI; the fit itself is in the opt-in `recovery` tier.
+
+What is **not** verified here: an `ms` fit on the motivating model. That is the acceptance
+benchmark, which is separate work, and no claim about Borghans is made from this change.
+
+## Consequences
+
+* New package `pybnf/shooting/` (`grid`, `backend`, `bngsim_backend`, `problem`, `solver`,
+  `driver`), and the `ms` fit type in
+  `pybnf/algorithms/optimizers/multiple_shooting.py` with `MSConfig`.
+* New configuration keys, all defaulted from ADR-0109's findings rather than from taste:
+  `ms_segments` (4 — the ladder starts in the *middle*), `ms_coarsening` (2),
+  `ms_penalty` (10) / `ms_penalty_growth` (5) — the schedule starts **tight** —
+  `ms_max_penalty`, `ms_feasibility_tol`, `ms_optimality_tol` (1e-6, looser than `gntr`'s
+  because it measures the augmented Lagrangian's gradient, which carries a factor of `rho`),
+  `ms_inner_iterations`, `ms_aux_decades`, and the runtime-guarded `ms_max_iterations`.
+* `Algorithm.run`'s end-of-fit path is extracted as `Algorithm._finalize_run()`. No behaviour
+  change: `run()` calls it in the same place with the same body.
+* No behaviour change to any existing fit. `pybnf/transcription/` gains its first consumer;
+  nothing in it changed.
+* Follow-on work, in order: parallel segment simulation; then the acceptance benchmark,
+  framed on the tail and the robustness the prototype measured.

--- a/docs/algorithms.rst
+++ b/docs/algorithms.rst
@@ -788,7 +788,10 @@ optimizers driven by exact forward parameter sensitivities:
 
 All three converge far faster than the metaheuristics near a good fit, and the same
 sensitivity machinery drives profile-likelihood identifiability analysis
-(``job_type = profile_likelihood``). These methods, the noise families and
+(``job_type = profile_likelihood``) and :ref:`multiple shooting <multiple_shooting>`
+(``job_type = ms``) — which changes the fit's *transcription* rather than its search,
+cutting each time course into segments joined by continuity constraints so that a long
+horizon stops hiding the answer from every optimizer. These methods, the noise families and
 constraints they support, and the capability gate that decides when a gradient fit
 is possible are documented in full on the :ref:`gradient-based fitting
 <gradient_fitting>` page.

--- a/docs/config_keys.rst
+++ b/docs/config_keys.rst
@@ -215,7 +215,8 @@ Required Keys
   taking the same values as :ref:`fit_type <fit_type>` above. It replaces ``fit_type``
   because that name was a misnomer -- the key selects across point-estimate
   *optimizers* (``de`` / ``ade`` / ``pso`` / ``ss`` / ``sim`` / ``powell`` / ``cmaes``
-  / ``sa``, and the gradient-based :ref:`trf / lbfgs / gntr <gradient_fitting>`), Bayesian
+  / ``sa``, and the gradient-based :ref:`trf / lbfgs / gntr <gradient_fitting>` plus
+  :ref:`multiple shooting <multiple_shooting>`, ``ms``), Bayesian
   *samplers* (``am`` / ``dream`` / ``p_dream`` / ``pt`` / ``mh``, and the
   gradient-based :ref:`hmc <alg-hmc>` for analytical objectives), the
   :ref:`profile-likelihood <gradient_fitting>` identifiability analysis
@@ -432,7 +433,10 @@ Required Keys
   Supported by every optimizer, including ``lbfgs`` and ``gntr``. ``job_type = trf``
   refuses a profiled fit (as it already refuses a searched free scale): under profiling
   the least-squares residual norm is constant, so a trust-region residual model carries
-  no information -- use ``lbfgs``.
+  no information -- use ``lbfgs``. It is the recommended pairing for :ref:`multiple
+  shooting <multiple_shooting>` (``job_type = ms``): a profiled scale is defined by the
+  data residuals alone, which continuity defects never enter, so the reported objective
+  stays comparable to a single-shoot one.
 
   See :ref:`normalization <normalization_key>` ``= scale`` for the same trick applied to
   an unknown multiplicative scale on the data.

--- a/docs/gradient_fitting.rst
+++ b/docs/gradient_fitting.rst
@@ -132,6 +132,83 @@ For all three, ``<method>_max_iterations`` caps the iterations per start and def
 ``max_iterations``.
 
 
+.. _multiple_shooting:
+
+Multiple shooting (``job_type = ms``)
+--------------------------------------
+
+Every method above fits by **single shooting**: simulate the whole time course from the model's
+initial conditions and compare it with the data. On a model whose difficulty *is* horizon length,
+that transcription can put the answer out of reach of any search. The motivating case is an
+oscillator: on ``Borghans_BiophysChem1997``, a correctly-shaped trajectory whose period is wrong by
+more than about 3 % scores **worse than fitting no dynamics at all**, so a flat line is the ceiling
+on essentially the whole parameter box, and fifteen independent global searches terminate at it.
+
+``job_type = ms`` changes the transcription rather than the search. Each experiment's time course
+is cut at knots; each segment is integrated from its **own** start state, and continuity between
+segments is imposed as an equality constraint rather than assumed. Over one short segment a period
+error cannot accumulate, so the information moves out of a residual term that saturates and into
+continuity defects, which carry a direction. The segment-start states are internal to the method —
+searched, bounded and differentiated, but never reported as fit results.
+
+**The score you get is an ordinary one.** Every iterate is *certified*: the auxiliary states are
+discarded, the parameters are re-simulated with ordinary single shooting, and that score is what is
+reported and ranked. A run that leaves continuity unconverged therefore scores as what it actually
+is, and the number in ``sorted_params_final.txt`` is directly comparable with any other fit's.
+
+**The ladder is the mechanism.** A run does not fix a segment count; it solves a sequence of
+transcriptions, coarsening toward the ordinary unsegmented problem (``4 → 2 → 1`` by default) and
+warm-starting each rung from the previous one. The stage trace is printed as it goes, and on the
+motivating problem it *is* the result — every segmented stage scored worse than a flat line, and
+the coarsening is what converted them.
+
+**Requirements and limits.** ``ms`` needs everything the gradient path needs, plus the bngsim
+SBML/Antimony backend: a knot carries the model's **state**, and only that path reports species
+columns with matching initial-condition sensitivities. It refuses, by name and up front, a fit it
+would otherwise quietly change — a dose-response scan or pre-equilibration protocol (no time axis
+to cut, or a measured phase that already starts from a carried state), and any scored quantity that
+is a function of a whole series (an analytic per-series ``scale``, a data ``normalization``, a
+``cumulative`` column, or BPSL constraints). An analytically profiled noise scale
+(``noise_profiling = 1``) is fine and is the recommended pairing: it is profiled over the pooled
+data residuals, which continuity defects never enter. Segments are simulated serially, so ``ms``
+does not scale across a cluster the way the metaheuristics do, and a stopped run cannot be resumed
+with ``-r``.
+
+**Tuning.** The defaults come from measurement on the motivating problem, not from convention, and
+are worth leaving alone unless you have a reason:
+
+* ``ms_segments`` (default ``4``) — the **finest** rung of the ladder, and ``ms_coarsening``
+  (default ``2``) the factor between rungs. Starting with many short segments is the wrong end:
+  under partial observability an over-segmented stage is under-determined and routinely certifies
+  worse than its own start.
+* ``ms_penalty`` (default ``10``) and ``ms_penalty_growth`` (default ``5``) — the augmented
+  Lagrangian's initial penalty and its growth factor, capped at ``ms_max_penalty``. Deliberately
+  **tight**: a loose start was measured both worse *and* twice as expensive, because the inner
+  solve on a nearly-unconstrained subproblem never converges and burns its whole budget.
+* ``ms_feasibility_tol`` / ``ms_optimality_tol`` (both ``1e-6``) — the scaled continuity defect and
+  the projected-gradient optimality a run must reach together to report convergence. The optimality
+  tolerance is looser than ``gntr_grad_tol`` on purpose: it measures the *augmented* Lagrangian's
+  gradient, which carries a factor of the penalty.
+* ``ms_inner_iterations`` (default ``50``) — trust-region iterations per outer iteration; an
+  approximate inner solve is what the method is designed around. ``ms_max_iterations`` caps outer
+  iterations per rung and defaults to the global ``max_iterations``.
+* ``ms_aux_decades`` (default ``6``) — the half-width, in decades, of a segment-start state's box
+  around its own magnitude.
+
+A minimal run::
+
+    edition = 2
+    job_type = ms
+    sbml_backend = bngsim
+    model: model.xml
+    experiment: myexp, data: mydata.exp
+    noise_profiling = 1
+    output_dir = output/ms
+
+The design, the measurements behind each default, and what this cut deliberately leaves out are
+recorded in ADR-0109 (the reusable transcription layer) and ADR-0110 (this consumer).
+
+
 Profile likelihood (identifiability + confidence intervals)
 -----------------------------------------------------------
 

--- a/docs/gradient_fitting.rst
+++ b/docs/gradient_fitting.rst
@@ -163,8 +163,15 @@ motivating problem it *is* the result — every segmented stage scored worse tha
 the coarsening is what converted them.
 
 **Requirements and limits.** ``ms`` needs everything the gradient path needs, plus the bngsim
-SBML/Antimony backend: a knot carries the model's **state**, and only that path reports species
-columns with matching initial-condition sensitivities. It refuses, by name and up front, a fit it
+SBML/Antimony backend: a knot carries the model's **state**, and that is the one PyBNF backend
+whose trajectory columns *are* the species and whose sensitivity selectors name them on both
+axes. A ``.net`` model is a reaction network with the same kind of state — and bngsim will
+return both its species trajectory and the matching ``d(species)/d(species₀)`` — but PyBNF's
+net backend builds its trajectory from observables and expressions and requests the same
+selectors, so a segment would come back carrying neither the state at the knot nor its
+derivative. Extending ``ms`` there is adapter work rather than a modelling obstacle; it is not
+free, since a net segment would need both selector families on one run and a combinatorially
+expanded network makes the auxiliary block ``(m-1)×n_species`` wide. It refuses, by name and up front, a fit it
 would otherwise quietly change — a dose-response scan or pre-equilibration protocol (no time axis
 to cut, or a measured phase that already starts from a carried state), and any scored quantity that
 is a function of a whole series (an analytic per-series ``scale``, a data ``normalization``, a

--- a/docs/gradient_fitting.rst
+++ b/docs/gradient_fitting.rst
@@ -162,16 +162,11 @@ warm-starting each rung from the previous one. The stage trace is printed as it 
 motivating problem it *is* the result — every segmented stage scored worse than a flat line, and
 the coarsening is what converted them.
 
-**Requirements and limits.** ``ms`` needs everything the gradient path needs, plus the bngsim
-SBML/Antimony backend: a knot carries the model's **state**, and that is the one PyBNF backend
-whose trajectory columns *are* the species and whose sensitivity selectors name them on both
-axes. A ``.net`` model is a reaction network with the same kind of state — and bngsim will
-return both its species trajectory and the matching ``d(species)/d(species₀)`` — but PyBNF's
-net backend builds its trajectory from observables and expressions and requests the same
-selectors, so a segment would come back carrying neither the state at the knot nor its
-derivative. Extending ``ms`` there is adapter work rather than a modelling obstacle; it is not
-free, since a net segment would need both selector families on one run and a combinatorially
-expanded network makes the auxiliary block ``(m-1)×n_species`` wide. It refuses, by name and up front, a fit it
+**Requirements and limits.** ``ms`` needs everything the gradient path needs, plus a model
+with an enumerated ODE state to restart from — which means either bngsim path. A knot carries
+the model's **state**, so both a generated network (``.net``, via BNGL) and an SBML/Antimony
+model with ``sbml_backend = bngsim`` are supported; a network-free (NFsim) model never
+enumerates a state and is refused. It refuses, by name and up front, a fit it
 would otherwise quietly change — a dose-response scan or pre-equilibration protocol (no time axis
 to cut, or a measured phase that already starts from a carried state), and any scored quantity that
 is a function of a whole series (an analytic per-series ``scale``, a data ``normalization``, a
@@ -180,6 +175,15 @@ is a function of a whole series (an analytic per-series ``scale``, a data ``norm
 data residuals, which continuity defects never enter. Segments are simulated serially, so ``ms``
 does not scale across a cluster the way the metaheuristics do, and a stopped run cannot be resumed
 with ``-r``.
+
+**A note on size, for network models.** The transcription's width scales with the model's
+**state**, not with the number of fitted parameters: the finest rung adds
+``(m − 1) × n_species`` internal variables per experiment, and the initial-condition
+sensitivity system is ``n_species`` wide. On a handful of species that is nothing; on a
+combinatorially expanded reaction network it can dwarf the fit's own dimension
+(``egfr_ground.net``, 356 species, at ``m = 4`` adds ~1068). A run prints the number it is
+adding as it starts, so the cost is visible before it is paid; lower ``ms_segments`` if it is
+more than the problem warrants.
 
 **Tuning.** The defaults come from measurement on the motivating problem, not from convention, and
 are worth leaving alone unless you have a reason:

--- a/docs/modules/index.rst
+++ b/docs/modules/index.rst
@@ -23,4 +23,5 @@ PyBNF Module References
    printing
    priors
    pset
+   shooting
    transcription

--- a/docs/modules/shooting.rst
+++ b/docs/modules/shooting.rst
@@ -39,6 +39,9 @@ The segment-simulation seam
 .. automodule:: pybnf.shooting.bngsim_backend
    :members:
 
+.. automodule:: pybnf.shooting.net_backend
+   :members:
+
 The transcription
 =================
 

--- a/docs/modules/shooting.rst
+++ b/docs/modules/shooting.rst
@@ -1,0 +1,58 @@
+.. _shooting_module:
+
+===============================================================
+Multiple shooting (:py:mod:`pybnf.shooting`)
+===============================================================
+
+:py:mod:`pybnf.transcription` (ADR-0109) is the reusable half of issue #563 — an augmented
+variable layout, an equality residual/Jacobian interface, and an optimizer-agnostic
+augmented-Lagrangian outer loop with its homotopy and its certification. It makes no
+simulator call and defines no ``job_type``. This package is the other half: what it takes to
+state *this* fit as that kind of problem.
+
+Split each scored experiment's time course at ``m - 1`` knots. Segment *j* is integrated
+from its own start state — segment 0's is the model's own initial conditions, which are
+often fitted parameters, and each interior knot carries an auxiliary state ``z_j`` that is
+searched, bounded and differentiated but is **never** a fit result. Continuity is imposed as
+``c_j = Phi_j(z_j, theta) - z_{j+1} = 0`` and enforced by the augmented Lagrangian, whose
+subproblem is solved by ``gntr``'s own Gauss-Newton trust-region step machine. Every
+reported score comes from discarding ``z``, re-simulating ``theta`` with ordinary single
+shooting, and scoring *that*, so a run that leaves continuity unconverged scores as what it
+actually is.
+
+The fit type that runs all of it is ``job_type = ms``
+(:py:mod:`pybnf.algorithms.optimizers.multiple_shooting`). The design, its measurements, and
+what this cut deliberately leaves out are recorded in ADR-0110.
+
+Knot placement
+==============
+
+.. automodule:: pybnf.shooting.grid
+   :members:
+
+The segment-simulation seam
+===========================
+
+.. automodule:: pybnf.shooting.backend
+   :members:
+
+.. automodule:: pybnf.shooting.bngsim_backend
+   :members:
+
+The transcription
+=================
+
+.. automodule:: pybnf.shooting.problem
+   :members:
+
+The inner solver
+================
+
+.. automodule:: pybnf.shooting.solver
+   :members:
+
+The ladder
+==========
+
+.. automodule:: pybnf.shooting.driver
+   :members:

--- a/pybnf/algorithms/__init__.py
+++ b/pybnf/algorithms/__init__.py
@@ -60,6 +60,13 @@ from .optimizers.cmaes import CMAESAlgorithm as CMAESAlgorithm
 from .optimizers.trf import TRFAlgorithm as TRFAlgorithm
 from .optimizers.lbfgs import LBFGSAlgorithm as LBFGSAlgorithm
 from .optimizers.gntr import GNTRAlgorithm as GNTRAlgorithm
+# Multiple shooting (#563, ADR-0110): the first consumer of the constrained-transcription
+# layer (pybnf/transcription, ADR-0109). A GradientOptimizer for its gates, routings and
+# start points, but it drives its own search -- a segment is not a PSet evaluation -- so it
+# overrides run() the way hmc does. Importing the leaf runs its @register_fit_type.
+from .optimizers.multiple_shooting import (
+    MultipleShootingAlgorithm as MultipleShootingAlgorithm,
+)
 # Profile likelihood (#446/#466): a standalone new-era job_type that reuses the same
 # gradient path -- a multi-start TRF polish to the optimum, then one adaptive re-optimized
 # profile per parameter for confidence intervals + identifiability. Importing the leaf runs

--- a/pybnf/algorithms/base.py
+++ b/pybnf/algorithms/base.py
@@ -1251,6 +1251,22 @@ class Algorithm(ABC):
 
         logger.info("Cancelling %d pending jobs" % len(pending))
         client.cancel(list(pending.keys()))
+        self._finalize_run()
+
+    def _finalize_run(self):
+        """The end-of-fit path: stop reason, final parameter sets, best-fit artifacts,
+        teardown.
+
+        Reached the same way however the search ended -- the algorithm's own stop
+        criterion, an exhausted job pool, or the wall-time budget -- because a budgeted run
+        is a *finished* run whose search was cut short and writes exactly what a converged
+        one writes (ADR-0093). Split out of :meth:`run` so a method that does **not** drive
+        the propose/score loop still writes the same artifacts every other fit type does,
+        rather than forking the tail: today that is ``job_type = ms``, whose unit of work is
+        a trajectory segment rather than a PSet evaluation and which therefore overrides
+        :meth:`run` (as ``hmc`` does, for the same reason). Everything here reads
+        :attr:`trajectory` and :attr:`stop_reason` and nothing about how they were filled.
+        """
         self._announce_stop_reason()
 
         # Write the final parameter sets, then copy the best simulations into the results

--- a/pybnf/algorithms/optimizers/multiple_shooting.py
+++ b/pybnf/algorithms/optimizers/multiple_shooting.py
@@ -35,11 +35,13 @@ dynamics), multiple shooting refuses three further classes of fit, each because 
 transcription would otherwise change the quantity being fitted rather than the way it is
 searched:
 
-* **a model whose state this cut's backend cannot surface** -- the state at a knot is the
-  ODE state vector, and of PyBNF's backends only the bngsim SBML/Antimony one puts species
-  columns and initial-condition sensitivities on the same run. A ``.net`` model has the same
-  kind of state and bngsim will return it; PyBNF's net adapter does not ask for it. See
-  :mod:`pybnf.shooting.bngsim_backend` for what closing that would take;
+* **a model with no enumerated state to restart from** -- the state at a knot is the ODE
+  state vector, which a network-free (NFsim) model never enumerates and a non-bngsim backend
+  does not expose. Both bngsim paths are supported, through two backends that differ only in
+  what a simulation *returns*: :mod:`pybnf.shooting.bngsim_backend` for SBML/Antimony, whose
+  trajectory columns already are the species, and :mod:`pybnf.shooting.net_backend` for
+  ``.net``, which asks for the observable and species selector families together so one
+  integration serves both the data terms and the continuity block (#577);
 * **an experiment that is not a plain measured time course** -- a dose-response scan has no
   time axis to cut, and a pre-equilibration protocol's measured phase already begins from a
   carried state that is not the model's own;
@@ -63,6 +65,7 @@ from ...registry import register_fit_type
 from ...shooting import (
     BngsimSegmentBackend,
     GaussNewtonSolver,
+    NetSegmentBackend,
     ShootingExperiment,
     feasible_ladder,
     run_multiple_shooting,
@@ -71,6 +74,49 @@ from ...shooting.grid import KNOT
 from ...transcription import PenaltySchedule, coarsening_ladder
 
 logger = logging.getLogger('pybnf.algorithms')
+
+
+def _is_sbml_path(model):
+    """Whether this model is on the bngsim SBML/Antimony backend, whose trajectory columns
+    *are* its species (:mod:`pybnf.shooting.bngsim_backend`)."""
+    return (hasattr(model, '_run_simulation') and hasattr(model, '_result_to_data')
+            and hasattr(model, 'species_names'))
+
+
+def _is_net_path(model):
+    """Whether this model is on the bngsim ``.net`` backend -- an expanded reaction network
+    whose species this cut reads alongside its observables
+    (:mod:`pybnf.shooting.net_backend`, #577).
+
+    A network-free (NFsim) model reuses the same ``_build_data`` but enumerates no species,
+    so the engine model's species list is what tells the two apart rather than the class.
+    """
+    engine = getattr(model, '_engine_model', None)
+    if engine is None or not hasattr(model, '_build_data'):
+        return False
+    try:
+        return len(list(engine.species_names)) > 0
+    except Exception:
+        return False
+
+
+def _state_names(model):
+    """The species a knot carries, whichever bngsim path this model is on.
+
+    The SBML/Antimony wrapper exposes them as a property; the ``.net`` wrapper keeps them on
+    its engine model. One accessor so the request-widening and the gate agree on what "the
+    state" is.
+    """
+    if _is_sbml_path(model):
+        return list(model.species_names)
+    return list(model._engine_model.species_names)
+
+
+def _flag(value):
+    try:
+        return bool(int(float(str(value).strip().strip('"\''))))
+    except (TypeError, ValueError):
+        return False
 
 
 class MSConfig(PyBNFConfigModel):
@@ -201,6 +247,15 @@ class MultipleShootingAlgorithm(GradientOptimizer):
                    % (', '.join(str(m) for m in dropped),
                       '-'.join(str(m) for m in rungs)))
         print1('Multiple-shooting ladder: %s' % '-'.join(str(m) for m in rungs))
+        # The transcription's width, stated up front. It scales with the model's *state*
+        # (the auxiliary block is (m-1) x n_species per experiment), not with the number of
+        # fitted parameters, so on an expanded reaction network it can dwarf the fit's own
+        # dimension -- which a user should hear from the run rather than infer from its
+        # duration (#577).
+        added = sum((spec.grid(rungs[0]).n_knots) * len(spec.backend.state_names)
+                    for spec in specs)
+        print1('  finest rung adds %i internal auxiliary variable(s) to this fit\'s %i free '
+               'parameter(s)' % (added, len(self.variables)))
         for spec in specs:
             print2(spec.grid(rungs[0]).describe())
 
@@ -269,8 +324,7 @@ class MultipleShootingAlgorithm(GradientOptimizer):
             self._require_carryable_state(model)
             self._request_state_sensitivities(model)
             for suffix, exp_data in self.exp_data.get(model.name, {}).items():
-                action, mutant = self._resolve_action(model, suffix)
-                self._require_simple_time_course(model, action, suffix)
+                backend = self._make_backend(model, suffix)
                 label = str(suffix)
                 if KNOT in label:
                     raise PybnfError(
@@ -286,11 +340,8 @@ class MultipleShootingAlgorithm(GradientOptimizer):
                         "to be re-evaluated at every fit point (#530)." % suffix,
                         hint='Fit this model with job_type = gntr, which resolves the '
                              'routing per evaluation.')
-                specs.append(ShootingExperiment(
-                    (model.name, suffix),
-                    BngsimSegmentBackend(model, action, mutant, suffix,
-                                         timeout=self.config.config['wall_time_sim']),
-                    exp_data, routing, label=label, start=0.0))
+                specs.append(ShootingExperiment((model.name, suffix), backend, exp_data,
+                                                routing, label=label, start=0.0))
         if not specs:
             raise PybnfError('Multiple shooting found no scored experiment to segment.')
         return specs
@@ -317,12 +368,30 @@ class MultipleShootingAlgorithm(GradientOptimizer):
         request = getattr(model, '_sensitivity_request', None)
         params = list(getattr(request, 'params', None) or [])
         ic = list(getattr(request, 'ic', None) or [])
-        for state in model.species_names:
+        for state in _state_names(model):
             if state not in ic:
                 ic.append(state)
         model.enable_output_sensitivities(params=params, ic=ic)
 
-    def _resolve_action(self, model, suffix):
+    def _make_backend(self, model, suffix):
+        """The segment simulator for one scored ``(model, condition)`` pair.
+
+        Two backends, because the two model paths differ in *what a simulation returns*,
+        not in whether they have a state (#577). The SBML/Antimony path reports its species
+        as the trajectory's columns with ``species:`` sensitivity selectors on both axes; the
+        ``.net`` path reports observables and expressions, so its backend asks for both
+        selector families on one run and appends the species columns itself.
+        """
+        timeout = self.config.config['wall_time_sim']
+        if _is_sbml_path(model):
+            action, mutant = self._resolve_sbml_action(model, suffix)
+            self._require_simple_time_course(model, action, suffix)
+            return BngsimSegmentBackend(model, action, mutant, suffix, timeout=timeout)
+        sim_params, mutant = self._resolve_net_action(model, suffix)
+        self._require_simple_net_action(sim_params, suffix)
+        return NetSegmentBackend(model, sim_params, mutant, suffix, timeout=timeout)
+
+    def _resolve_sbml_action(self, model, suffix):
         """The ``(action, condition)`` pair whose output is scored under ``suffix``.
 
         The same pairing :meth:`~pybnf.bngsim_sbml_model.BngsimSbmlModelNoTimeout.execute`
@@ -340,34 +409,84 @@ class MultipleShootingAlgorithm(GradientOptimizer):
             "Multiple shooting could not resolve which simulation of model '%s' produces "
             "the scored output '%s'." % (getattr(model, 'name', '?'), suffix))
 
+    def _resolve_net_action(self, model, suffix):
+        """The ``(parsed simulate action, condition)`` pair scored under ``suffix``.
+
+        The ``.net`` peer of :meth:`_resolve_sbml_action`. A net model's actions are raw
+        BNGL ``simulate()`` lines rather than objects, so each is parsed the way
+        ``_execute_actions`` parses it and matched on the same
+        ``action suffix + mutant suffix`` key.
+
+        The wildtype is appended rather than assumed present: ``BngsimModel.execute`` runs
+        the base actions *before* its mutant loop rather than as an empty-suffix member of
+        it (which is where the SBML path puts it), so a model with conditions declared still
+        scores its unperturbed run under the bare action suffix.
+        """
+        from ...bngsim_model.parsing import _parse_simulate_action
+        from ...pset import MutationSet
+        conditions = list(getattr(model, 'mutants', []) or [])
+        if not any(getattr(m, 'suffix', '') == '' for m in conditions):
+            conditions.append(MutationSet())
+        for mutant in conditions:
+            for line in getattr(model, 'actions', []) or []:
+                sim_params = _parse_simulate_action(str(line).strip())
+                if sim_params is None:
+                    continue
+                if sim_params.get('suffix', 'time_course') + mutant.suffix == suffix:
+                    return sim_params, mutant
+        raise PybnfError(
+            "Multiple shooting could not resolve which simulate() action of model '%s' "
+            "produces the scored output '%s'." % (getattr(model, 'name', '?'), suffix))
+
     # --- gates ------------------------------------------------------------- #
     def _require_carryable_state(self, model):
-        """Refuse a model whose state this cut's backends cannot surface.
+        """Refuse a model whose state no segment backend can surface.
 
-        Not a statement about the model: a ``.net`` file is a reaction network with the same
-        kind of ODE state an SBML model has, and bngsim returns both its species trajectory
-        and its ``d(species)/d(species_0)`` when asked. The gap is in PyBNF's net adapter,
-        which builds its ``Data`` from observables and expressions and requests
-        ``observable:`` / ``expression:`` sensitivity selectors, so a segment simulation
-        would come back carrying neither the state at the knot nor its derivative. The
-        message says which of those it is, because "your model has no state" would send a
-        user looking in the wrong place.
+        Both bngsim paths qualify (#577): the SBML/Antimony one reports species columns and
+        ``species:`` sensitivity selectors directly, and the ``.net`` one is a reaction
+        network with the same kind of ODE state whose species trajectory and
+        ``d(species)/d(species_0)`` bngsim returns when asked -- which
+        :mod:`pybnf.shooting.net_backend` does. What is left over is a backend with no
+        expanded network to carry at all (network-free NFsim) or no bngsim seam (a
+        RoadRunner/SBML model), and the message names that rather than implying the model
+        has no state.
         """
-        if hasattr(model, '_run_simulation') and hasattr(model, 'species_names') \
-                and hasattr(model, '_result_to_data'):
+        if _is_sbml_path(model) or _is_net_path(model):
             return
         raise PybnfError(
             "Multiple shooting (job_type = ms) restarts a simulation from the model's own "
-            "state at each knot, and PyBNF's backend for model '%s' does not surface that "
-            "state: its trajectory carries observables and expressions rather than species, "
-            "and its forward-sensitivity request names the same selectors, so a segment "
-            "would return neither the state at a knot nor its d(state)/d(state). The model "
-            "itself has a perfectly good state -- this is a limitation of the backend "
-            "adapter, not of the model." % getattr(model, 'name', '?'),
-            hint=['Simulate the model through the bngsim SBML/Antimony path (an SBML model '
-                  'needs \'sbml_backend = bngsim\'), whose species columns and '
+            "state at each knot, and model '%s' uses a backend that has no such state to "
+            "restart from -- a network-free (NFsim) model never enumerates one, and a "
+            "non-bngsim backend exposes neither the state nor its forward sensitivities."
+            % getattr(model, 'name', '?'),
+            hint=['Simulate the model through bngsim -- a generated network (.net) or an '
+                  'SBML model with \'sbml_backend = bngsim\' -- whose species and '
                   'initial-condition sensitivities are what a knot carries.',
                   'Or fit with job_type = gntr, which needs no segment transcription.'])
+
+    def _require_simple_net_action(self, sim_params, suffix):
+        """Refuse a ``.net`` ``simulate()`` action that is not a plain measured time course.
+
+        The ``.net`` peer of :meth:`_require_simple_time_course`, on the parsed action rather
+        than an action object.
+        """
+        method = str(sim_params.get('method', 'ode')).strip().strip('"\'')
+        reason = None
+        if method != 'ode':
+            reason = ('it requests method=%r, which is not deterministic ODE integration '
+                      'and so carries no forward sensitivities' % method)
+        elif _flag(sim_params.get('continue', 0)):
+            reason = ("it continues from a previous action's end state rather than from "
+                      "the model's own initial conditions")
+        elif sim_params.get('stop_if'):
+            reason = ('a stop_if condition can end it before its horizon, so its knots are '
+                      'not placed on a span it is guaranteed to reach')
+        if reason is None:
+            return
+        raise PybnfError(
+            "Multiple shooting (job_type = ms) segments a measured time course, and "
+            "experiment '%s' cannot be segmented: %s." % (suffix, reason),
+            hint='Fit with job_type = gntr, which needs no segment transcription.')
 
     def _require_simple_time_course(self, model, action, suffix):
         """Refuse an experiment that is not a plain measured time course."""

--- a/pybnf/algorithms/optimizers/multiple_shooting.py
+++ b/pybnf/algorithms/optimizers/multiple_shooting.py
@@ -1,0 +1,444 @@
+"""Multiple shooting (``job_type = ms``, #563/ADR-0110): the fit type over ADR-0109's layer.
+
+What the method does is documented in :mod:`pybnf.shooting`; this module is the *fit type*
+-- the gates, the configuration surface, the ladder's tunables, and the run.
+
+Why this one overrides ``run()``
+--------------------------------
+Every other optimizer plugs into the shared propose/score loop: propose a
+:class:`~pybnf.pset.PSet`, have the cluster simulate and score it, consume the result,
+propose the next. Multiple shooting's unit of work is not a PSet evaluation. A segment is
+one span of one experiment integrated **from a state that is not in any parameter set** --
+the auxiliary variable ``z_j``, which ADR-0109 keeps structurally out of the reported fit
+results -- and one augmented-model evaluation is ``m`` such spans whose forward
+sensitivities have to be assembled together, on one machine, before a single step can be
+taken. The layer's inner-solver contract is a blocking call for the same reason
+(``solve(subproblem, u0, tolerance)``; "the solver never calls back into the outer loop").
+
+So this fit type drives its own search on the master and calls
+:meth:`~pybnf.algorithms.base.Algorithm._finalize_run` for the end-of-fit path, exactly as
+``job_type = hmc`` does and for the same class of reason (ADR-0059: "the gradient cannot
+survive the per-pset dask round-trip"). What it does **not** do is fork the tail: every
+certified iterate is entered in the ordinary trajectory at its ordinary single-shoot score,
+so ``sorted_params``, the best-fit simulations, the information criteria, the profiled-noise
+report, and the inference-data sidecar are produced by the same code every other fit type
+uses, from numbers that mean the same thing.
+
+The corollary, stated rather than discovered: this cut runs its segments serially on the
+master. Segment simulation is embarrassingly parallel and the interface does not prevent
+scheduling it, but nothing here schedules it.
+
+The gates
+---------
+Beyond the gradient path's own (edition 2, a forward-sensitivity backend, differentiable
+dynamics), multiple shooting refuses three further classes of fit, each because the
+transcription would otherwise change the quantity being fitted rather than the way it is
+searched:
+
+* **a model whose state it cannot carry** -- the state at a knot is the ODE state vector,
+  and only the bngsim SBML/Antimony path reports species columns with initial-condition
+  sensitivities on the same axis (:mod:`pybnf.shooting.bngsim_backend`);
+* **an experiment that is not a plain measured time course** -- a dose-response scan has no
+  time axis to cut, and a pre-equilibration protocol's measured phase already begins from a
+  carried state that is not the model's own;
+* **a quantity that is a function of a whole series** -- an analytic per-series scale
+  (ADR-0066), a ``Data``-level normalization (ADR-0053), or a cumulative-to-incident
+  difference (ADR-0051). Cutting the series changes each of them, so the segmented fit would
+  not be a transcription of the fit that was requested. An analytically profiled **noise
+  scale** (ADR-0108) is deliberately not in this list: it is profiled over the pooled
+  residuals of every scored experiment, so cutting one series into ``m`` pieces pools the
+  same residuals and yields the same ``sigma_hat`` -- which is also what keeps continuity
+  violation out of the reported likelihood.
+"""
+
+import logging
+from typing import ClassVar
+
+from .gradient_base import GradientOptimizer
+from ...config_schema import PyBNFConfigModel
+from ...printing import PybnfError, print0, print1, print2
+from ...registry import register_fit_type
+from ...shooting import (
+    BngsimSegmentBackend,
+    GaussNewtonSolver,
+    ShootingExperiment,
+    feasible_ladder,
+    run_multiple_shooting,
+)
+from ...shooting.grid import KNOT
+from ...transcription import PenaltySchedule, coarsening_ladder
+
+logger = logging.getLogger('pybnf.algorithms')
+
+
+class MSConfig(PyBNFConfigModel):
+    """Multiple-shooting config fields, co-located with the method (ADR-0006).
+
+    Three of these carry measurements rather than preferences, and their defaults are the
+    #563 prototype's findings rather than round numbers (ADR-0109):
+
+    ``ms_segments`` is the **finest** rung of the ladder, and it defaults to 4 rather than
+    to the largest affordable number. Starting with many short segments -- the easiest
+    landscape -- is the wrong end on the motivating problem: at ``m = 8``, with one observed
+    state of three, the segmented problem is under-determined and the stage routinely
+    certifies worse than its own start. ``ms_coarsening`` is the factor between rungs, so
+    the default ladder is ``4 -> 2 -> 1`` and always ends at the ordinary unsegmented fit.
+
+    ``ms_penalty`` and ``ms_penalty_growth`` start the augmented Lagrangian **tight**, which
+    is the opposite of what the multiple-shooting literature's motivation suggests. Measured
+    from one start: ``rho_0 = 0.1, gamma = 3`` reached ``-178.38`` in 124 s while
+    ``rho_0 = 10, gamma = 5`` reached ``-200.70`` in 62 s -- better *and* at half the cost,
+    because the inner solve on a nearly-unconstrained subproblem never converges and burns
+    its whole budget every outer iteration.
+
+    ``ms_optimality_tol`` measures the *augmented Lagrangian's* projected gradient, whose
+    penalty term carries a factor of ``rho``, so it is deliberately looser than ``gntr``'s
+    ``1e-8`` on the fit's own gradient: the answer is certified by reconstruction, not by a
+    KKT residual, so the extra digits buy nothing a certificate does not already establish.
+
+    ``ms_aux_decades`` is the half-width, in decades, of an auxiliary state's box around its
+    own magnitude; ``ms_inner_iterations`` bounds each inner solve (an approximate inner
+    minimisation is what the method is designed around, and the outer loop's stall detector
+    is what notices a solver that has stopped achieving anything). Like every other local
+    method's, ``ms_max_iterations`` is runtime-guarded -- it defaults to the global
+    ``max_iterations`` when unset -- and bounds the outer iterations per rung.
+    """
+
+    ms_segments: int = 4
+    ms_coarsening: int = 2
+    ms_penalty: float = 10.0
+    ms_penalty_growth: float = 5.0
+    ms_max_penalty: float = 1e8
+    ms_feasibility_tol: float = 1e-6
+    ms_optimality_tol: float = 1e-6
+    ms_inner_iterations: int = 50
+    ms_aux_decades: float = 6.0
+
+    RUNTIME_KEYS: ClassVar[frozenset] = frozenset({'ms_max_iterations'})
+
+
+# Neither `refiner` nor `start_from_box`: those two flags classify the *start-point*
+# optimizers, which take a `var` / `logvar` point (ADR-0015/0017). `ms` draws every variable
+# from its prior like the population optimizers do, and it is not a local polish -- so it is
+# in the "everything else" category, and multi-start over a bounded box comes from
+# `_is_box_start`, which reads the priors rather than the registry.
+@register_fit_type('ms', family='optimizer', display_name='Multiple Shooting',
+                   schema=MSConfig)
+class MultipleShootingAlgorithm(GradientOptimizer):
+    """The multiple-shooting fit type.
+
+    Inherits the gradient path's pre-flight gates, its forward-sensitivity activation and
+    per-experiment routing (:meth:`~GradientOptimizer._setup_gradient_path`), its
+    ``u`` <-> PSet plumbing, and its start-point resolution (the box centre, then
+    ``population_size - 1`` Latin-hypercube starts). It replaces only the search: the
+    propose/score loop is not the granularity a segment lives at, so :meth:`run` drives the
+    ladder directly (see the module docstring).
+    """
+
+    fit_type = 'ms'
+    START_POINT_KEY = 'ms_start_point'
+    _method_label = 'multiple shooting'
+
+    def __init__(self, config, refine=False):
+        super().__init__(config, refine=refine)
+        self.max_outer = config.config.get('ms_max_iterations',
+                                           config.config['max_iterations'])
+        self.n_segments = int(config.config['ms_segments'])
+        self.coarsening = int(config.config['ms_coarsening'])
+        self.inner_iterations = int(config.config['ms_inner_iterations'])
+        self.aux_decades = float(config.config['ms_aux_decades'])
+        self.schedule = PenaltySchedule(
+            initial_penalty=config.config['ms_penalty'],
+            growth=config.config['ms_penalty_growth'],
+            max_penalty=config.config['ms_max_penalty'],
+            optimality_tol=config.config['ms_optimality_tol'],
+            feasibility_tol=config.config['ms_feasibility_tol'])
+        self.homotopies = []
+
+    def _start_banner(self):
+        return ('Running multiple shooting: coarsening ladder from %i segment(s), up to %i '
+                'outer iteration(s) per rung, from %i start point(s)'
+                % (self.n_segments, self.max_outer, self.n_starts))
+
+    def _make_runner(self, u0):
+        """Never called: this fit type does not drive per-start step machines through the
+        propose/score loop (see the module docstring)."""
+        raise PybnfError('job_type = ms drives its own search; it builds no step machine '
+                         'for the propose/score loop. This is an internal wiring error.')
+
+    # --- the run ----------------------------------------------------------- #
+    def run(self, client=None, resume=None, debug=False):
+        """Drive the coarsening ladder from every start point, then finalize.
+
+        ``client`` is accepted and ignored: a segment simulation is not a job the cluster
+        can be handed (see the module docstring). ``resume`` is refused rather than
+        silently ignored -- there is no checkpointed step machine to resume from, and a
+        resumed run that quietly restarted from scratch would be worse than one that says
+        it cannot.
+        """
+        del client, debug
+        if resume:
+            raise PybnfError(
+                'job_type = ms cannot resume a stopped run: it drives its own search '
+                'rather than the checkpointed propose/score loop, so there is no partial '
+                'state to continue from.',
+                hint='Start the fit again, seeding it from the best fit the stopped run '
+                     'wrote (Results/sorted_params_final.txt).')
+        self.stop_reason = None
+        self.completed_simulations = 0
+        print2(self._start_banner())
+
+        self._setup_gradient_path()
+        specs = self._build_specs()
+        rungs, dropped = feasible_ladder(
+            specs, coarsening_ladder(start=self.n_segments, factor=self.coarsening))
+        if dropped:
+            # No silent caps: a dropped rung changes what ran, so it is reported.
+            print1('Segment count(s) %s exceed the shortest experiment\'s measurement count '
+                   'and were dropped; running the ladder %s.'
+                   % (', '.join(str(m) for m in dropped),
+                      '-'.join(str(m) for m in rungs)))
+        print1('Multiple-shooting ladder: %s' % '-'.join(str(m) for m in rungs))
+        for spec in specs:
+            print2(spec.grid(rungs[0]).describe())
+
+        for index, start in enumerate(self.start_psets):
+            if self._budget_spent():
+                break
+            solver = GaussNewtonSolver(max_iterations=self.inner_iterations,
+                                       stop_check=self._budget_spent)
+            result = run_multiple_shooting(
+                specs, self.objective, self.variables, self._pset_from_u,
+                self._param_vec(start), ladder=rungs, schedule=self.schedule,
+                inner_solver=solver, max_outer=self.max_outer,
+                aux_decades=self.aux_decades, stop_check=self._budget_spent,
+                on_iterate=self._record_iterate, on_stage=self._report_stage)
+            # Segment integrations, not augmented-model evaluations: one evaluation is m
+            # integrations plus the certification's, and reporting evaluations would
+            # understate the cost by the factor the method is judged on.
+            self.completed_simulations = sum(spec.backend.n_simulations for spec in specs)
+            self.homotopies.append(result)
+            print1('Start %i of %i: %s' % (index + 1, len(self.start_psets),
+                                           result.summary()))
+            print1('  stage trace: %s' % result.trace())
+            if not result.certified:
+                # The ladder always ends unsegmented, so this should not happen; say so
+                # loudly rather than let an unreconstructed score read as a fit result.
+                print0('Warning: some of this run\'s scores did not go through the '
+                       'ordinary single-shoot path and are not comparable with an '
+                       'ordinary fit\'s.')
+
+        if self._budget_spent():
+            self.stop_reason = self._wall_time_stop_reason(self.completed_simulations)
+        self._finalize_run()
+
+    def _record_iterate(self, record):
+        """Enter one certified outer iterate in the ordinary trajectory.
+
+        The certificate *is* an ordinary single-shoot score of the reported parameters, so
+        the trajectory holds the same kind of number every other fit type puts there and
+        ``trajectory.best_fit()`` is this run's answer -- which is also how the run reports
+        its **best certified** iterate rather than its last (ADR-0109 finding 5.3) without
+        a ranking rule of its own. An unaccepted certificate (a reconstruction that did not
+        simulate, or scored non-finite) is not a fit result and is not entered.
+        """
+        if not record.certificate.accepted:
+            return
+        self.probe_counter += 1
+        name = '%s_%i' % (self.fit_type, self.probe_counter)
+        self.trajectory.add(self._pset_from_u(record.reported, name=name),
+                            record.certificate.objective, name)
+        if self.probe_counter % self.config.config['output_every'] == 0:
+            self.output_results()
+
+    def _report_stage(self, stage):
+        print2('  %s' % stage.outer.summary())
+
+    # --- the experiments --------------------------------------------------- #
+    def _build_specs(self):
+        """One :class:`~pybnf.shooting.problem.ShootingExperiment` per scored experiment.
+
+        Built once for the whole fit -- the backend, the observations, and the routing do
+        not depend on the segment count, so every rung of the ladder reuses them.
+        """
+        self._require_series_are_cuttable()
+        specs = []
+        for model in self.model_list:
+            self._require_carryable_state(model)
+            self._request_state_sensitivities(model)
+            for suffix, exp_data in self.exp_data.get(model.name, {}).items():
+                action, mutant = self._resolve_action(model, suffix)
+                self._require_simple_time_course(model, action, suffix)
+                label = str(suffix)
+                if KNOT in label:
+                    raise PybnfError(
+                        "Multiple shooting names each knot '<experiment>%s<fraction>', and "
+                        "experiment suffix '%s' already contains %r."
+                        % (KNOT, label, KNOT))
+                routing = self._routings[(model.name, suffix)]
+                if routing.is_point_dependent:
+                    raise PybnfError(
+                        "Multiple shooting (job_type = ms) does not yet support a fit whose "
+                        "chain-rule factors are point-dependent -- experiment '%s' has a "
+                        "seed derivative that reads other model symbols, so its routing has "
+                        "to be re-evaluated at every fit point (#530)." % suffix,
+                        hint='Fit this model with job_type = gntr, which resolves the '
+                             'routing per evaluation.')
+                specs.append(ShootingExperiment(
+                    (model.name, suffix),
+                    BngsimSegmentBackend(model, action, mutant, suffix,
+                                         timeout=self.config.config['wall_time_sim']),
+                    exp_data, routing, label=label, start=0.0))
+        if not specs:
+            raise PybnfError('Multiple shooting found no scored experiment to segment.')
+        return specs
+
+    def _request_state_sensitivities(self, model):
+        """Widen this model's forward-sensitivity request to **every carried state**.
+
+        :meth:`~GradientOptimizer._setup_gradient_path` asks for exactly the columns the
+        routings read: the parameter axis a free parameter binds, and the initial-condition
+        axis only for a species some free parameter *is* an initial condition of. That is
+        the right request for an ordinary gradient fit and the wrong one here. Multiple
+        shooting reads ``d(anything)/d(z_j)`` for every state it carries across a knot --
+        both for the continuity block (which is exactly ``d(end state)/d(start state)``) and
+        for the data rows of every segment after the first, whose predictions depend on
+        their own segment-start state through the same axis. A state no free parameter
+        happens to seed would otherwise come back with no ``ic`` column at all, and the
+        assembly would refuse mid-run.
+
+        Widening rather than replacing: the parameter axis and any initial-condition column
+        the routings already asked for are kept, so an ordinary route is unaffected. The
+        cost is real and inherent -- a full initial-condition axis is one sensitivity system
+        per state -- which is the price of carrying the state at a knot.
+        """
+        request = getattr(model, '_sensitivity_request', None)
+        params = list(getattr(request, 'params', None) or [])
+        ic = list(getattr(request, 'ic', None) or [])
+        for state in model.species_names:
+            if state not in ic:
+                ic.append(state)
+        model.enable_output_sensitivities(params=params, ic=ic)
+
+    def _resolve_action(self, model, suffix):
+        """The ``(action, condition)`` pair whose output is scored under ``suffix``.
+
+        The same pairing :meth:`~pybnf.bngsim_sbml_model.BngsimSbmlModelNoTimeout.execute`
+        makes -- a mutant simulation's output suffix is ``action.suffix + mutant.suffix`` --
+        read back so a segment is simulated under exactly the condition the experiment was
+        measured under.
+        """
+        for mutant in getattr(model, 'mutants', []) or []:
+            for action in getattr(model, 'actions', []) or []:
+                if getattr(action, 'suffix', None) is None:
+                    continue
+                if action.suffix + mutant.suffix == suffix:
+                    return action, mutant
+        raise PybnfError(
+            "Multiple shooting could not resolve which simulation of model '%s' produces "
+            "the scored output '%s'." % (getattr(model, 'name', '?'), suffix))
+
+    # --- gates ------------------------------------------------------------- #
+    def _require_carryable_state(self, model):
+        """Refuse a model whose state a knot cannot carry."""
+        if hasattr(model, '_run_simulation') and hasattr(model, 'species_names') \
+                and hasattr(model, '_result_to_data'):
+            return
+        raise PybnfError(
+            "Multiple shooting (job_type = ms) restarts a simulation from the model's own "
+            "state at each knot, and model '%s' uses a backend that does not expose one: "
+            "its trajectory reports observables (sums over species), from which the state "
+            "cannot be recovered." % getattr(model, 'name', '?'),
+            hint=['Simulate the model through the bngsim SBML/Antimony path (an SBML model '
+                  'needs \'sbml_backend = bngsim\'), whose species columns and '
+                  'initial-condition sensitivities are what a knot carries.',
+                  'Or fit with job_type = gntr, which needs no segment transcription.'])
+
+    def _require_simple_time_course(self, model, action, suffix):
+        """Refuse an experiment that is not a plain measured time course."""
+        reason = None
+        if type(action).__name__ != 'TimeCourse':
+            reason = 'it is a %s, which has no time axis to cut' % type(action).__name__
+        elif getattr(action, 'preequilibrate', False):
+            reason = ('its measured phase already begins from a carried, equilibrated state '
+                      'rather than from the model\'s own initial conditions')
+        elif getattr(action, 'steady_state', False):
+            reason = 'a relaxation to steady state has no fixed horizon to place knots on'
+        elif getattr(action, 'initial_state_only', False):
+            reason = 'it measures only t = 0, so there is nothing to segment'
+        elif getattr(model, '_resolve_method', None) is not None \
+                and model._resolve_method(action) != 'ode':
+            reason = 'it is not integrated as an ODE, so it carries no forward sensitivities'
+        if reason is None:
+            return
+        raise PybnfError(
+            "Multiple shooting (job_type = ms) segments a measured time course, and "
+            "experiment '%s' cannot be segmented: %s." % (suffix, reason),
+            hint='Fit with job_type = gntr, which needs no segment transcription.')
+
+    def _require_series_are_cuttable(self):
+        """Refuse a fit whose scored quantity is a function of a whole series.
+
+        Each of these is computed *over* the series it belongs to, so splitting the series
+        changes it -- and a transcription that changes the objective is not a transcription
+        of the requested fit. An analytically profiled noise scale is deliberately absent
+        from this list; see the module docstring.
+        """
+        if self.config.config.get('normalization'):
+            raise PybnfError(
+                "Multiple shooting (job_type = ms) cuts each experiment's time course into "
+                "segments, and this fit normalizes its data (normalization = %s) -- a "
+                "normalizer is computed over the whole series, so the segments would be "
+                "normalized differently from the fit that was requested."
+                % self.config.config['normalization'],
+                hint='Fit with job_type = gntr, which scores each series whole.')
+        if getattr(self.objective, '_analytic_scale', None):
+            raise PybnfError(
+                "Multiple shooting (job_type = ms) cuts each experiment's time course into "
+                "segments, and this fit profiles an analytic per-series scale (ADR-0066) -- "
+                "the scale is a property of the whole series, so each segment would be "
+                "scaled on its own.",
+                hint='Fit with job_type = gntr, which profiles the scale over the whole '
+                     'series.')
+        for by_suffix in self.exp_data.values():
+            for suffix, exp_data in by_suffix.items():
+                for column in exp_data.cols:
+                    if self.objective._is_cumulative(column):
+                        raise PybnfError(
+                            "Multiple shooting (job_type = ms) cuts each experiment's time "
+                            "course into segments, and column '%s' of experiment '%s' is "
+                            "declared cumulative -- its prediction is the difference from "
+                            "the previous row, and at a knot that row is in another "
+                            "segment." % (column, suffix),
+                            hint='Fit with job_type = gntr, which differences the whole '
+                                 'series.')
+        if self.config.constraints:
+            raise PybnfError(
+                "Multiple shooting (job_type = ms) does not support a fit with qualitative "
+                "or inequality constraints (.con / .prop): a constraint is stated over a "
+                "trajectory, and a segmented trajectory does not join up until the run "
+                "converges.",
+                hint='Fit with job_type = gntr, which evaluates the constraints on the '
+                     'whole trajectory.')
+
+    # --- reporting --------------------------------------------------------- #
+    def best_stage_trace(self):
+        """The stage trace of the start that produced the run's best certified fit.
+
+        The single most informative artifact a homotopy produces -- it shows whether the
+        coarsening is converting the segmented stages, which is the mechanism the method
+        rests on. ``None`` before any start has run.
+        """
+        finished = [h for h in self.homotopies if h.best is not None]
+        if not finished:
+            return None
+        return min(finished, key=lambda h: h.best_score).trace()
+
+    def start_run(self):
+        raise PybnfError('job_type = ms drives its own search and does not use the '
+                         'propose/score loop. This is an internal wiring error.')
+
+    def got_result(self, res):
+        del res
+        raise PybnfError('job_type = ms drives its own search and does not use the '
+                         'propose/score loop. This is an internal wiring error.')

--- a/pybnf/algorithms/optimizers/multiple_shooting.py
+++ b/pybnf/algorithms/optimizers/multiple_shooting.py
@@ -35,9 +35,11 @@ dynamics), multiple shooting refuses three further classes of fit, each because 
 transcription would otherwise change the quantity being fitted rather than the way it is
 searched:
 
-* **a model whose state it cannot carry** -- the state at a knot is the ODE state vector,
-  and only the bngsim SBML/Antimony path reports species columns with initial-condition
-  sensitivities on the same axis (:mod:`pybnf.shooting.bngsim_backend`);
+* **a model whose state this cut's backend cannot surface** -- the state at a knot is the
+  ODE state vector, and of PyBNF's backends only the bngsim SBML/Antimony one puts species
+  columns and initial-condition sensitivities on the same run. A ``.net`` model has the same
+  kind of state and bngsim will return it; PyBNF's net adapter does not ask for it. See
+  :mod:`pybnf.shooting.bngsim_backend` for what closing that would take;
 * **an experiment that is not a plain measured time course** -- a dose-response scan has no
   time axis to cut, and a pre-equilibration protocol's measured phase already begins from a
   carried state that is not the model's own;
@@ -340,15 +342,28 @@ class MultipleShootingAlgorithm(GradientOptimizer):
 
     # --- gates ------------------------------------------------------------- #
     def _require_carryable_state(self, model):
-        """Refuse a model whose state a knot cannot carry."""
+        """Refuse a model whose state this cut's backends cannot surface.
+
+        Not a statement about the model: a ``.net`` file is a reaction network with the same
+        kind of ODE state an SBML model has, and bngsim returns both its species trajectory
+        and its ``d(species)/d(species_0)`` when asked. The gap is in PyBNF's net adapter,
+        which builds its ``Data`` from observables and expressions and requests
+        ``observable:`` / ``expression:`` sensitivity selectors, so a segment simulation
+        would come back carrying neither the state at the knot nor its derivative. The
+        message says which of those it is, because "your model has no state" would send a
+        user looking in the wrong place.
+        """
         if hasattr(model, '_run_simulation') and hasattr(model, 'species_names') \
                 and hasattr(model, '_result_to_data'):
             return
         raise PybnfError(
             "Multiple shooting (job_type = ms) restarts a simulation from the model's own "
-            "state at each knot, and model '%s' uses a backend that does not expose one: "
-            "its trajectory reports observables (sums over species), from which the state "
-            "cannot be recovered." % getattr(model, 'name', '?'),
+            "state at each knot, and PyBNF's backend for model '%s' does not surface that "
+            "state: its trajectory carries observables and expressions rather than species, "
+            "and its forward-sensitivity request names the same selectors, so a segment "
+            "would return neither the state at a knot nor its d(state)/d(state). The model "
+            "itself has a perfectly good state -- this is a limitation of the backend "
+            "adapter, not of the model." % getattr(model, 'name', '?'),
             hint=['Simulate the model through the bngsim SBML/Antimony path (an SBML model '
                   'needs \'sbml_backend = bngsim\'), whose species columns and '
                   'initial-condition sensitivities are what a knot carries.',

--- a/pybnf/parse.py
+++ b/pybnf/parse.py
@@ -54,6 +54,11 @@ numkeys_int = ['verbosity', 'parallel_count', 'delete_old_files', 'population_si
                # cycle budgets (runtime-guarded RUNTIME_KEYS, defaulting to max_iterations).
                'lbfgs_history', 'trf_max_iterations', 'lbfgs_max_iterations',
                'gntr_max_iterations',
+               # multiple shooting (job_type = ms, #563/ADR-0110): the finest rung of the
+               # coarsening ladder and the factor between rungs, the per-outer-iteration
+               # inner-solve cap, and the outer-iteration budget per rung (a runtime-guarded
+               # RUNTIME_KEY, defaulting to max_iterations).
+               'ms_segments', 'ms_coarsening', 'ms_inner_iterations', 'ms_max_iterations',
                # DREAM multi-try count (ADR-0067 Stage 2, #357): candidate proposals
                # per chain per generation (n_try = 1 is the classic single-try engine).
                'n_try',
@@ -90,6 +95,12 @@ numkeys_float = ['min_objective', 'cognitive', 'social', 'particle_weight',
                  'trf_grad_tol', 'trf_step_tol', 'lbfgs_grad_tol', 'lbfgs_step_tol',
                  'lbfgs_c1', 'lbfgs_backtrack',
                  'gntr_grad_tol', 'gntr_step_tol', 'gntr_ridge',
+                 # multiple shooting (job_type = ms, #563/ADR-0110): the augmented-Lagrangian
+                 # penalty schedule (rho_0, gamma, the ceiling), the KKT feasibility +
+                 # optimality tolerances the outer loop stops on, and the half-width in
+                 # decades of an auxiliary segment-start state's box.
+                 'ms_penalty', 'ms_penalty_growth', 'ms_max_penalty',
+                 'ms_feasibility_tol', 'ms_optimality_tol', 'ms_aux_decades',
                  # HMC (job_type = hmc, ADR-0059): NUTS dual-averaging target acceptance.
                  'target_accept',
                  # profile likelihood (job_type = profile_likelihood, #446/#466): confidence

--- a/pybnf/shooting/__init__.py
+++ b/pybnf/shooting/__init__.py
@@ -55,6 +55,7 @@ The fit type that runs all of it is :mod:`pybnf.algorithms.optimizers.multiple_s
 
 from .backend import SegmentBackend, SegmentSimulationFailed, SegmentTrace, trace_from_data
 from .bngsim_backend import BngsimSegmentBackend
+from .net_backend import NetSegmentBackend
 from .driver import coarsening_stages, feasible_ladder, run_multiple_shooting
 from .grid import SegmentGrid
 from .problem import (
@@ -73,6 +74,7 @@ __all__ = [
     'BngsimSegmentBackend',
     'GaussNewtonSolver',
     'MultipleShootingProblem',
+    'NetSegmentBackend',
     'SegmentBackend',
     'SegmentGrid',
     'SegmentSimulationFailed',

--- a/pybnf/shooting/__init__.py
+++ b/pybnf/shooting/__init__.py
@@ -1,0 +1,87 @@
+"""Multiple shooting: the first consumer of the constrained-transcription layer (#563).
+
+:mod:`pybnf.transcription` (ADR-0109) is the reusable half -- an augmented variable layout,
+an equality residual/Jacobian interface, and an optimizer-agnostic augmented-Lagrangian outer
+loop with its homotopy and its certification. It makes no simulator call and defines no
+``fit_type``. This package is the other half: what it takes to state *this* fit as that kind
+of problem.
+
+The transcription
+-----------------
+Split each scored experiment's time course at ``m - 1`` knots. Segment ``j`` is integrated
+from its own start state -- segment 0's is the model's own initial conditions, which are
+often fitted parameters, and each interior knot carries an auxiliary state ``z_j`` that is
+searched, bounded and differentiated but is **never** a fit result. Continuity is imposed as
+
+    ``c_j = Phi_j(z_j, theta) - z_{j+1} = 0``
+
+and enforced by the augmented Lagrangian, whose subproblem is solved by ``gntr``'s own
+Gauss-Newton trust-region step machine. Every reported score comes from discarding ``z``,
+re-simulating ``theta`` with ordinary single shooting, and scoring *that* -- so a run that
+leaves continuity unconverged scores as what it actually is.
+
+Why this is worth the machinery
+-------------------------------
+On ``Borghans_BiophysChem1997`` a correctly-shaped oscillator whose period is wrong by more
+than about 3 % scores *worse than fitting no dynamics at all*, so under single shooting the
+flat line is the ceiling on nearly the whole box and fifteen independent global searches
+terminate at it. Over one short segment a period error cannot accumulate: the period
+information moves out of a residual term that saturates and into continuity defects, which
+carry a direction. The #563 prototype solved that problem this way, at ``OG = -1.2827``.
+
+What the prototype's paired sweeps do *not* support, and this package does not claim: that
+multiple shooting improves the typical fit (24-24 over 48 paired starts, medians tied at
+every radius), or that it solves Borghans from an uninformed start (0/24 either way). The
+measured case is the **tail** and the **robustness** -- it reached a basin single shooting
+reached from no start at any radius, and a segment that fails to integrate does not kill the
+whole trajectory.
+
+The pieces
+----------
+* :mod:`~pybnf.shooting.grid` -- knot placement, and the naming that lets a coarser stage
+  recognise a finer one's knots so the ladder *continues* rather than reseeds;
+* :mod:`~pybnf.shooting.backend` -- the one simulator seam (simulate one span from a
+  supplied state, with both sensitivity axes), plus
+  :mod:`~pybnf.shooting.bngsim_backend`, its implementation against bngsim;
+* :mod:`~pybnf.shooting.problem` -- the transcription itself: the ``IC``-routed objective
+  assembly, the continuity block, and the certified reconstruction;
+* :mod:`~pybnf.shooting.solver` -- the Gauss-Newton inner solver, which is ``gntr``'s runner
+  driven synchronously;
+* :mod:`~pybnf.shooting.driver` -- the ladder.
+
+The fit type that runs all of it is :mod:`pybnf.algorithms.optimizers.multiple_shooting`
+(``job_type = ms``).
+"""
+
+from .backend import SegmentBackend, SegmentSimulationFailed, SegmentTrace, trace_from_data
+from .bngsim_backend import BngsimSegmentBackend
+from .driver import coarsening_stages, feasible_ladder, run_multiple_shooting
+from .grid import SegmentGrid
+from .problem import (
+    AUX_DECADES,
+    STATE_FLOOR,
+    MultipleShootingProblem,
+    SegmentedExperiment,
+    ShootingExperiment,
+    seed_stage,
+)
+from .solver import GaussNewtonSolver
+
+__all__ = [
+    'AUX_DECADES',
+    'STATE_FLOOR',
+    'BngsimSegmentBackend',
+    'GaussNewtonSolver',
+    'MultipleShootingProblem',
+    'SegmentBackend',
+    'SegmentGrid',
+    'SegmentSimulationFailed',
+    'SegmentTrace',
+    'SegmentedExperiment',
+    'ShootingExperiment',
+    'coarsening_stages',
+    'feasible_ladder',
+    'run_multiple_shooting',
+    'seed_stage',
+    'trace_from_data',
+]

--- a/pybnf/shooting/backend.py
+++ b/pybnf/shooting/backend.py
@@ -1,0 +1,202 @@
+"""The segment-simulation seam: the one place multiple shooting touches a simulator (#563).
+
+Everything else in :mod:`pybnf.shooting` is arithmetic over what this seam returns -- knot
+placement, the ``IC``-routed objective assembly, the continuity block, the inner solver, the
+homotopy. Narrowing the simulator coupling to a single method is what lets all of that be
+verified offline against a closed-form backend, exactly as
+:mod:`pybnf.transcription` is verified against a closed-form transcription: an offline
+implementation of :class:`SegmentBackend` exercises the same code path bngsim does.
+
+What a segment simulation is
+----------------------------
+One span ``[t_j, t_{j+1}]`` of one experiment, integrated **from a state the transcription
+supplies** rather than from the model's own initial conditions, with output at the
+segment's own data times and at its end knot. Two properties make it different from an
+ordinary PyBNF simulation, and both are why this cannot ride the propose/score loop:
+
+* the initial state is an *argument*, not a property of the parameter set -- segment ``j``'s
+  start is the auxiliary variable ``z_j``, which is never a fit result and never enters a
+  :class:`~pybnf.pset.PSet`; and
+* the run must come back carrying its forward sensitivities on **both** axes. The parameter
+  axis gives ``dPhi/dtheta``; the initial-condition axis gives ``dPhi/dz_j``, which is the
+  block the continuity Jacobian is built from and the reason #563 needed
+  ``sensitivity_ic`` to exist at all.
+
+The prototype's structural finding is what keeps the objective half cheap: a segment-start
+state enters the data fit as an ``IC`` route with chain-rule factor 1, so the *same*
+tensor this seam already returns feeds
+:func:`~pybnf.gradient.assembly.assemble_gradient_and_fisher_hessian` with no new residual
+math. This module therefore returns the tensor as-is, in the native units the assembly
+expects, and does no differentiation of its own.
+
+Segment 0 is not special-cased
+------------------------------
+The first segment starts from the model's own initial conditions -- which are frequently
+*fitted* (``init_Z_state`` and friends), so they are reported free parameters rather than
+auxiliary ones. A caller passes ``initial_state = None`` for it, and the backend simulates
+the model as configured. Everything downstream reads that back as "this segment has no
+auxiliary block", which is the same shape as the ``m = 1`` stage having none at all.
+"""
+
+from abc import ABC, abstractmethod
+
+import numpy as np
+
+from ..printing import PybnfError
+
+
+class SegmentSimulationFailed(Exception):
+    """One segment did not integrate.
+
+    Raised by a backend rather than returned, because a non-integrable segment is a
+    property of the *point*, not of the run: the caller converts it into a non-finite local
+    model, the inner solver's trust region shrinks, and the search backs off -- the same way
+    a failed simulation is handled everywhere else on the gradient path (#492). It is not a
+    fit-ending error, which is exactly the robustness the #563 prototype measured (a segment
+    that fails does not kill the whole trajectory: median ``-166.95`` against single
+    shooting's ``-105.50`` from an uninformed box draw).
+    """
+
+
+class SegmentTrace:
+    """One simulated segment: its scored rows, and its end-knot state with derivatives.
+
+    :param data: The segment's :class:`~pybnf.data.Data` over its own output grid,
+        carrying the :class:`~pybnf.data.OutputSensitivities` payload. This is the object
+        the objective assembly consumes, unchanged.
+    :param end_state: The model state at the segment's **end knot**, in the order of
+        ``state_names``. The left half of the continuity defect
+        ``c_j = Phi_j(z_j, theta) - z_{j+1}``.
+    :param d_end_param: ``d(end state)/d(native parameter)``, shape
+        ``(n_state, len(param_axis))``, or ``None`` when no parameter axis was requested.
+    :param d_end_ic: ``d(end state)/d(initial state)``, shape ``(n_state, len(ic_axis))``,
+        or ``None``. For an interior segment this is the ``dPhi_j/dz_j`` block; for
+        segment 0 it is the derivative with respect to the model's own initials, which is
+        how a *fitted* initial condition reaches the continuity rows.
+    :param param_axis: Native parameter ids labelling ``d_end_param``'s columns.
+    :param ic_axis: Species labelling ``d_end_ic``'s columns.
+    """
+
+    __slots__ = ('data', 'end_state', 'd_end_param', 'd_end_ic', 'param_axis', 'ic_axis')
+
+    def __init__(self, data, end_state, d_end_param=None, d_end_ic=None,
+                 param_axis=(), ic_axis=()):
+        self.data = data
+        self.end_state = np.asarray(end_state, dtype=float).reshape(-1)
+        self.d_end_param = None if d_end_param is None else np.atleast_2d(
+            np.asarray(d_end_param, dtype=float))
+        self.d_end_ic = None if d_end_ic is None else np.atleast_2d(
+            np.asarray(d_end_ic, dtype=float))
+        self.param_axis = tuple(param_axis)
+        self.ic_axis = tuple(ic_axis)
+
+    def is_finite(self):
+        for array in (self.end_state, self.d_end_param, self.d_end_ic):
+            if array is not None and not np.all(np.isfinite(array)):
+                return False
+        return True
+
+    def __repr__(self):
+        return 'SegmentTrace(states=%i, dparam=%s, dic=%s)' % (
+            len(self.end_state),
+            None if self.d_end_param is None else self.d_end_param.shape,
+            None if self.d_end_ic is None else self.d_end_ic.shape)
+
+
+class SegmentBackend(ABC):
+    """What multiple shooting needs from a simulator, and nothing else.
+
+    One instance per scored experiment (one ``(model, condition)`` pair), built once per
+    fit and reused across every evaluation -- the #563 prototype measured that constructing
+    a sensitivity-bearing simulator costs ~17 ms warm against ~50 ms for the integration
+    itself, so at ``m`` segments per evaluation construction would dominate.
+    """
+
+    #: Segment integrations this backend has performed. The cost the #563 acceptance
+    #: benchmark reports and the prototype's paired sweeps measured multiple shooting's
+    #: 2-7x overhead in -- and the number a run reports as its completed simulations, which
+    #: is deliberately *not* the count of augmented-model evaluations: one evaluation is
+    #: ``m`` integrations, so reporting evaluations would understate the cost by the very
+    #: factor the method is being judged on. An implementation increments it per
+    #: :meth:`simulate`.
+    n_simulations = 0
+
+    @property
+    @abstractmethod
+    def state_names(self):
+        """The model state carried across a knot, in a fixed order.
+
+        For an ODE model this is its species. It is the vector an auxiliary block holds,
+        the vector a continuity row is written on, and the axis of ``d_end_ic``.
+        """
+
+    @property
+    @abstractmethod
+    def nominal_state(self):
+        """A representative magnitude for each state, in ``state_names`` order.
+
+        Used for two things a fit cannot do without: the strictly positive
+        :class:`~pybnf.transcription.equality.EqualityModel` scales -- a continuity defect
+        is a difference of states, so a model whose species span six orders of magnitude
+        would otherwise hand the penalty term a condition number for free -- and the floor
+        under an auxiliary variable's box.
+        """
+
+    @abstractmethod
+    def simulate(self, pset, sample_times, initial_state=None):
+        """Integrate one span and return its :class:`~pybnf.data.Data`.
+
+        :param pset: The reported parameter set, exactly as an ordinary evaluation would
+            apply it (conditions, bind-by-id, initial assignments and all).
+        :param sample_times: Strictly increasing output times. ``sample_times[0]`` is
+            where integration starts and ``sample_times[-1]`` is the segment's end knot.
+        :param initial_state: ``{state name: value}`` overriding the model's own initial
+            conditions, or ``None`` for the first segment, which starts from the model as
+            configured.
+
+        Raises :class:`SegmentSimulationFailed` for a point that does not integrate.
+        """
+
+
+def trace_from_data(data, state_names, selector_prefix='species'):
+    """Read a :class:`SegmentTrace` off a simulated :class:`~pybnf.data.Data`.
+
+    The end-knot state is the last row of the state columns, and its derivatives are the
+    last row of the sensitivity tensor -- which is the point of putting the end knot in the
+    segment's own output grid rather than simulating the span twice.
+
+    A ``Data`` with no ``output_sensitivities`` yields a value-only trace, which is what the
+    certification path (an ordinary single-shoot score, no derivatives) and a scalar
+    evaluation need.
+    """
+    state_names = tuple(state_names)
+    missing = [name for name in state_names if name not in data.cols]
+    if missing:
+        raise PybnfError(
+            'A multiple-shooting segment simulation returned no column for state(s) %s. The '
+            'state carried across a knot must be a simulated column of the same experiment.'
+            % ', '.join(sorted(missing)))
+    rows = data.data
+    end_state = np.array([rows[-1, data.cols[name]] for name in state_names], dtype=float)
+
+    sens = data.output_sensitivities
+    if sens is None:
+        return SegmentTrace(data, end_state)
+
+    selectors = ['%s:%s' % (selector_prefix, name) for name in state_names]
+    unknown = [s for s in selectors if s not in sens.selectors]
+    if unknown:
+        raise PybnfError(
+            'A multiple-shooting segment simulation returned no sensitivity column for %s. '
+            'The continuity Jacobian is built from the state at the end knot, so every '
+            'carried state must be a sensitivity selector of the same run.'
+            % ', '.join(sorted(unknown)))
+    d_end_param = None
+    if sens.d_param is not None:
+        d_end_param = np.array([sens.slice_for(s, axis='parameter')[-1] for s in selectors],
+                               dtype=float)
+    d_end_ic = None
+    if sens.d_ic is not None:
+        d_end_ic = np.array([sens.slice_for(s, axis='ic')[-1] for s in selectors], dtype=float)
+    return SegmentTrace(data, end_state, d_end_param=d_end_param, d_end_ic=d_end_ic,
+                        param_axis=tuple(sens.param_names), ic_axis=tuple(sens.ic_species))

--- a/pybnf/shooting/bngsim_backend.py
+++ b/pybnf/shooting/bngsim_backend.py
@@ -8,18 +8,28 @@ convert the result -- so a segment is simulated by exactly the machinery a whole
 is, with two differences: it starts at a knot instead of at ``t = 0``, and its initial state
 is supplied rather than read off the model.
 
-Why this backend, and not the ``.net`` one
--------------------------------------------
+Why the SBML/Antimony path, and what the ``.net`` path would need
+------------------------------------------------------------------
 Multiple shooting is written on the model's **state**: a knot carries the ODE state vector,
 a continuity row is a difference of states, and the continuity Jacobian is
-``d(state)/d(state)``. The bngsim SBML/Antimony path reports its species as the trajectory's
-own columns and its forward-sensitivity selectors are ``species:<name>`` on both axes, so
-the state and its two derivatives come off one run. The ``.net`` path reports
-``observable:<name>`` selectors -- observables are *sums over* species, from which the state
-is not recoverable -- and a reaction network's state is the whole species list, which for a
-rule-based model is not a vector a fit can carry at every knot. That is a real limit, and
-``job_type = ms`` refuses the ``.net`` backend by name rather than failing later at a
-missing selector.
+``d(state)/d(state)``. The bngsim SBML/Antimony path hands all of that over on one run --
+its trajectory's columns *are* the species, and its forward-sensitivity selectors are
+``species:<name>`` on both axes.
+
+A ``.net`` model is a reaction network with exactly the same kind of state, and bngsim
+returns both its species trajectory and its ``d(species)/d(species_0)`` when asked. What is
+missing is on PyBNF's side: the net backend's ``Data`` carries ``time + observables +
+expressions`` (:meth:`~pybnf.bngsim_model.net_model.BngsimModel._build_data`) and its
+sensitivity request names ``observable:`` / ``expression:`` selectors, so neither the state
+at a knot nor its derivative is in what a segment simulation would return. Closing that is
+an adapter change rather than a modelling obstacle -- and it is not free: an experiment
+scores *observables*, so a net segment needs both selector families on one run, and on a
+combinatorially expanded network the auxiliary block is ``(m - 1) x n_species`` wide and the
+initial-condition sensitivity system is ``n_species`` wide, so the transcription's cost
+scales with the expanded species count rather than with the number of fitted parameters.
+
+This cut does not close it. ``job_type = ms`` refuses the net backend up front, naming the
+gap, rather than failing later at a missing selector.
 
 Simulator reuse
 ---------------

--- a/pybnf/shooting/bngsim_backend.py
+++ b/pybnf/shooting/bngsim_backend.py
@@ -1,0 +1,173 @@
+"""The bngsim SBML/Antimony segment backend (#563).
+
+The one place :mod:`pybnf.shooting` touches a simulator. It implements
+:class:`~pybnf.shooting.backend.SegmentBackend` against the same private seams an ordinary
+SBML evaluation uses -- ``_engine_model_for_action`` to build the point's engine model,
+``_run_simulation`` to integrate one span at explicit output times, ``_result_to_data`` to
+convert the result -- so a segment is simulated by exactly the machinery a whole experiment
+is, with two differences: it starts at a knot instead of at ``t = 0``, and its initial state
+is supplied rather than read off the model.
+
+Why this backend, and not the ``.net`` one
+-------------------------------------------
+Multiple shooting is written on the model's **state**: a knot carries the ODE state vector,
+a continuity row is a difference of states, and the continuity Jacobian is
+``d(state)/d(state)``. The bngsim SBML/Antimony path reports its species as the trajectory's
+own columns and its forward-sensitivity selectors are ``species:<name>`` on both axes, so
+the state and its two derivatives come off one run. The ``.net`` path reports
+``observable:<name>`` selectors -- observables are *sums over* species, from which the state
+is not recoverable -- and a reaction network's state is the whole species list, which for a
+rule-based model is not a vector a fit can carry at every knot. That is a real limit, and
+``job_type = ms`` refuses the ``.net`` backend by name rather than failing later at a
+missing selector.
+
+Simulator reuse
+---------------
+The #563 prototype measured that constructing a sensitivity-bearing ``bngsim.Simulator``
+costs ~230 ms cold and ~17 ms warm against ~50 ms for the integration itself, so at ``m``
+segments per evaluation construction would dominate. It also verified the fix: mutating the
+model behind an existing ``Simulator`` and ``save_concentrations()`` + ``reset()``-ing gives
+bit-identical states *and* sensitivities to a freshly built one. This backend therefore
+keeps one engine model and one ``Simulator`` per parameter point and restarts them at each
+knot. The restart is what distinguishes this from the pre-equilibration protocol (ADR-0052),
+which runs a second phase on the same simulator *without* a reset precisely so the state
+carries over.
+"""
+
+import numpy as np
+
+from ..printing import PybnfError
+from .backend import SegmentBackend, SegmentSimulationFailed
+
+
+class BngsimSegmentBackend(SegmentBackend):
+    """One scored ``(model, condition)`` pair's segment simulator.
+
+    :param model: The PyBNF model object, already built and with its sensitivity request
+        applied (``enable_output_sensitivities``). This backend **owns** it: it assigns the
+        parameter set in place rather than deep-copying per evaluation, which is sound
+        because the whole multiple-shooting driver runs single-threaded on the master (a
+        segment is not a :class:`~pybnf.pset.PSet` evaluation and never reaches a worker).
+    :param action: The ``TimeCourse`` action this experiment is measured by.
+    :param mutant: The ``MutationSet`` (condition) it is measured under.
+    :param suffix: The full output suffix, ``action.suffix + mutant.suffix``.
+    :param timeout: Per-segment wall-clock bound, from ``wall_time_sim``. A pathological
+        parameter point can otherwise spend minutes inside CVODE's analytical-Jacobian
+        failure and finite-difference retry, and a multi-start sweep is then dominated by
+        points that were never going to score.
+    """
+
+    def __init__(self, model, action, mutant, suffix, timeout=None, method='ode'):
+        self.model = model
+        self.action = action
+        self.mutant = mutant
+        self.suffix = str(suffix)
+        self.timeout = timeout
+        self.method = str(method)
+        if not hasattr(model, '_run_simulation') or not hasattr(model, '_result_to_data'):
+            raise PybnfError(
+                "Multiple shooting (job_type = ms) simulates one segment at a time from a "
+                "state it supplies, which model '%s' provides no seam for. It needs the "
+                "bngsim SBML/Antimony backend (an SBML model needs 'sbml_backend = bngsim')."
+                % getattr(model, 'name', '?'))
+        self._states = tuple(model.species_names)
+        self._nominal = _nominal_state(model, self._states)
+        self.n_simulations = 0
+        self._point = None          # identity of the PSet the prepared engine holds
+        self._engine = None
+        self._sim = None
+
+    # -- the contract -----------------------------------------------------------
+
+    @property
+    def state_names(self):
+        return self._states
+
+    @property
+    def nominal_state(self):
+        return self._nominal
+
+    def simulate(self, pset, sample_times, initial_state=None):
+        times = [float(t) for t in np.asarray(sample_times, dtype=float).reshape(-1)]
+        if len(times) < 2:
+            raise PybnfError('A multiple-shooting segment needs at least two output times; '
+                             'got %r.' % (times,))
+        engine, sim = self._prepare(pset)
+        if initial_state:
+            for name, value in initial_state.items():
+                if not self.model._set_engine_value_if_present(engine, name, float(value)):
+                    raise PybnfError(
+                        "Multiple shooting tried to restart model '%s' from a state named "
+                        "'%s', which is not one of its species." % (
+                            getattr(self.model, 'name', '?'), name))
+            engine.save_concentrations()
+        engine.reset()
+        self.n_simulations += 1
+        try:
+            result = self.model._run_simulation(
+                engine, times[-1], len(times), method=self.method, timeout=self.timeout,
+                sample_times=times, suffix=self.suffix, sim=sim)
+            data = self.model._result_to_data(result)
+        except Exception as exc:
+            # A non-integrable point is a property of the point, not of the run: hand it
+            # back as a failed segment so the inner solver's trust region shrinks. The
+            # prepared engine is dropped, because whatever state a failed CVODE call left
+            # it in is not one to restart the next segment from.
+            self._point = None
+            raise SegmentSimulationFailed('%s: %s' % (type(exc).__name__, exc)) from exc
+        if not np.all(np.isfinite(np.asarray(data.data, dtype=float))):
+            raise SegmentSimulationFailed('the segment produced a non-finite trajectory')
+        return data
+
+    # -- one engine + one simulator per parameter point --------------------------
+
+    def _prepare(self, pset):
+        """The engine model and ``Simulator`` for ``pset``, built once and reused across
+        that point's segments (see the module docstring on why that matters).
+
+        Keyed on the PSet's *identity*: the caller
+        (:meth:`~pybnf.shooting.problem.MultipleShootingProblem._traces`) builds one PSet per
+        augmented evaluation and simulates every segment from it, so identity is exactly the
+        right granularity and needs no hashing of the parameter vector.
+        """
+        if self._point is pset and self._engine is not None:
+            return self._engine, self._sim
+        self.model.param_set = pset
+        # The per-action sensitivity gate (#475/#482) reads this: without it a scored
+        # experiment's segments would run sensitivity-free and the assembly would find no
+        # tensor to differentiate.
+        self.model._current_action_suffix = self.suffix
+        try:
+            engine = self.model._engine_model_for_action(mut=self.mutant)
+            sim = self.model._make_simulator(engine, self.method)
+        except Exception as exc:
+            self._point = None
+            raise SegmentSimulationFailed(
+                'the model could not be prepared at this point (%s: %s)'
+                % (type(exc).__name__, exc)) from exc
+        self._point, self._engine, self._sim = pset, engine, sim
+        return engine, sim
+
+    def __repr__(self):
+        return 'BngsimSegmentBackend(%r, states=%i)' % (self.suffix, len(self._states))
+
+
+def _nominal_state(model, states):
+    """Each species' declared magnitude, in PyBNF value units.
+
+    Two uses, both needing only a *representative* number: the strictly positive constraint
+    scales, and the centre of each auxiliary variable's box. A species declared at zero --
+    which on a model that grows its products is most of them -- says nothing about its own
+    magnitude, so it inherits the model's scalar one (the median of the positive
+    declarations), which is the same substitution ADR-0105 makes for the per-species absolute
+    tolerance and for the same reason: the alternative is a scale of zero, which the layer
+    refuses outright.
+    """
+    values = getattr(model, '_nominal_species_values', None) or {}
+    factors = getattr(model, '_species_unit_factor', None) or {}
+    declared = np.array([float(values.get(name, 0.0)) / float(factors.get(name, 1.0) or 1.0)
+                         for name in states], dtype=float)
+    declared[~np.isfinite(declared)] = 0.0
+    positive = declared[declared > 0.0]
+    fallback = float(np.median(positive)) if positive.size else 1.0
+    return np.where(declared > 0.0, declared, fallback)

--- a/pybnf/shooting/driver.py
+++ b/pybnf/shooting/driver.py
@@ -1,0 +1,106 @@
+"""Driving the ladder: one fit, transcribed at several segment counts in turn (#563).
+
+The whole of multiple shooting's outer control flow is
+:func:`~pybnf.transcription.homotopy.run_homotopy`; this module supplies the three things it
+needs that are specific to segments -- the ladder of segment counts, a stage *factory* per
+rung, and the defaults ADR-0109's findings fixed.
+
+Why the stages are callables
+----------------------------
+``run_homotopy`` accepts a stage as a :class:`~pybnf.transcription.augmented.TranscriptionProblem`
+or as a ``(reported) -> TranscriptionProblem`` callable, and multiple shooting needs the
+second form: a stage's auxiliary variables are seeded by reading a *nominal trajectory at the
+incoming parameters* at each knot, and the incoming parameters are whatever the previous rung
+finished at. Seeding that way makes each stage feasible at its own iteration zero, so every
+discontinuity a run holds is the optimizer's choice rather than an artifact of how the stage
+was built.
+
+The ladder starts in the middle
+-------------------------------
+``(4, 2, 1)``, from :func:`~pybnf.transcription.homotopy.coarsening_ladder`, and the middle
+is the measured part. Starting at many short segments -- the easiest landscape, and what the
+original formulation proposed -- is the wrong end on the motivating problem: with one
+observed state of three and ~14 points per segment, ``m = 8`` is under-determined, the data
+term is satisfiable without correct dynamics, and the stage routinely certifies *worse than
+its own start*. Over eight paired starts, ``4-2-1`` had the best tail at moderate cost and
+``8-4-2-1`` did not. The ladder always ends at ``m = 1``, which is the ordinary unsegmented
+fit -- so a multiple-shooting run finishes by solving the problem the user actually asked
+about, and its last rung is the one whose objective needs no certification because it *is*
+the certificate.
+"""
+
+import numpy as np
+
+from ..transcription import PenaltySchedule, coarsening_ladder, run_homotopy
+from .problem import AUX_DECADES, seed_stage
+from .solver import GaussNewtonSolver
+
+
+def feasible_ladder(specs, ladder=None):
+    """The requested ladder, clamped to what the data can support.
+
+    A segment count above an experiment's own measurement count places knots between
+    observations everywhere and leaves segments with nothing to fit -- a transcription whose
+    auxiliary states are determined by continuity alone in *every* segment, which is not the
+    method, it is an ODE solver with extra variables. Rungs above that are dropped and the
+    caller is told which (a silent cap would read as "we ran the ladder you asked for").
+
+    Returns ``(rungs, dropped)``.
+    """
+    rungs = tuple(int(m) for m in (coarsening_ladder() if ladder is None else ladder))
+    limit = min((len(np.unique(spec.times)) for spec in specs), default=1)
+    kept = tuple(m for m in rungs if m <= max(1, limit))
+    dropped = tuple(m for m in rungs if m not in kept)
+    if 1 not in kept:
+        # The ladder must end at the unsegmented problem: that rung is what makes the run's
+        # answer an ordinary fit result rather than a segmented score.
+        kept = kept + (1,)
+    return kept, dropped
+
+
+def coarsening_stages(specs, rungs, objective, variables, pset_from_u,
+                      aux_decades=AUX_DECADES):
+    """One stage factory per rung, in the order ``run_homotopy`` will run them."""
+    def factory(n_segments):
+        def build(reported):
+            return seed_stage(specs, n_segments, objective, variables, pset_from_u, reported,
+                              aux_decades=aux_decades)
+        return build
+    return [factory(m) for m in rungs]
+
+
+def run_multiple_shooting(specs, objective, variables, pset_from_u, reported_start,
+                          ladder=None, schedule=None, inner_solver=None, max_outer=25,
+                          aux_decades=AUX_DECADES, stop_check=None, on_iterate=None,
+                          on_stage=None):
+    """Solve one fit by multiple shooting, down the coarsening ladder.
+
+    :param specs: The :class:`~pybnf.shooting.problem.ShootingExperiment`\\ s -- one per
+        scored ``(model, condition)`` pair, built once for the whole fit.
+    :param objective: The fit's own objective function.
+    :param variables: Its reported free parameters, in ``Configuration.variables`` order.
+    :param pset_from_u: The algorithm's sampling-space to :class:`~pybnf.pset.PSet` bridge.
+    :param reported_start: The fit's start point in sampling space.
+    :param ladder: Segment counts, finest first. Defaults to ``(4, 2, 1)``.
+    :param schedule: The :class:`~pybnf.transcription.outer.PenaltySchedule`. Its defaults
+        carry ADR-0109 finding 5.1 -- the penalty starts **tight** (``rho_0 = 10``,
+        ``gamma = 5``), because on the motivating problem a loose start was both worse and
+        twice as expensive: the inner solve on a nearly-unconstrained subproblem never
+        converges and burns its whole budget every outer iteration.
+    :param inner_solver: Defaults to a :class:`~pybnf.shooting.solver.GaussNewtonSolver`.
+    :param stop_check: The wall-clock-budget seam, passed to the outer loop *and* to the
+        default inner solver, so a deadline lands inside a long inner solve rather than
+        after it.
+
+    Returns the :class:`~pybnf.transcription.homotopy.HomotopyResult`, whose ``best`` is the
+    best **certified** iterate over the whole ladder -- not its last, which on one prototype
+    start held ``-147.0`` while an earlier iterate certified at ``-196.3``.
+    """
+    rungs, _dropped = feasible_ladder(specs, ladder)
+    if inner_solver is None:
+        inner_solver = GaussNewtonSolver(stop_check=stop_check)
+    stages = coarsening_stages(specs, rungs, objective, variables, pset_from_u,
+                               aux_decades=aux_decades)
+    return run_homotopy(stages, inner_solver, reported_start,
+                        schedule=schedule or PenaltySchedule(), max_outer=max_outer,
+                        stop_check=stop_check, on_iterate=on_iterate, on_stage=on_stage)

--- a/pybnf/shooting/grid.py
+++ b/pybnf/shooting/grid.py
@@ -1,0 +1,183 @@
+"""Knot placement: where a time course is cut, and which data point lands in which piece (#563).
+
+Multiple shooting's first decision is where to break the horizon. :class:`SegmentGrid` owns
+that decision and nothing else -- no simulator, no objective, no optimizer -- so the two
+things that are easy to get subtly wrong are testable in isolation: which segment a data
+point belongs to, and whether a coarser grid's knots are recognisably *the same knots* as a
+finer grid's.
+
+Equal time, because the alternative needs information a fit does not have
+--------------------------------------------------------------------------
+The #563 prototype cut ``[0, T]`` into ``m`` equal spans and solved the motivating problem
+that way, so that is what ships. The obvious refinements -- knots at the data's own
+quantiles, or at the features of a nominal trajectory (a burst, a peak) -- are *start-point
+dependent*: they place the transcription's structure using a trajectory the fit has not
+established yet, and on the motivating problem the nominal trajectory is exactly what is in
+question (an oscillator whose period is wrong everywhere except a 3 % window). Equal spans
+place the knots using only the experiment's own time axis, which is a fact rather than a
+guess. ``knot_times`` is a plain attribute, so a future consumer can hand in its own.
+
+Names, because the homotopy transfers by name
+---------------------------------------------
+:meth:`~pybnf.transcription.layout.AugmentedLayout.carry_over` moves an auxiliary block from
+one stage to the next iff the next stage declares a block of the same **name and size** --
+the layer never learns what a knot is, which is what keeps the rule generic. So the naming
+here is load-bearing: a knot must get the same name at every segment count that has it, or
+the ``4 -> 2 -> 1`` ladder reseeds instead of continuing and the coarsening (the mechanism,
+ADR-0109 finding 5.2) buys nothing.
+
+Naming a knot by its **exact fraction of the horizon** does that. At ``m = 4`` the knots are
+``1/4, 1/2, 3/4``; at ``m = 2``, ``1/2`` -- and ``Fraction(2, 4) == Fraction(1, 2)``, so the
+surviving knot carries its solved state down the ladder while ``1/4`` and ``3/4`` are
+discarded, which is what coarsening *is*. Exact rational arithmetic rather than a rounded
+float, so ``1/3`` and ``0.333333`` can never be two names for one knot (or one name for two).
+
+Which segment owns a data point
+-------------------------------
+Half-open ``[start_j, start_{j+1})``, with the final segment owning the horizon endpoint --
+the same convention ``tests/test_transcription.py::ShootingProblem`` pins offline. A point
+lying exactly on a knot is therefore read at ``dt = 0`` from that knot's own auxiliary state,
+so its prediction is the auxiliary variable itself: the one row where the data sees a
+segment-start state directly rather than through an integration. The alternative (a knot
+point belonging to the segment that ends there) reads it through the *previous* segment's
+whole span, which is the same number only when continuity has already converged.
+"""
+
+from fractions import Fraction
+
+import numpy as np
+
+from ..printing import PybnfError
+
+#: Separator between an experiment's label and a knot's fraction in a block name
+#: (``'exp1@1/2'``). A block name may not contain the layout's ``'::'`` qualifier, and this
+#: one does not.
+KNOT = '@'
+
+
+class SegmentGrid:
+    """The knots of one experiment's time course at one segment count.
+
+    :param times: The experiment's measurement times, in the independent variable's units.
+        Need not be sorted; duplicates are allowed (repeat measurements at one time).
+    :param n_segments: ``m``, the number of segments. ``m = 1`` is the ordinary
+        unsegmented problem: no knots, no auxiliary variables, no continuity constraints.
+    :param label: The experiment's label, used to build block names. Two experiments in one
+        fit get different labels so their knots never collide in one layout.
+    :param start: The horizon's start. Defaults to ``min(times)``, but a time course whose
+        first measurement is after the model's ``t = 0`` still integrates from ``0``, so a
+        caller that knows the simulation's own start passes it.
+    :param horizon: The horizon's end. Defaults to ``max(times)``.
+    """
+
+    def __init__(self, times, n_segments, label='exp', start=None, horizon=None):
+        self.times = np.asarray(times, dtype=float).reshape(-1)
+        if self.times.size == 0:
+            raise PybnfError('A multiple-shooting segment grid needs at least one '
+                             'measurement time.')
+        self.n_segments = int(n_segments)
+        if self.n_segments < 1:
+            raise PybnfError('A multiple-shooting segment count must be at least 1; got %r.'
+                             % n_segments)
+        self.label = str(label)
+        if KNOT in self.label:
+            raise PybnfError("A multiple-shooting experiment label may not contain %r, the "
+                             "knot-name separator; got %r." % (KNOT, self.label))
+        self.start = float(np.min(self.times) if start is None else start)
+        self.horizon = float(np.max(self.times) if horizon is None else horizon)
+        if not self.horizon > self.start:
+            raise PybnfError(
+                'A multiple-shooting segment grid needs a positive horizon; experiment %r '
+                'spans [%g, %g].' % (self.label, self.start, self.horizon))
+        if np.any(self.times < self.start) or np.any(self.times > self.horizon):
+            raise PybnfError(
+                'Experiment %r has measurement times outside its own [%g, %g] horizon.'
+                % (self.label, self.start, self.horizon))
+
+        span = self.horizon - self.start
+        #: Each interior knot's exact fraction of the horizon -- the identity
+        #: :meth:`~pybnf.transcription.layout.AugmentedLayout.carry_over` matches on.
+        self.fractions = tuple(Fraction(i, self.n_segments)
+                               for i in range(1, self.n_segments))
+        #: Interior knot times (``m - 1`` of them; empty at ``m = 1``).
+        self.knot_times = tuple(self.start + float(f) * span for f in self.fractions)
+        #: Each segment's start time: the horizon's start, then every interior knot.
+        self.starts = (self.start,) + self.knot_times
+        #: Each segment's end time.
+        self.ends = self.knot_times + (self.horizon,)
+        #: Which segment each entry of :attr:`times` belongs to.
+        self.segment_of = np.clip(
+            np.searchsorted(np.asarray(self.starts, dtype=float), self.times, side='right') - 1,
+            0, self.n_segments - 1)
+
+    # -- identity ---------------------------------------------------------------
+
+    @property
+    def block_names(self):
+        """One auxiliary-block name per interior knot, in segment order.
+
+        ``'<label>@<fraction>'`` -- ``('exp1@1/4', 'exp1@1/2', 'exp1@3/4')`` at ``m = 4``.
+        The ``m = 2`` grid of the same experiment declares ``('exp1@1/2',)``, which is a
+        subset **by name**, so the ladder carries that knot's solved state over.
+        """
+        return tuple('%s%s%s' % (self.label, KNOT, f) for f in self.fractions)
+
+    @property
+    def n_knots(self):
+        return len(self.fractions)
+
+    # -- per-segment views ------------------------------------------------------
+
+    def rows_in(self, segment):
+        """Indices into :attr:`times` of the data points segment ``segment`` owns."""
+        return np.flatnonzero(self.segment_of == int(segment))
+
+    def sample_times(self, segment):
+        """``(output times, data row indices)`` for one segment.
+
+        The output grid is this segment's start knot, its own data times, and its end knot,
+        de-duplicated and sorted. The start knot is present because integration begins
+        there; the end knot because the continuity defect is read off the **same** run that
+        produced the data rows, rather than from a second simulation of the same span.
+        """
+        rows = self.rows_in(segment)
+        pts = np.unique(np.concatenate(
+            ([self.starts[segment]], self.times[rows], [self.ends[segment]])))
+        return pts, rows
+
+    def row_positions(self, segment):
+        """Where each of segment ``segment``'s data points lands in its output grid.
+
+        Returned alongside the row indices as ``(output rows, data row indices)`` so a
+        caller reads the simulated trajectory at exactly the measured times without
+        re-searching the grid per point.
+        """
+        pts, rows = self.sample_times(segment)
+        return np.searchsorted(pts, self.times[rows]), rows
+
+    def seed_times(self):
+        """One output grid covering the whole horizon: every knot and every data time.
+
+        What a stage's auxiliary variables are seeded from -- one ordinary single-shoot
+        simulation whose state is read off at each knot. Seeding this way makes the
+        transcription **feasible at iteration zero**, so every discontinuity the run
+        subsequently holds is the optimizer's own choice rather than an artifact of the
+        start (the prototype's ``seed_aux``).
+        """
+        return np.unique(np.concatenate(
+            ([self.start], self.times, np.asarray(self.knot_times, dtype=float),
+             [self.horizon])))
+
+    def describe(self):
+        """One line for the run log."""
+        if self.n_segments == 1:
+            return ('%s: 1 segment over [%g, %g] (the ordinary unsegmented problem)'
+                    % (self.label, self.start, self.horizon))
+        counts = [len(self.rows_in(j)) for j in range(self.n_segments)]
+        return ('%s: %i segments over [%g, %g], knots at %s, %s data point(s) per segment'
+                % (self.label, self.n_segments, self.start, self.horizon,
+                   ', '.join('%g' % t for t in self.knot_times),
+                   '/'.join(str(c) for c in counts)))
+
+    def __repr__(self):
+        return 'SegmentGrid(%r, m=%i, knots=%i)' % (self.label, self.n_segments, self.n_knots)

--- a/pybnf/shooting/net_backend.py
+++ b/pybnf/shooting/net_backend.py
@@ -1,0 +1,278 @@
+"""The bngsim ``.net`` segment backend -- multiple shooting on a reaction network (#577).
+
+The SBML/Antimony backend (:mod:`pybnf.shooting.bngsim_backend`) got the state for free: that
+path reports its species *as* the trajectory's columns and labels its forward-sensitivity
+selectors ``species:<name>`` on both axes, so one run hands over everything a knot needs. The
+``.net`` path does not, and for a while ``job_type = ms`` refused it on that basis -- wrongly
+framed as a property of the model. It is not one. A ``.net`` file is a fully expanded reaction
+network with exactly the same kind of ODE state, and bngsim returns both its species
+trajectory and its ``d(species)/d(species_0)`` when asked. What was missing was that nobody
+asked: :meth:`~pybnf.bngsim_model.net_model.BngsimModel._build_data` assembles
+``time + observables + expressions``, and the net backend's sensitivity request names
+``observable:`` / ``expression:`` selectors.
+
+This module asks. It is the one place in :mod:`pybnf.shooting` that needs *both* selector
+families on one run, and that is the whole of what makes it different from its SBML peer:
+
+* **an experiment scores observables, a continuity row is a difference of species.** On the
+  SBML path those are the same columns; here they are not. ``OutputSensitivities.selectors``
+  is a plain list, so one tensor carries the observable/expression rows the data terms read
+  and the species rows the continuity block reads -- requested together, off one integration,
+  because asking twice would mean integrating twice.
+* **the segment's ``Data`` carries both too**, the ordinary observable/expression columns the
+  objective scores plus the species columns
+  :func:`~pybnf.shooting.backend.trace_from_data` reads the end-knot state from. Species
+  names carry parentheses (``A(b!1).B(a!1)``) and observables do not, so a collision is
+  vanishingly unlikely -- and is refused rather than silently overwritten, because a species
+  column quietly shadowing an observable would change what the fit scores.
+
+Nothing in the net backend is modified: this composes its existing pieces (``_build_data``,
+the engine clone, the mutant copy, the species-initializer sync) from outside, so every
+ordinary ``.net`` fit is untouched.
+
+The cost, which is real and is the model's, not the method's
+-------------------------------------------------------------
+The auxiliary block is ``(m - 1) x n_species`` wide and the initial-condition sensitivity
+system is ``n_species`` wide, so the transcription scales with the **expanded** species count
+rather than with the number of fitted parameters. On a small network that is nothing; on a
+combinatorially expanded one it is the dominant term -- ``egfr_ground.net`` (356 species) at
+``m = 4`` adds ~1068 auxiliary variables. That is a property of writing multiple shooting on
+the state of a rule-based model, not something this backend can arrange away, so
+``job_type = ms`` reports the added width when it starts rather than letting a user discover
+it from the run time.
+"""
+
+import numpy as np
+
+from ..data import Data, OutputSensitivities
+from ..printing import PybnfError
+from .backend import SegmentBackend, SegmentSimulationFailed
+
+
+class NetSegmentBackend(SegmentBackend):
+    """One scored ``(model, condition)`` pair's segment simulator, on the ``.net`` path.
+
+    :param model: The :class:`~pybnf.bngsim_model.net_model.BngsimModel`. This backend
+        **owns** it, assigning the parameter set in place rather than deep-copying per
+        evaluation -- sound because the whole multiple-shooting driver runs single-threaded
+        on the master (a segment is not a :class:`~pybnf.pset.PSet` evaluation and never
+        reaches a worker).
+    :param sim_params: The parsed ``simulate()`` action this experiment is measured by, as
+        :func:`~pybnf.bngsim_model.parsing._parse_simulate_action` returns it.
+    :param mutant: The ``MutationSet`` (condition) it is measured under.
+    :param suffix: The full output suffix, ``action suffix + mutant suffix``.
+    :param timeout: Per-segment wall-clock bound, from ``wall_time_sim``.
+    """
+
+    def __init__(self, model, sim_params, mutant, suffix, timeout=None):
+        self.model = model
+        self.sim_params = dict(sim_params or {})
+        self.mutant = mutant
+        self.suffix = str(suffix)
+        self.timeout = timeout
+        self.print_functions = _flag(self.sim_params.get('print_functions', 0))
+        self._states = tuple(model._engine_model.species_names)
+        self._nominal = self._declared_state()
+        self.n_simulations = 0
+        self._point = None          # identity of the PSet the prepared engine holds
+        self._prepared = None       # the per-point model copy (base or mutant)
+        self._engine = None
+        self._sim = None
+
+    # -- the contract -----------------------------------------------------------
+
+    @property
+    def state_names(self):
+        return self._states
+
+    @property
+    def nominal_state(self):
+        return self._nominal
+
+    def simulate(self, pset, sample_times, initial_state=None):
+        times = [float(t) for t in np.asarray(sample_times, dtype=float).reshape(-1)]
+        if len(times) < 2:
+            raise PybnfError('A multiple-shooting segment needs at least two output times; '
+                             'got %r.' % (times,))
+        prepared, engine, sim = self._prepare(pset)
+        if initial_state:
+            for name, value in initial_state.items():
+                if name not in self._state_set:
+                    raise PybnfError(
+                        "Multiple shooting tried to restart model '%s' from a state named "
+                        "'%s', which is not one of its species."
+                        % (getattr(self.model, 'name', '?'), name))
+                engine.set_concentration(name, float(value))
+            engine.save_concentrations()
+        engine.reset()
+        self.n_simulations += 1
+        try:
+            result = sim.run(t_span=(times[0], times[-1]), n_points=len(times),
+                             sample_times=times, **self._run_kwargs())
+            data = self._data_with_state(prepared, result)
+        except Exception as exc:
+            # A non-integrable point is a property of the point, not of the run. The
+            # prepared engine is dropped: whatever state a failed solve left it in is not
+            # one to restart the next segment from.
+            self._point = None
+            raise SegmentSimulationFailed('%s: %s' % (type(exc).__name__, exc)) from exc
+        if not np.all(np.isfinite(np.asarray(data.data, dtype=float))):
+            raise SegmentSimulationFailed('the segment produced a non-finite trajectory')
+        return data
+
+    # -- one engine + one simulator per parameter point --------------------------
+
+    @property
+    def _state_set(self):
+        return set(self._states)
+
+    def _prepare(self, pset):
+        """The per-point model copy, engine model and ``Simulator``, built once and reused
+        across that point's segments.
+
+        Mirrors ``BngsimModel.execute``'s preamble -- apply the parameter set, re-derive the
+        species initial concentrations from it (a free parameter that only seeds an IC is a
+        silent no-op without that sync), reset -- on a *clone*, via the same
+        ``_get_mutant_model_bngsim`` copy the ordinary mutant path uses. The wildtype's empty
+        ``MutationSet`` goes through it too, so there is one code path rather than a special
+        case that could drift from it.
+        """
+        if self._point is pset and self._engine is not None:
+            return self._prepared, self._engine, self._sim
+        self.model.param_set = pset
+        # The per-action sensitivity gate (#475) reads this: without it a scored
+        # experiment's segments would run sensitivity-free and the assembly would find no
+        # tensor to differentiate.
+        self.model._current_action_suffix = self.sim_params.get('suffix', 'time_course')
+        try:
+            prepared = self.model._get_mutant_model_bngsim(self.mutant)
+            engine = prepared._engine_model
+            for name in (prepared.param_set or {}).keys():
+                try:
+                    engine.set_param(name, prepared.param_set[name])
+                except Exception:
+                    # A free parameter of another model in a multi-model fit; the ordinary
+                    # execute path warns and carries on, and so does this one.
+                    pass
+            prepared._sync_species_initial_concentrations(engine)
+            engine.reset()
+            sim = _runtime().bngsim.Simulator(
+                engine, method='ode', **prepared._codegen_kwargs('ode'),
+                **prepared._sensitivity_request_kwargs('ode'))
+        except PybnfError:
+            self._point = None
+            raise
+        except Exception as exc:
+            self._point = None
+            raise SegmentSimulationFailed(
+                'the model could not be prepared at this point (%s: %s)'
+                % (type(exc).__name__, exc)) from exc
+        self._point, self._prepared, self._engine, self._sim = pset, prepared, engine, sim
+        return prepared, engine, sim
+
+    def _run_kwargs(self):
+        """The action's own tolerances and this fit's ``wall_time_sim``, as the ordinary
+        net simulate path passes them."""
+        kwargs = {}
+        for key in ('atol', 'rtol'):
+            if key in self.sim_params:
+                try:
+                    kwargs[key] = float(self.sim_params[key])
+                except (TypeError, ValueError):
+                    pass
+        try:
+            timeout = float(self.timeout)
+        except (TypeError, ValueError):
+            timeout = 0.0
+        if timeout > 0.0:
+            kwargs['timeout'] = timeout
+        return kwargs
+
+    # -- both selector families, off one run -------------------------------------
+
+    def _data_with_state(self, prepared, result):
+        """The ordinary net ``Data`` plus the species columns and their sensitivity rows.
+
+        The value columns are the net backend's own (``_build_data``, unmodified), so what
+        the objective scores is byte-identical to an ordinary fit's; the species columns are
+        appended, and the sensitivity tensor is requested over the union of both selector
+        families.
+        """
+        data = prepared._build_data(result, print_functions=self.print_functions)
+        species = list(result.species_names)
+        clash = sorted(set(species) & set(data.cols))
+        if clash:
+            raise PybnfError(
+                "Multiple shooting adds model '%s'\\'s species columns to each segment's "
+                "trajectory so a knot can carry the state, and species %s already name a "
+                "scored column of that trajectory. One name cannot mean both an observable "
+                "and a species here." % (getattr(self.model, 'name', '?'), ', '.join(clash)))
+        headers = [data.headers[i] for i in sorted(data.headers)] + species
+        out = Data.from_columns(
+            np.column_stack([np.asarray(data.data, dtype=float),
+                             np.asarray(result.species, dtype=float)]), headers)
+        sens = self._union_sensitivities(prepared, result, species)
+        if sens is not None:
+            out.output_sensitivities = sens
+        return out
+
+    def _union_sensitivities(self, prepared, result, species):
+        """One tensor over the observable/expression rows the data terms read **and** the
+        species rows the continuity block reads.
+
+        bngsim answers a mixed selector list from a single run, which is what makes this one
+        integration rather than two. ``None`` on the scalar path, or when the run carried no
+        sensitivities.
+        """
+        if getattr(prepared, '_sensitivity_request', None) is None:
+            return None
+        if not (getattr(result, 'has_sensitivities', False)
+                or getattr(result, 'has_sensitivities_ic', False)):
+            return None
+        selectors = ['observable:%s' % name for name in result.observable_names]
+        if self.print_functions and getattr(result, 'has_sensitivities_expressions', False):
+            selectors += ['expression:%s' % name
+                          for name in prepared._differentiable_expression_names(result)]
+        selectors += ['species:%s' % name for name in species]
+        param_names = list(result.sensitivity_params)
+        ic_species = list(result.sensitivity_ic_species)
+        d_param = (np.asarray(result.output_sensitivities(selectors, axis='parameter'),
+                              dtype=float) if param_names else None)
+        d_ic = (np.asarray(result.output_sensitivities(selectors, axis='ic'), dtype=float)
+                if ic_species else None)
+        return OutputSensitivities(selectors=selectors, param_names=param_names,
+                                   ic_species=ic_species, d_param=d_param, d_ic=d_ic)
+
+    def _declared_state(self):
+        """Each species' declared magnitude, read off a freshly reset engine clone.
+
+        The constraint scales and the centre of each auxiliary variable's box need only a
+        representative number. A species declared at zero -- on a network that grows its
+        products, most of them -- says nothing about its own magnitude, so it inherits the
+        model's scalar one (the median of the positive declarations), the same substitution
+        ADR-0105 makes for the per-species absolute tolerance and for the same reason: the
+        alternative is a scale of zero, which the transcription layer refuses outright.
+        """
+        engine = self.model._engine_model
+        declared = np.array([float(engine.get_concentration(name)) for name in self._states],
+                            dtype=float)
+        declared[~np.isfinite(declared)] = 0.0
+        positive = declared[declared > 0.0]
+        fallback = float(np.median(positive)) if positive.size else 1.0
+        return np.where(declared > 0.0, declared, fallback)
+
+    def __repr__(self):
+        return 'NetSegmentBackend(%r, states=%i)' % (self.suffix, len(self._states))
+
+
+def _runtime():
+    """The net backend's lazily-imported bngsim runtime handle."""
+    from ..bngsim_model import _runtime as rt
+    return rt
+
+
+def _flag(value):
+    try:
+        return bool(int(float(str(value))))
+    except (TypeError, ValueError):
+        return False

--- a/pybnf/shooting/problem.py
+++ b/pybnf/shooting/problem.py
@@ -1,0 +1,647 @@
+"""The multiple-shooting transcription: #563's first consumer of ADR-0109's layer.
+
+:class:`MultipleShootingProblem` implements the two abstract methods
+:class:`~pybnf.transcription.augmented.TranscriptionProblem` declares, plus ``certify``,
+and gets the augmented-Lagrangian outer loop, the penalty schedule, the homotopy, the
+best-iterate certification, and the reporting for free. Everything specific to multiple
+shooting is here:
+
+* which data point belongs to which segment (:mod:`pybnf.shooting.grid`);
+* how a segment is simulated from a state the transcription supplies
+  (:mod:`pybnf.shooting.backend`);
+* how the fit's own objective is assembled over the *pieces*; and
+* the continuity constraints ``c_j = Phi_j(z_j, theta) - z_{j+1}`` and their Jacobian.
+
+The objective half needs no new residual math
+----------------------------------------------
+This is the structural finding the #563 prototype established, and it is what keeps this
+module small. A segment-start state enters the data fit as an ``IC`` route with chain-rule
+factor **1** -- ``sensitivity_ic`` is ``dy(t)/dy0``, and the transcription sets ``y0``
+directly -- so an auxiliary variable is, to
+:func:`~pybnf.gradient.assembly.assemble_gradient_and_fisher_hessian`, an ordinary free
+parameter with an ordinary route. Each segment is presented to the assembly as its own
+*experiment*: its own simulated ``Data``, its own slice of the observations, and its own
+:class:`~pybnf.gradient.routing.ExperimentRouting`. The assembly already sums across
+experiments, so the segmented data fit is the unsegmented one rearranged, and its gradient
+and Fisher block come out over the augmented column list in one pass.
+
+Two things that rearrangement has to get right, and both are structural rather than
+cosmetic:
+
+**Segment ``j > 0`` does not read the model's own initial conditions.** They were
+overridden by ``z_j``. A reported free parameter that is a fitted initial condition
+therefore has *no* effect on that segment, and its ``IC`` contribution is dropped from that
+segment's routing. Keeping it would credit ``init_Z_state`` with a derivative it does not
+have on ``m - 1`` of the ``m`` segments -- a wrong column the fit cannot detect from its own
+objective. Segment 0 keeps it, which is exactly how a fitted initial condition reaches the
+first continuity row.
+
+**A quantity profiled or normalised across a whole series cannot be cut.** An analytic
+per-series scale (ADR-0066) and a ``Data``-level normalization (ADR-0053/0102) are functions
+of the series they are computed over, so splitting the series changes them; a
+cumulative-to-incident transform (ADR-0051) is a difference between neighbouring rows, and
+the row before a knot is in another piece. Those are refused by the ``ms`` fit type's gates
+rather than silently rearranged. An analytically profiled **noise scale** (ADR-0108) is the
+opposite case and needs no gate: it is profiled over the pooled residuals of every supplied
+experiment, so cutting one series into ``m`` pieces pools exactly the same residuals and
+gives exactly the same ``sigma_hat``.
+
+The constraint terms never enter ``f``
+---------------------------------------
+:attr:`~pybnf.transcription.augmented.AugmentedModel.objective_value` is the fit's own
+objective, scored by the fit's own objective function on the segmented trajectory. The
+penalty lives strictly outside it (ADR-0109), which is what keeps an estimated noise scale
+from absorbing continuity violation as measurement noise -- and 13 of the 23 slugs in the
+motivating benchmark corpus estimate at least one.
+"""
+
+import numpy as np
+
+from ..data import Data
+from ..gradient import IC, NONE, PARAM, ExperimentRouting, ParamRoute
+from ..gradient.assembly import assemble_gradient_and_fisher_hessian
+from ..printing import PybnfError
+from ..pset import FreeParameter
+from ..transcription import (
+    AugmentedLayout,
+    BlockJacobian,
+    Certificate,
+    EqualityModel,
+    EqualitySystem,
+    JacobianBlock,
+    ObjectiveModel,
+    TranscriptionProblem,
+    VariableBlock,
+)
+from .backend import SegmentSimulationFailed, trace_from_data
+from .grid import SegmentGrid
+
+#: Floor under a state magnitude, so a species that is identically zero over the whole
+#: horizon still gets a strictly positive constraint scale and a finite auxiliary box. The
+#: layer requires strictly positive scales precisely so this decision is made once, here,
+#: rather than being discovered as a divide-by-zero inside the penalty term.
+STATE_FLOOR = 1e-12
+
+#: Half-width, in decades, of an auxiliary state's box around its own magnitude. Wide
+#: enough that the box is not a constraint on the search (the #563 prototype used a fixed
+#: ``1e-6 .. 1e3`` window and never reported a knot pinned at a bound), finite because the
+#: inner optimizers this layer feeds are bound-constrained and a segment-start
+#: concentration that is allowed to go negative is not a state the simulator can restart
+#: from.
+AUX_DECADES = 6.0
+
+
+class ShootingExperiment:
+    """One scored ``(model, condition)`` pair, at the fit level: everything about it that
+    does **not** depend on the segment count.
+
+    Built once per fit and shared by every rung of the ladder, which is what makes a stage
+    cheap to construct: a homotopy builds one :class:`SegmentedExperiment` per rung around
+    the same backend, observations, and routing.
+
+    :param key: ``(model name, suffix)`` -- the identity this experiment has in the
+        simulated/experimental data dictionaries the objective consumes.
+    :param backend: Its :class:`~pybnf.shooting.backend.SegmentBackend`.
+    :param exp_data: Its observations, as an ordinary PyBNF :class:`~pybnf.data.Data`.
+    :param routing: The experiment's prebuilt
+        :class:`~pybnf.gradient.routing.ExperimentRouting` over the **reported** free
+        parameters, exactly as the gradient optimizers build it once per fit.
+    :param times: Its measurement times. Defaults to ``exp_data``'s independent-variable
+        column.
+    :param label: The label its knots are named under. Defaults to the suffix.
+    :param start: Where the simulation starts. Defaults to the first measurement time; a
+        time course whose first measurement is after ``t = 0`` should pass ``0.0``.
+    """
+
+    def __init__(self, key, backend, exp_data, routing, times=None, label=None, start=None,
+                 horizon=None):
+        self.key = (str(key[0]), str(key[1]))
+        self.backend = backend
+        self.exp_data = exp_data
+        self.routing = routing
+        if times is None:
+            times = np.asarray(exp_data.data, dtype=float)[:, exp_data.cols[exp_data.indvar]]
+        self.times = np.asarray(times, dtype=float).reshape(-1)
+        self.label = str(label if label is not None else self.key[1])
+        self.start = start
+        self.horizon = horizon
+
+    def grid(self, n_segments):
+        """This experiment's knots at one segment count."""
+        return SegmentGrid(self.times, n_segments, label=self.label, start=self.start,
+                           horizon=self.horizon)
+
+    @property
+    def state_names(self):
+        return tuple(self.backend.state_names)
+
+
+class SegmentedExperiment:
+    """One :class:`ShootingExperiment` cut at the knots of one stage."""
+
+    def __init__(self, spec, grid):
+        self.spec = spec
+        self.key = spec.key
+        self.backend = spec.backend
+        self.exp_data = spec.exp_data
+        self.routing = spec.routing
+        self.grid = grid
+        #: The ``m = 1`` grid of the same experiment -- what :meth:`certify` simulates.
+        #: Not a special case: the unsegmented problem is the one-segment transcription.
+        self.certification_grid = spec.grid(1)
+        self._subsets = {}
+
+    @property
+    def state_names(self):
+        return tuple(self.backend.state_names)
+
+    def segment_key(self, segment):
+        """The dictionary key one segment is scored under.
+
+        A synthetic suffix, distinct per segment, because the objective scores a
+        ``{model: {suffix: Data}}`` mapping and the ``m`` pieces of one experiment must be
+        ``m`` entries rather than one that overwrites the others.
+        """
+        return '%s#seg%i' % (self.key[1], segment)
+
+    def segment_exp_data(self, segment):
+        """This experiment's observations restricted to one segment's rows.
+
+        Cached: the slice depends only on the grid, never on the fit point, so it is built
+        once per stage rather than once per evaluation.
+        """
+        segment = int(segment)
+        if segment not in self._subsets:
+            self._subsets[segment] = _subset_rows(self.exp_data, self.grid.rows_in(segment))
+        return self._subsets[segment]
+
+    def has_data(self, segment):
+        return len(self.grid.rows_in(segment)) > 0
+
+
+class MultipleShootingProblem(TranscriptionProblem, EqualitySystem):
+    """One rung of the segment ladder: the fit, transcribed at a fixed segment count.
+
+    :param experiments: The :class:`SegmentedExperiment`\\ s, all at the same segment
+        count.
+    :param objective: The fit's own objective function.
+    :param variables: The fit's reported free parameters, in ``Configuration.variables``
+        order -- the same order every existing PyBNF seam uses.
+    :param pset_from_u: ``(u_reported) -> PSet``: the algorithm's own sampling-space to
+        parameter-set bridge (:meth:`~pybnf.algorithms.base.Algorithm._pset_from_u`), so
+        this module never re-derives the ``theta <-> u`` transform.
+    :param blocks: The auxiliary :class:`~pybnf.transcription.layout.VariableBlock`\\ s,
+        one per knot of every experiment, already seeded (see :func:`seed_stage`).
+    :param scales: ``{experiment key: per-state constraint scale}`` -- the magnitude each
+        continuity defect is measured against.
+    :param name: The stage label for the trace (``'m=4'``).
+    """
+
+    def __init__(self, experiments, objective, variables, pset_from_u, blocks, scales,
+                 name=None):
+        self.experiments = list(experiments)
+        self.objective = objective
+        self.variables = list(variables)
+        self._pset_from_u = pset_from_u
+        self._scales = dict(scales)
+        self._name = name or ('m=%i' % (self.experiments[0].grid.n_segments
+                                        if self.experiments else 1))
+
+        lower = np.array([v.to_sampling_space(v.lower_bound) if v.bounded else -np.inf
+                          for v in self.variables], dtype=float)
+        upper = np.array([v.to_sampling_space(v.upper_bound) if v.bounded else np.inf
+                          for v in self.variables], dtype=float)
+        self._layout = AugmentedLayout([v.name for v in self.variables], lower, upper, blocks)
+
+        # Constraint identity, fixed for the stage: n_state rows per knot, in the layout's
+        # own block order, so a Jacobian block's row range is a plain slice.
+        names, rows_of = [], {}
+        for experiment in self.experiments:
+            for block_name in experiment.grid.block_names:
+                rows_of[block_name] = slice(len(names), len(names) + len(experiment.state_names))
+                names.extend('%s::%s' % (block_name, state)
+                             for state in experiment.state_names)
+        self._constraint_names = tuple(names)
+        self._constraint_rows = rows_of
+        self._constraint_scales = np.array(
+            [self._scales[experiment.key][i]
+             for experiment in self.experiments
+             for _block in experiment.grid.block_names
+             for i in range(len(experiment.state_names))], dtype=float)
+
+        self._cache_key = None
+        self._cache = None
+        self.n_certifications = 0
+
+    # -- identity ---------------------------------------------------------------
+
+    @property
+    def layout(self):
+        return self._layout
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def constraint_names(self):
+        return self._constraint_names
+
+    def describe(self):
+        """The stage in one line: what it added, and where."""
+        return '%s -- %s; %s' % (self._name, self._layout.describe(),
+                                 '; '.join(e.grid.describe() for e in self.experiments))
+
+    # -- the segment pass -------------------------------------------------------
+
+    def _knot_state(self, u, experiment, segment):
+        """Segment ``segment``'s start state as ``{state name: value}``, or ``None`` for
+        segment 0 (which starts from the model's own initial conditions)."""
+        if segment == 0:
+            return None
+        block = experiment.grid.block_names[segment - 1]
+        values = 10.0 ** self._layout.internal_of(u, block)
+        return dict(zip(experiment.state_names, values))
+
+    def _traces(self, u):
+        """Every segment of every experiment, simulated once at ``u``.
+
+        Cached on the point, because the outer loop asks for the objective and the
+        constraints at the *same* point (``AugmentedSubproblem.at`` linearises both
+        together) and a segment simulation is the expensive thing here. ``None`` when any
+        segment failed to integrate: the caller turns that into a non-finite local model,
+        which is the signal the inner solver's trust region backs off on.
+        """
+        u = np.asarray(u, dtype=float).reshape(-1)
+        key = u.tobytes()
+        if self._cache_key == key:
+            return self._cache
+        pset = self._pset_from_u(self._layout.reported_of(u))
+        traces = []
+        ok = True
+        for experiment in self.experiments:
+            per_segment = []
+            for segment in range(experiment.grid.n_segments):
+                times, _rows = experiment.grid.sample_times(segment)
+                try:
+                    data = experiment.backend.simulate(
+                        pset, times, self._knot_state(u, experiment, segment))
+                    trace = trace_from_data(data, experiment.state_names)
+                except SegmentSimulationFailed:
+                    trace, ok = None, False
+                else:
+                    if not trace.is_finite():
+                        ok = False
+                per_segment.append(trace)
+                if not ok:
+                    # One unusable segment makes the whole local model unusable, so the
+                    # rest of this point's segments are work whose answer is already
+                    # decided. Stopping here is what keeps a search that has wandered into
+                    # a non-integrable corner from paying m simulations per rejected trial.
+                    break
+            traces.append(per_segment)
+            if not ok:
+                break
+        self._cache_key = key
+        self._cache = (pset, traces) if ok else None
+        return self._cache
+
+    def _free_params(self, u, pset):
+        """The augmented free-parameter list, in layout order.
+
+        The reported block is read straight off the evaluated PSet -- so every
+        ``d theta/d u`` factor is taken at the point actually simulated, exactly as
+        :meth:`~pybnf.algorithms.optimizers.gradient_base.GradientOptimizer.gradient_at`
+        does -- and each auxiliary coordinate is a ``loguniform_var``
+        :class:`~pybnf.pset.FreeParameter` carrying its own box. Presenting an auxiliary
+        state as a genuine free parameter is what lets the assembly treat it as one: it
+        supplies the ``ln(10) * 10**u`` chain factor from the same
+        :mod:`pybnf.priors.scale` code the reported parameters use, rather than from a
+        second implementation of log10.
+        """
+        params = [pset.get_param(v.name) for v in self.variables]
+        for block in self._layout.blocks:
+            values = self._layout.internal_of(u, block.name)
+            for name, lo, hi, value in zip(block.qualified_names, block.lower, block.upper,
+                                           values):
+                params.append(FreeParameter(name, 'loguniform_var', 10.0 ** lo, 10.0 ** hi,
+                                            value=10.0 ** value))
+        return params
+
+    # -- the objective ----------------------------------------------------------
+
+    def objective_at(self, u):
+        cached = self._traces(u)
+        if cached is None:
+            return self._unusable_objective()
+        pset, traces = cached
+        sim_dict, exp_dict, items = {}, {}, []
+        for experiment, per_segment in zip(self.experiments, traces):
+            model_name = experiment.key[0]
+            for segment, trace in enumerate(per_segment):
+                if not experiment.has_data(segment):
+                    # A segment with no observations contributes no residual; its
+                    # auxiliary state is determined by continuity alone, which is the
+                    # normal case for an unobserved species and the corner the constraint
+                    # scaling exists for.
+                    continue
+                key = experiment.segment_key(segment)
+                sim_dict.setdefault(model_name, {})[key] = trace.data
+                exp_dict.setdefault(model_name, {})[key] = experiment.segment_exp_data(segment)
+                items.append((trace.data, experiment.segment_exp_data(segment),
+                              self._segment_routing(experiment, segment), key))
+        # Score first, assemble second -- the same order the gradient optimizers use. The
+        # measurement layer materialises its expression columns during scoring, and the
+        # assembly reads those columns.
+        value = self.objective.evaluate_multiple(sim_dict, exp_dict, pset, show_warnings=False)
+        if value is None or not np.isfinite(value):
+            return self._unusable_objective()
+        grad = assemble_gradient_and_fisher_hessian(
+            self.objective, items, self._free_params(u, pset))
+        return ObjectiveModel.from_gradient_result(value, grad)
+
+    def _unusable_objective(self):
+        """The local model at a point that did not simulate, or did not score.
+
+        Non-finite by construction, which is the signal
+        :meth:`~pybnf.transcription.augmented.AugmentedModel.is_finite` carries to the
+        inner solver: shrink the trust region and try a shorter step, rather than end the
+        run. A segment that fails is a property of the point.
+        """
+        return ObjectiveModel(np.inf, np.full(self._layout.size, np.nan))
+
+    def _segment_routing(self, experiment, segment):
+        """This segment's routing over the **augmented** free-parameter list.
+
+        Three populations, and the whole of the ``IC``-route finding is in the second:
+
+        * every reported free parameter keeps its route -- minus, for ``segment > 0``, any
+          ``IC`` contribution to a state this segment overrode (see the module docstring);
+        * this segment's own auxiliary block routes to ``IC`` on its states with factor 1;
+        * every other auxiliary block gets an empty route, because this segment's
+          trajectory does not depend on another segment's start state. An empty route is a
+          structural zero column, not an omission: the assembly indexes routes by name into
+          the augmented column list, so a block that is absent from the routing would leave
+          an uninitialised column rather than a zero one.
+        """
+        overridden = set(experiment.state_names) if segment > 0 else set()
+        routes = {}
+        for name, route in experiment.routing.routes.items():
+            kept = tuple(c for c in route.contributions
+                         if not (c.target == IC and c.key in overridden))
+            routes[name] = ParamRoute(free_param=name, contributions=kept)
+        own = (experiment.grid.block_names[segment - 1] if segment > 0 else None)
+        for block in self._layout.blocks:
+            states = (experiment.state_names if block.name == own else ())
+            for qualified, state in zip(block.qualified_names, block.labels):
+                routes[qualified] = (
+                    ParamRoute.single(qualified, IC, state, 1.0) if state in states
+                    else ParamRoute(free_param=qualified, contributions=()))
+        return ExperimentRouting(routes=routes,
+                                 nominal_values=experiment.routing.nominal_values,
+                                 condition=experiment.routing.condition)
+
+    # -- the constraints --------------------------------------------------------
+
+    def equality_at(self, u):
+        if not self._constraint_names:
+            return self.empty_model()
+        cached = self._traces(u)
+        if cached is None:
+            return self._unusable_equality()
+        _pset, traces = cached
+        u = np.asarray(u, dtype=float).reshape(-1)   # this method indexes u by block slice
+        m = len(self._constraint_names)
+        residual = np.zeros(m)
+        blocks = []
+        reported = slice(0, self._layout.n_reported)
+        factors = self._reported_scale_factors(u)
+        for experiment, per_segment in zip(self.experiments, traces):
+            n_state = len(experiment.state_names)
+            for knot, block_name in enumerate(experiment.grid.block_names):
+                segment = knot                      # segment `knot` ends at knot `knot + 1`
+                trace = per_segment[segment]
+                rows = self._constraint_rows[block_name]
+                next_slice = self._layout.slice_of(block_name)
+                z_next = 10.0 ** u[next_slice]
+                residual[rows] = trace.end_state - z_next
+
+                # d(end state)/d(reported parameters), folded from this segment's routing
+                # exactly as the objective's columns are, then taken into sampling space.
+                # The same routing the data rows of this segment were assembled through, so
+                # a fitted initial condition contributes here on segment 0 and nowhere else.
+                routing = self._segment_routing(experiment, segment)
+                d_reported = np.zeros((n_state, self._layout.n_reported))
+                for j, v in enumerate(self.variables):
+                    d_reported[:, j] = _fold_route(routing.routes[v.name], trace)
+                blocks.append(JacobianBlock(rows, reported, d_reported * factors[np.newaxis, :]))
+
+                # d(end state)/d(this segment's own start state) -- the IC route, chain-ruled
+                # through the auxiliary variable's own log10 space.
+                if segment > 0:
+                    own = experiment.grid.block_names[segment - 1]
+                    own_slice = self._layout.slice_of(own)
+                    z_own = 10.0 ** u[own_slice]
+                    columns = _ic_columns(trace, experiment.state_names)
+                    blocks.append(JacobianBlock(
+                        rows, own_slice, columns * (np.log(10.0) * z_own)[np.newaxis, :]))
+
+                # d(-z_{j+1})/d(its own coordinates): the constant -I of the transcription,
+                # in the auxiliary variable's log10 space.
+                blocks.append(JacobianBlock(
+                    rows, next_slice, -np.diag(np.log(10.0) * z_next)))
+
+        return EqualityModel(residual, BlockJacobian((m, self._layout.size), blocks),
+                             scales=self._constraint_scales, names=self._constraint_names)
+
+    def _unusable_equality(self):
+        """The constraint linearisation at a point that did not simulate: non-finite, so
+        the augmented model is, so the inner solver backs off."""
+        m = len(self._constraint_names)
+        return EqualityModel(np.full(m, np.inf),
+                             BlockJacobian((m, self._layout.size), ()),
+                             scales=self._constraint_scales, names=self._constraint_names)
+
+    def _reported_scale_factors(self, u):
+        """``d theta/d u`` for the reported block at ``u``.
+
+        The constraint rows are in the model's own state units but their columns are in the
+        space the optimizer walks, so the reported half of every continuity block takes the
+        same chain factor the objective's Jacobian does.
+        """
+        reported = self._layout.reported_of(u)
+        return np.array([v.d_from_sampling_space(reported[j]) if v.log_space else 1.0
+                         for j, v in enumerate(self.variables)], dtype=float)
+
+    # -- certification ----------------------------------------------------------
+
+    def certify(self, reported):
+        """Reconstruct ``reported`` through the fit's ordinary unsegmented path.
+
+        Every auxiliary state is discarded and each experiment is simulated once over its
+        whole horizon from the model's own initial conditions -- which *is* the single-shoot
+        problem -- and scored by the fit's own objective. That score is the only one
+        comparable with an ordinary PyBNF fit's, and under ADR-0109 it is the only one this
+        run may report: the augmented objective at an infeasible point is computed on
+        trajectories that do not join up.
+        """
+        self.n_certifications += 1
+        pset = self._pset_from_u(np.asarray(reported, dtype=float))
+        sim_dict, exp_dict = {}, {}
+        for experiment in self.experiments:
+            model_name, suffix = experiment.key
+            times, _rows = experiment.certification_grid.sample_times(0)
+            try:
+                data = experiment.backend.simulate(pset, times, None)
+            except SegmentSimulationFailed as exc:
+                return Certificate.reject('the reconstructed trajectory did not '
+                                          'simulate (%s)' % exc)
+            sim_dict.setdefault(model_name, {})[suffix] = data
+            exp_dict.setdefault(model_name, {})[suffix] = experiment.exp_data
+        value = self.objective.evaluate_multiple(sim_dict, exp_dict, pset, show_warnings=False)
+        if value is None or not np.isfinite(value):
+            return Certificate.reject('the reconstructed trajectory scored non-finite')
+        return Certificate.accept(value, detail='single-shoot reconstruction')
+
+
+# ---------------------------------------------------------------------------
+# Stage construction
+# ---------------------------------------------------------------------------
+
+def seed_stage(specs, n_segments, objective, variables, pset_from_u, reported,
+               aux_decades=AUX_DECADES, name=None):
+    """Build one rung of the ladder, with its auxiliary states seeded from ``reported``.
+
+    Each experiment is simulated **once**, unsegmented, at the incoming parameters, and the
+    state is read off at each knot. Seeding this way makes the transcription feasible at
+    iteration zero: every continuity defect is exactly zero at the start point, so any
+    discontinuity the run subsequently holds is the optimizer's own choice rather than an
+    artifact of how the stage was built. It is also why a homotopy stage is a *callable*
+    in :func:`~pybnf.transcription.homotopy.run_homotopy` -- the seeds are not knowable
+    until the previous stage has finished moving ``theta``.
+
+    A start point that does not simulate is not a failure: the knots fall back to the
+    model's own declared state magnitudes, the first inner solve sees a large defect, and
+    the run proceeds (or stops with a stated reason) rather than dying at construction.
+
+    ``aux_decades`` sets each auxiliary variable's box: ``+/- aux_decades`` around the
+    state's own magnitude, in log10. Wide enough not to constrain the search, finite
+    because the inner optimizers are bound-constrained and a segment-start concentration
+    that is allowed to go negative is not a state a simulator can restart from.
+    """
+    reported = np.asarray(reported, dtype=float).reshape(-1)
+    pset = pset_from_u(reported)
+    staged, blocks, scales = [], [], {}
+    for spec in specs:
+        experiment = SegmentedExperiment(spec, spec.grid(n_segments))
+        nominal = np.maximum(np.asarray(spec.backend.nominal_state, dtype=float), STATE_FLOOR)
+        seeds, magnitude = _seed_knots(experiment, pset, nominal)
+        scales[experiment.key] = magnitude
+        centre = np.log10(magnitude)
+        lower, upper = centre - aux_decades, centre + aux_decades
+        for block_name, seed in zip(experiment.grid.block_names, seeds):
+            initial = np.clip(np.log10(np.maximum(seed, STATE_FLOOR)), lower, upper)
+            blocks.append(VariableBlock(block_name, experiment.state_names, lower, upper,
+                                        initial))
+        staged.append(experiment)
+    return MultipleShootingProblem(staged, objective, variables, pset_from_u, blocks, scales,
+                                   name=name or ('m=%i' % n_segments))
+
+
+def _seed_knots(experiment, pset, nominal):
+    """``(per-knot seed states, per-state magnitude)`` from one unsegmented simulation.
+
+    The magnitude is the larger of the model's declared nominal and the largest value the
+    seeding trajectory actually reaches, per state. Declared nominals alone understate a
+    species that starts empty and grows -- which on an oscillator is most of them -- and a
+    constraint scale that understates its state hands the penalty term a condition number
+    for free, which is the corner ADR-0109's scaling exists to close.
+    """
+    grid = experiment.grid
+    if grid.n_knots == 0:
+        return [], nominal
+    try:
+        data = experiment.backend.simulate(pset, grid.seed_times(), None)
+    except SegmentSimulationFailed:
+        return [nominal.copy() for _ in range(grid.n_knots)], nominal
+    columns = [data.cols[name] for name in experiment.state_names]
+    trajectory = np.abs(np.asarray(data.data, dtype=float)[:, columns])
+    if not np.all(np.isfinite(trajectory)):
+        return [nominal.copy() for _ in range(grid.n_knots)], nominal
+    times = np.asarray(data.data, dtype=float)[:, data.cols[data.indvar]]
+    seeds = []
+    for knot_time in grid.knot_times:
+        row = int(np.argmin(np.abs(times - knot_time)))
+        seeds.append(np.asarray(data.data, dtype=float)[row, columns])
+    magnitude = np.maximum(nominal, np.max(trajectory, axis=0))
+    return seeds, np.maximum(magnitude, STATE_FLOOR)
+
+
+# ---------------------------------------------------------------------------
+# Small helpers
+# ---------------------------------------------------------------------------
+
+def _fold_route(route, trace):
+    """``d(end state)/d(one free parameter)``: the route's contributions, summed.
+
+    The same fold :func:`pybnf.gradient.assembly._raw_sensitivity_accessor` performs for a
+    scored column, applied to the end-knot row instead -- one place, so a condition's
+    chain-rule factor and a multi-column route reach the continuity block exactly as they
+    reach the data rows. A :data:`~pybnf.gradient.routing.NONE` term (a free noise scale)
+    and a pinned zero-factor term contribute nothing, by the same test the assembly uses.
+    """
+    total = np.zeros(len(trace.end_state))
+    for contribution in route.contributions:
+        if contribution.target == NONE or contribution.factor == 0.0:
+            continue
+        if contribution.target == PARAM:
+            axis, tensor = trace.param_axis, trace.d_end_param
+        else:
+            axis, tensor = trace.ic_axis, trace.d_end_ic
+        if tensor is None or contribution.key not in axis:
+            raise PybnfError(
+                "Multiple shooting needs the %s sensitivity column '%s' at a segment's end "
+                "knot, and the segment simulation did not return it. The continuity "
+                "Jacobian is built from the same forward-sensitivity request the data rows "
+                "use, so a missing column is an internal wiring error."
+                % (contribution.target, contribution.key))
+        total = total + contribution.factor * tensor[:, axis.index(contribution.key)]
+    return total
+
+
+def _ic_columns(trace, state_names):
+    """``d(end state)/d(start state)`` as an ``(n_state, n_state)`` block.
+
+    The ``IC`` route with chain-rule factor 1, read off the tensor the segment already
+    returned: column ``s`` is ``d(end state)/d(z_s)``. Reordered to ``state_names`` so the
+    block's columns line up with the auxiliary block's own component order rather than with
+    whatever order the backend requested its sensitivity axis in.
+    """
+    if trace.d_end_ic is None:
+        raise PybnfError(
+            'Multiple shooting needs initial-condition sensitivities at a segment end knot '
+            '(the continuity Jacobian is d(end state)/d(start state)), and the segment '
+            'simulation returned none.')
+    missing = [name for name in state_names if name not in trace.ic_axis]
+    if missing:
+        raise PybnfError(
+            'A multiple-shooting segment simulation returned no initial-condition '
+            'sensitivity axis for state(s) %s.' % ', '.join(sorted(missing)))
+    return trace.d_end_ic[:, [trace.ic_axis.index(name) for name in state_names]]
+
+
+def _subset_rows(data, rows):
+    """One :class:`~pybnf.data.Data` restricted to a row subset, weights included.
+
+    Bootstrap weights are per-point (``sqrt(w)``-folded into both the residual and the
+    Jacobian), so a segment must carry its own rows' weights or a bootstrap refit would
+    silently reweight the fit it is resampling.
+    """
+    rows = np.asarray(rows, dtype=int)
+    out = Data(arr=np.asarray(data.data, dtype=float)[rows, :].copy())
+    out.cols = dict(data.cols)
+    out.headers = dict(data.headers)
+    out.indvar = data.indvar
+    if data.weights is not None:
+        out.weights = np.asarray(data.weights, dtype=float)[rows, :].copy()
+    return out

--- a/pybnf/shooting/solver.py
+++ b/pybnf/shooting/solver.py
@@ -1,0 +1,182 @@
+"""The inner solver: ``gntr``'s step machine, driven against an augmented subproblem (#563).
+
+ADR-0109's layer ships no inner solver, deliberately -- shipping one would state a
+preference the optimizer-agnostic contract exists to avoid. A *consumer* has to choose one,
+and for multiple shooting the choice is measured rather than assumed. Over 30 data seeds x 2
+starts on the layer's offline shooting problem (120 runs), a trust-region least-squares
+solver converged **60/60** while a quasi-Newton one converged 36/60 and stalled out on the
+rest. The reason is structural: the KKT stop needs the scaled defect and the first-order
+optimality below tolerance in *one* iterate, and a method built from gradient differences
+handles an augmented Lagrangian whose penalty term carries a large ``rho`` far less well
+than one that sees ``rho J_c^T J_c`` explicitly. So the MVP steps from the Gauss-Newton
+form, and a consumer should not treat the inner optimizer as free.
+
+Reusing the fit type rather than reimplementing it
+--------------------------------------------------
+The Gauss-Newton form is ``(gradient, PSD hessian)`` -- exactly what ``job_type = gntr``
+already consumes, and :class:`~pybnf.algorithms.optimizers.gntr._GNTRRunner` is already a
+headless, backend-free step machine over that pair: ridge-regularise ``H``, eigen-factor it
+into the pseudo-Jacobian that reproduces the Coleman-Li-scaled Newton step, and run ``trf``'s
+bound-constrained trust-region-reflective accept/reject state machine unchanged. So this
+module is a *driver*, not a method: it feeds that runner the augmented Lagrangian instead of
+the fit's own objective, and nothing about the step math is new or separately tuned.
+
+Driving it synchronously is the one difference from ``gntr``'s own use, and it is forced by
+the interface above rather than chosen: ADR-0109's contract is
+``solve(subproblem, u0, tolerance) -> InnerOutcome``, a blocking call, because an inner
+solver "never calls back into the outer loop". Since a segment simulation is not a
+:class:`~pybnf.pset.PSet` evaluation either (:mod:`pybnf.shooting.backend`), nothing is lost:
+the propose/score loop was never available to this path.
+
+Two tolerances, and why the outer loop's is only a floor away from being obeyed
+-------------------------------------------------------------------------------
+``tolerance`` is ``omega_k``, the outer loop's inner-optimality target: loose at first and
+tightening as the penalty rises. It becomes the runner's ``grad_tol``, so an early
+subproblem is solved roughly and a late one tightly -- which is the entire economic argument
+for the augmented-Lagrangian frame. It is floored (:attr:`GaussNewtonSolver.grad_tol_floor`)
+because ``omega`` decays geometrically and will eventually pass below what any solver can
+demonstrate on a finite-precision Hessian; past that point the runner would simply spend its
+whole iteration budget every outer iteration, which is the same waste ADR-0109 finding 5.1
+measured on a too-loose penalty, arrived at from the other side.
+"""
+
+import numpy as np
+
+from ..transcription import InnerOutcome
+
+
+def _step_machine():
+    """``(runner class, DONE sentinel)`` from the ``gntr`` fit type, imported lazily.
+
+    The import is deferred because the dependency runs *against* the usual direction: a fit
+    type imports the libraries it needs, and here a library reaches back into a fit type for
+    its step machine. Importing :mod:`pybnf.algorithms.optimizers.gntr` at module scope
+    executes ``pybnf.algorithms.__init__``, which registers every fit type -- including
+    ``ms``, which imports this package -- so the cycle would close at import time. Deferring
+    it to the first solve breaks the cycle and keeps :mod:`pybnf.shooting` importable on its
+    own, which is what lets the whole package be exercised against a closed-form backend
+    with no fit type in the picture.
+    """
+    from ..algorithms.optimizers.gntr import _GNTRRunner
+    from ..algorithms.optimizers.gradient_base import DONE
+    return _GNTRRunner, DONE
+
+
+class _FisherModel:
+    """The duck-typed local model :class:`~pybnf.algorithms.optimizers.gntr._GNTRRunner`
+    reads: a scalar gradient and a PSD curvature matrix.
+
+    The runner consumes a :class:`~pybnf.gradient.assembly.GradientResult` by attribute
+    (``gradient``, ``hessian``) and never by type, so the augmented Lagrangian's own
+    ``(grad f + J_c^T(lambda + rho c), H_f + rho J_c^T J_c)`` is handed over as-is. That is
+    what "optimizer-agnostic" buys in practice: the fit type needs no knowledge that a
+    multiplier exists.
+    """
+
+    __slots__ = ('gradient', 'hessian')
+
+    def __init__(self, gradient, hessian):
+        self.gradient = gradient
+        self.hessian = hessian
+
+
+class GaussNewtonSolver:
+    """An inner solver on ADR-0109's contract, stepping from the Gauss-Newton form.
+
+    :param max_iterations: Trust-region iterations per inner solve. Bounded per *outer*
+        iteration rather than per run: an approximate inner minimisation is what the
+        augmented-Lagrangian method is designed around, and the outer loop's stall detector
+        is what notices a solver that stops achieving anything.
+    :param ridge: The relative Levenberg ridge added to the curvature before the
+        pseudo-Jacobian factorisation, as in ``gntr_ridge``. It matters more here than in an
+        ordinary fit: with one observed state of three, the auxiliary states of the
+        unobserved two carry **no data term at all** and their data-fit curvature is exactly
+        zero, so the constraint block ``rho J_c^T J_c`` is the only curvature they have.
+    :param step_tol: Negligible-step tolerance, as in ``gntr_step_tol``.
+    :param grad_tol_floor: Floor under the outer loop's ``omega_k`` (see the module
+        docstring).
+    :param stop_check: Zero-argument callable; ``True`` truncates the inner solve at
+        whichever iterate it has reached. The wall-clock-budget seam (ADR-0093/0107) --
+        a truncated inner solve is a normal outcome here, not a failure, and the outer loop
+        keeps the iterate.
+    """
+
+    def __init__(self, max_iterations=50, ridge=1e-10, step_tol=1e-10, grad_tol_floor=1e-10,
+                 stop_check=None):
+        self.max_iterations = int(max_iterations)
+        self.ridge = float(ridge)
+        self.step_tol = float(step_tol)
+        self.grad_tol_floor = float(grad_tol_floor)
+        self.stop_check = stop_check
+        #: Model evaluations spent across every inner solve this object has driven -- the
+        #: cost accounting the #563 acceptance benchmark reports, and the quantity the
+        #: prototype's paired sweep measured multiple shooting's 2-7x overhead in.
+        self.n_evaluations = 0
+
+    def __call__(self, subproblem, u0, tolerance):
+        runner_class, done = _step_machine()
+        lower, upper = subproblem.lower, subproblem.upper
+        runner = runner_class(np.clip(np.asarray(u0, dtype=float), lower, upper),
+                              lower, upper, self.max_iterations,
+                              grad_tol=max(float(tolerance), self.grad_tol_floor),
+                              step_tol=self.step_tol, ridge=self.ridge)
+        point = runner.start()
+        spent = 0
+        truncated = False
+        while True:
+            if self.stop_check is not None and self.stop_check():
+                truncated = True
+                break
+            model = subproblem.at(point)
+            spent += 1
+            self.n_evaluations += 1
+            nxt = runner.got(point, *_local_model(model))
+            if nxt is done:
+                break
+            point = np.clip(np.asarray(nxt, dtype=float), lower, upper)
+
+        if truncated:
+            return InnerOutcome(runner.point, converged=False, n_evaluations=spent,
+                                message='inner solve truncated by the run\'s stop check')
+        return InnerOutcome(runner.point, converged=_met_its_tolerance(runner),
+                            n_evaluations=spent, message=runner.stop_reason or '')
+
+    def __repr__(self):
+        return 'GaussNewtonSolver(max_iterations=%i, evaluations=%i)' % (
+            self.max_iterations, self.n_evaluations)
+
+
+def _local_model(model):
+    """``(score, local model)`` for one visited point.
+
+    A point whose segments did not integrate -- or whose curvature could not be assembled --
+    is handed over as a non-finite score with **no** model, which is the signal the runner
+    already understands: shrink the trust region and propose a shorter step, and at the
+    start point end this solve rather than stepping from a surface that is not there
+    (#492/#528). Multiple shooting meets that case far more often than an ordinary fit does,
+    because it deliberately visits states the model was never integrated from.
+    """
+    if not model.is_finite():
+        return float('inf'), None
+    hessian = model.hessian()
+    if hessian is None:
+        return float('inf'), None
+    return model.value, _FisherModel(model.gradient, hessian)
+
+
+def _met_its_tolerance(runner):
+    """Whether an inner solve stopped because it *finished*, rather than ran out.
+
+    :class:`~pybnf.transcription.outer.InnerOutcome`'s ``converged`` means "met the
+    tolerance it was given, as opposed to running out of iterations or budget". A flat
+    scaled gradient and a negligible step both qualify -- the second is a solver that cannot
+    improve its point further, which is a finished solve of this subproblem however loose
+    ``omega_k`` was. An exhausted iteration budget and a failed start do not.
+
+    Nothing load-bearing rests on the answer: the outer loop **measures** the
+    projected-gradient optimality itself at each iterate rather than trusting this flag
+    (ADR-0109), precisely so an inner solver's own opinion cannot certify a KKT point.
+    """
+    if runner.failure is not None or runner.stop_reason is None:
+        return False
+    return 'max_iterations' not in runner.stop_reason

--- a/tests/recovery_harness.py
+++ b/tests/recovery_harness.py
@@ -51,6 +51,7 @@ _ALGORITHMS = {
     'lbfgs': algorithms.LBFGSAlgorithm,   # gradient-based scalar quasi-Newton fallback (#386)
     'gntr': algorithms.GNTRAlgorithm,   # general-objective Fisher/Gauss-Newton trust region (#481)
     'profile_likelihood': algorithms.ProfileLikelihoodAlgorithm,   # PL identifiability (#446/#466)
+    'ms': algorithms.MultipleShootingAlgorithm,   # multiple shooting (#563/ADR-0110)
 }
 
 

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -354,13 +354,14 @@ class TestRegistrySchemaSeam:
         # The gradient-based optimizers (#386/#481) land with their own schemas: trf
         # (trust-region least-squares) with TRFConfig, lbfgs (L-BFGS-B) with LBFGSConfig,
         # and gntr (general-objective Fisher/Gauss-Newton trust region) with GNTRConfig.
-        # profile_likelihood (#446/#466) lands with ProfileLikelihoodConfig.
+        # profile_likelihood (#446/#466) lands with ProfileLikelihoodConfig, and ms
+        # (multiple shooting, #563/ADR-0110) with MSConfig.
         # Only 'check' remains unmigrated. Each step extends this set -- a ratchet.
         from pybnf.registry import FIT_TYPE_REGISTRY
         migrated = {c for c, e in FIT_TYPE_REGISTRY.items() if e.schema is not None}
         assert migrated == {'pso', 'de', 'ade', 'ss', 'sim', 'powell', 'cmaes',
                             'mh', 'pt', 'sa', 'am', 'dream', 'p_dream', 'hmc', 'trf', 'lbfgs',
-                            'gntr', 'profile_likelihood'}
+                            'gntr', 'profile_likelihood', 'ms'}
         assert FIT_TYPE_REGISTRY['check'].schema is None
 
 

--- a/tests/test_pybnf_main_helpers.py
+++ b/tests/test_pybnf_main_helpers.py
@@ -54,6 +54,7 @@ _DISPATCH = [
     ('trf', 'TRFAlgorithm'),
     ('lbfgs', 'LBFGSAlgorithm'),
     ('gntr', 'GNTRAlgorithm'),
+    ('ms', 'MultipleShootingAlgorithm'),
     ('profile_likelihood', 'ProfileLikelihoodAlgorithm'),
     ('ade', 'AsynchronousDifferentialEvolution'),
     ('dream', 'DreamAlgorithm'),
@@ -93,7 +94,7 @@ def test_only_mh_and_sa_are_deprecated():
 
 def test_families_partition_the_codes():
     fam = {code: e.family for code, e in FIT_TYPE_REGISTRY.items()}
-    assert {c for c, f in fam.items() if f == 'optimizer'} == {'pso', 'de', 'ade', 'ss', 'sim', 'sa', 'powell', 'cmaes', 'trf', 'lbfgs', 'gntr', 'profile_likelihood'}
+    assert {c for c, f in fam.items() if f == 'optimizer'} == {'pso', 'de', 'ade', 'ss', 'sim', 'sa', 'powell', 'cmaes', 'trf', 'lbfgs', 'gntr', 'ms', 'profile_likelihood'}
     assert {c for c, f in fam.items() if f == 'sampler'} == {'mh', 'pt', 'am', 'dream', 'p_dream', 'hmc'}
     assert {c for c, f in fam.items() if f == 'checker'} == {'check'}
 

--- a/tests/test_shooting.py
+++ b/tests/test_shooting.py
@@ -1,0 +1,535 @@
+"""The multiple-shooting consumer (#563, ADR-0110), offline.
+
+:mod:`pybnf.shooting` narrows its simulator coupling to one method
+(:class:`~pybnf.shooting.backend.SegmentBackend.simulate`) precisely so everything above it
+can be verified without a simulator -- the same strategy that let ADR-0109's layer be
+verified against a closed-form transcription. This module implements that one method for a
+problem whose flow and both sensitivities are elementary, and then holds the consumer to the
+claims that matter:
+
+* **knot identity** -- a coarser stage's knots are a subset of a finer stage's *by name*, so
+  the ``4 -> 2 -> 1`` ladder continues rather than reseeds. If this breaks, the homotopy
+  silently becomes three independent solves, which is the mechanism ADR-0109 finding 5.2
+  says the method rests on;
+* **the ``IC`` route with factor 1** -- the objective's gradient and the continuity
+  Jacobian, both pinned against central differences of the quantities they claim to
+  differentiate, including the corner where a reported free parameter *is* an initial
+  condition and therefore contributes on segment 0 and nowhere else;
+* **feasibility at iteration zero** -- seeding the knots from a nominal trajectory leaves
+  every continuity defect at zero, so a discontinuity the run holds later is the optimizer's
+  own;
+* **the load-bearing claim** -- at convergence the transcription is equivalent to the
+  uninterrupted fit, measured against a single-shoot optimum computed **independently** by
+  ``scipy.least_squares`` rather than against this package's own arithmetic written twice.
+
+The offline problem
+-------------------
+Two states, ``y' = k y`` and ``w' = -k w``, with only ``y`` observed. The flow is
+``y(t) = z_y e^{k dt}``, ``w(t) = z_w e^{-k dt}``, and both sensitivity axes are elementary.
+It has the shape the simulator-backed consumer has -- knots, auxiliary segment-start states,
+continuity defects, a data term reading its own segment's auxiliary state, and a
+single-shoot reconstruction -- and it has the motivating problem's hard corner: ``w`` carries
+no data term at all, so half the auxiliary variables are determined by continuity alone.
+"""
+
+import numpy as np
+import pytest
+from scipy.optimize import least_squares
+
+from pybnf.data import Data, OutputSensitivities
+from pybnf.gradient import IC, PARAM, ExperimentRouting, ParamRoute
+from pybnf.objective import ChiSquareObjective
+from pybnf.printing import PybnfError
+from pybnf.pset import FreeParameter, PSet
+from pybnf.shooting import (
+    GaussNewtonSolver,
+    SegmentBackend,
+    SegmentGrid,
+    SegmentSimulationFailed,
+    ShootingExperiment,
+    feasible_ladder,
+    run_multiple_shooting,
+    seed_stage,
+)
+from pybnf.shooting.grid import KNOT
+from pybnf.transcription import AugmentedLagrangian, Multipliers, PenaltySchedule
+
+W0 = 2.0           # the unobserved state's (fixed) initial value
+SIGMA = 0.05
+
+
+# ---------------------------------------------------------------------------
+# The closed-form backend
+# ---------------------------------------------------------------------------
+
+class TwoStateBackend(SegmentBackend):
+    """``y' = k y``, ``w' = -k w`` in closed form, with both sensitivity axes.
+
+    Deliberately the same *shape* a bngsim segment run returns: a
+    :class:`~pybnf.data.Data` whose columns are the states, carrying an
+    :class:`~pybnf.data.OutputSensitivities` with ``species:<name>`` selectors and both a
+    parameter and an initial-condition axis. Everything in :mod:`pybnf.shooting` above
+    :meth:`simulate` therefore runs unmodified.
+    """
+
+    def __init__(self):
+        self.n_simulations = 0
+        self.fail_beyond = None    # |k| above which this "model" refuses to integrate
+
+    @property
+    def state_names(self):
+        return ('y', 'w')
+
+    @property
+    def nominal_state(self):
+        return np.array([1.0, W0])
+
+    def simulate(self, pset, sample_times, initial_state=None):
+        self.n_simulations += 1
+        k = float(pset['k'])
+        if self.fail_beyond is not None and abs(k) > self.fail_beyond:
+            raise SegmentSimulationFailed('the closed-form backend refuses |k| > %g'
+                                          % self.fail_beyond)
+        state = ({'y': float(pset['y0']), 'w': W0} if initial_state is None
+                 else {name: float(value) for name, value in initial_state.items()})
+        times = np.asarray(sample_times, dtype=float)
+        dt = times - times[0]
+        grow, decay = np.exp(k * dt), np.exp(-k * dt)
+        y, w = state['y'] * grow, state['w'] * decay
+
+        data = Data.from_columns(np.column_stack([times, y, w]), ['time', 'y', 'w'])
+        d_param = np.zeros((len(times), 2, 1))
+        d_param[:, 0, 0] = state['y'] * dt * grow          # dy/dk
+        d_param[:, 1, 0] = -state['w'] * dt * decay        # dw/dk
+        d_ic = np.zeros((len(times), 2, 2))
+        d_ic[:, 0, 0] = grow                               # dy/dz_y
+        d_ic[:, 1, 1] = decay                              # dw/dz_w
+        data.output_sensitivities = OutputSensitivities(
+            selectors=['species:y', 'species:w'], param_names=['k'], ic_species=['y', 'w'],
+            d_param=d_param, d_ic=d_ic)
+        return data
+
+
+# ---------------------------------------------------------------------------
+# Fixture plumbing
+# ---------------------------------------------------------------------------
+
+def observations(k_true=0.7, y0_true=1.0, n=25, horizon=3.0, seed=4):
+    rng = np.random.default_rng(seed)
+    times = np.linspace(0.0, horizon, n)
+    return times, y0_true * np.exp(k_true * times) + rng.normal(0.0, SIGMA, size=n)
+
+
+def variables(k=0.4, y0=0.8, log_space=False):
+    """The fit's reported free parameters.
+
+    ``log_space`` makes both ``loguniform_var``, so the search coordinate is ``log10(theta)``
+    and every column of the objective Jacobian *and* of the continuity block carries a
+    ``d theta/d u = ln(10) * theta`` factor. That factor is applied in two different places
+    (the assembly's own, and this package's for the constraint rows), so the log variant is
+    what stops the second from being a second implementation of the first.
+    """
+    kind = 'loguniform_var' if log_space else 'uniform_var'
+    lower = 0.01 if log_space else -2.0
+    return [FreeParameter('k', kind, lower, 2.0, value=k),
+            FreeParameter('y0', kind, 0.01, 10.0, value=y0)]
+
+
+def pset_from_u_for(free_params):
+    def pset_from_u(u):
+        return PSet([v.set_value(v.from_sampling_space(u[i]))
+                     for i, v in enumerate(free_params)])
+    return pset_from_u
+
+
+def make_spec(times, obs, backend=None):
+    exp_data = Data.from_columns(
+        np.column_stack([times, obs, np.full(len(obs), SIGMA)]), ['time', 'y', 'y_SD'])
+    routing = ExperimentRouting(routes={
+        'k': ParamRoute.single('k', PARAM, 'k', 1.0),
+        'y0': ParamRoute.single('y0', IC, 'y', 1.0),
+    })
+    return ShootingExperiment(('model', 'exp1'), backend or TwoStateBackend(), exp_data,
+                              routing, label='exp1', start=0.0)
+
+
+def build_stage(n_segments, start_u=(0.4, 0.8), seed=4, backend=None, log_space=False):
+    """One rung, seeded at ``start_u``, plus the pieces a caller needs to poke at it.
+
+    ``start_u`` is in **sampling space**, so under ``log_space`` it is ``log10(theta)``.
+    """
+    times, obs = observations(seed=seed)
+    free = variables(log_space=log_space)
+    spec = make_spec(times, obs, backend=backend)
+    problem = seed_stage([spec], n_segments, ChiSquareObjective(), free,
+                         pset_from_u_for(free), np.asarray(start_u, dtype=float))
+    return problem, spec, free
+
+
+def single_shoot_optimum(times, obs):
+    """The uninterrupted fit's optimum, computed independently of this package."""
+    result = least_squares(
+        lambda p: (p[1] * np.exp(p[0] * times) - obs) / SIGMA, [0.4, 0.8],
+        bounds=([-2.0, 0.01], [2.0, 10.0]), xtol=1e-14, ftol=1e-14, gtol=1e-14)
+    return np.asarray(result.x, dtype=float), float(0.5 * result.fun @ result.fun)
+
+
+# ---------------------------------------------------------------------------
+# Knot placement
+# ---------------------------------------------------------------------------
+
+class TestSegmentGrid:
+
+    def test_knot_names_nest_down_the_ladder(self):
+        """The load-bearing naming property: a coarser stage's knots are a *subset by name*
+        of a finer one's, which is the only thing ``carry_over`` matches on."""
+        times = np.linspace(0.0, 3.0, 13)
+        fine = SegmentGrid(times, 4, label='exp1')
+        mid = SegmentGrid(times, 2, label='exp1')
+        assert fine.block_names == ('exp1@1/4', 'exp1@1/2', 'exp1@3/4')
+        assert mid.block_names == ('exp1@1/2',)
+        assert set(mid.block_names) < set(fine.block_names)
+        assert SegmentGrid(times, 1, label='exp1').block_names == ()
+
+    def test_a_knot_is_named_by_its_exact_fraction_not_a_rounded_float(self):
+        times = np.linspace(0.0, 1.0, 7)
+        assert SegmentGrid(times, 3, label='e').block_names == ('e@1/3', 'e@2/3')
+        # Exact rationals, so 1/3 at m=3 and 2/6 at m=6 are one knot, not two names.
+        assert 'e@1/3' in SegmentGrid(times, 6, label='e').block_names
+
+    def test_a_point_on_a_knot_belongs_to_the_later_segment(self):
+        """Half-open ``[start_j, start_{j+1})``: a point exactly on a knot is read at
+        ``dt = 0`` from that knot's own auxiliary state, which is the one row where the data
+        sees a segment-start state directly."""
+        grid = SegmentGrid(np.array([0.0, 1.0, 2.0, 3.0, 4.0]), 2, label='e', start=0.0,
+                           horizon=4.0)
+        assert grid.knot_times == (2.0,)
+        assert list(grid.segment_of) == [0, 0, 1, 1, 1]
+
+    def test_every_segment_outputs_its_own_start_and_end_knot(self):
+        grid = SegmentGrid(np.linspace(0.0, 3.0, 7), 3, label='e', start=0.0)
+        for segment in range(3):
+            pts, rows = grid.sample_times(segment)
+            assert pts[0] == pytest.approx(grid.starts[segment])
+            assert pts[-1] == pytest.approx(grid.ends[segment])
+            positions, same_rows = grid.row_positions(segment)
+            assert list(same_rows) == list(rows)
+            np.testing.assert_allclose(pts[positions], grid.times[rows])
+
+    def test_a_label_may_not_contain_the_knot_separator(self):
+        with pytest.raises(PybnfError, match='knot-name separator'):
+            SegmentGrid(np.linspace(0, 1, 3), 2, label='a%sb' % KNOT)
+
+
+# ---------------------------------------------------------------------------
+# The layout the transcription declares
+# ---------------------------------------------------------------------------
+
+class TestStageLayout:
+
+    def test_auxiliary_states_are_never_reported_parameters(self):
+        problem, _spec, free = build_stage(4)
+        layout = problem.layout
+        assert layout.reported_names == ('k', 'y0')
+        assert layout.n_internal == 3 * 2                      # 3 knots x 2 states
+        assert layout.names[:2] == ('k', 'y0')
+        assert all('::' in name for name in layout.names[2:])
+        u = layout.initial_point([0.4, 0.8])
+        np.testing.assert_allclose(layout.reported_of(u), [0.4, 0.8])
+
+    def test_the_seeded_start_point_is_feasible(self):
+        """Seeding each knot from a nominal trajectory at the incoming parameters makes the
+        transcription feasible at iteration zero, so every discontinuity the run holds later
+        is the optimizer's own choice rather than an artifact of the stage."""
+        problem, _spec, _free = build_stage(4)
+        u = problem.layout.initial_point([0.4, 0.8])
+        assert problem.equality_at(u).defect_norm == pytest.approx(0.0, abs=1e-9)
+
+    def test_a_coarser_stage_carries_the_surviving_knot_and_drops_the_rest(self):
+        fine, spec, free = build_stage(4)
+        coarse = seed_stage([spec], 2, ChiSquareObjective(), free, pset_from_u_for(free),
+                            np.array([0.4, 0.8]))
+        u = fine.layout.initial_point([0.4, 0.8])
+        u[fine.layout.slice_of('exp1@1/2')] = [0.25, -0.75]     # a "solved" knot state
+        moved = fine.layout.carry_over(u, coarse.layout)
+        np.testing.assert_allclose(coarse.layout.internal_of(moved, 'exp1@1/2'),
+                                   [0.25, -0.75])
+        assert coarse.layout.block_names == ('exp1@1/2',)
+
+    def test_the_one_segment_stage_is_the_unsegmented_problem(self):
+        problem, _spec, _free = build_stage(1)
+        assert problem.layout.n_internal == 0
+        assert problem.constraint_names == ()
+        assert problem.equality_at(problem.layout.initial_point([0.4, 0.8])).n_constraints == 0
+
+
+# ---------------------------------------------------------------------------
+# The derivatives -- against central differences
+# ---------------------------------------------------------------------------
+
+def central_difference(fun, u, step=1e-6):
+    """Jacobian of ``fun`` at ``u`` by central differences, one column per coordinate."""
+    base = np.atleast_1d(np.asarray(fun(u), dtype=float))
+    out = np.zeros((len(base), len(u)))
+    for j in range(len(u)):
+        h = step * max(1.0, abs(u[j]))
+        up, down = np.array(u, dtype=float), np.array(u, dtype=float)
+        up[j] += h
+        down[j] -= h
+        out[:, j] = (np.atleast_1d(np.asarray(fun(up), dtype=float))
+                     - np.atleast_1d(np.asarray(fun(down), dtype=float))) / (2.0 * h)
+    return out
+
+
+def perturbed(problem, base=(0.55, 0.9), knot_shift=0.12):
+    """A point that is *not* the feasible seed: the knots are stale, the defects nonzero.
+
+    Differentiating only at a feasible point would leave the whole ``-z_{j+1}`` half of the
+    continuity Jacobian untested against anything but zero.
+    """
+    u = problem.layout.initial_point(list(base))
+    u[problem.layout.n_reported:] += knot_shift
+    return u
+
+
+#: Both parameterisations of the reported block. The log variant is not a repeat: the
+#: ``d theta/d u`` factor is applied by the gradient assembly for the objective's columns and
+#: by this package for the continuity block's, and only a log-scaled parameter tells the two
+#: apart (the factor is 1 for a linear one). ``loguniform_var`` is also how a rate constant is
+#: normally declared, so it is the common case rather than the exotic one.
+LOG_SPACE = [
+    pytest.param(False, (0.55, 0.9), id='linear'),
+    pytest.param(True, (np.log10(0.55), np.log10(0.9)), id='log10'),
+]
+
+
+class TestDerivatives:
+
+    @pytest.mark.parametrize('log_space,base', LOG_SPACE)
+    def test_objective_gradient_matches_central_differences(self, log_space, base):
+        """The ``IC``-routed data term: ``d f/d u`` over the reported parameters *and* over
+        every auxiliary state, against differences of the objective the fit actually scores."""
+        problem, _spec, _free = build_stage(4, start_u=base, log_space=log_space)
+        u = perturbed(problem, base=base)
+        model = problem.objective_at(u)
+        numeric = central_difference(lambda x: problem.objective_at(x).value, u)[0]
+        np.testing.assert_allclose(model.gradient, numeric, rtol=2e-5, atol=1e-7)
+
+    def test_the_least_squares_residual_reproduces_the_objective(self):
+        """The invariant that makes the assembled model the fit's own: ``0.5||rho||^2`` is
+        the value ``evaluate`` reports, over the segmented trajectory."""
+        problem, _spec, _free = build_stage(4)
+        model = problem.objective_at(perturbed(problem))
+        assert model.least_squares_exact
+        assert 0.5 * model.residual @ model.residual == pytest.approx(model.value)
+        np.testing.assert_allclose(model.jacobian.T @ model.residual, model.gradient,
+                                   rtol=1e-9, atol=1e-9)
+
+    @pytest.mark.parametrize('log_space,base', LOG_SPACE)
+    def test_constraint_jacobian_matches_central_differences(self, log_space, base):
+        problem, _spec, _free = build_stage(4, start_u=base, log_space=log_space)
+        u = perturbed(problem, base=base)
+        model = problem.equality_at(u)
+        numeric = central_difference(lambda x: problem.equality_at(x).residual, u)
+        np.testing.assert_allclose(model.jacobian.to_dense(), numeric, rtol=2e-5, atol=1e-7)
+
+    @pytest.mark.parametrize('log_space,base', LOG_SPACE)
+    def test_augmented_gradient_matches_central_differences(self, log_space, base):
+        """The whole augmented Lagrangian, at nonzero multipliers and a raised penalty --
+        the quantity the inner solver actually steps from."""
+        problem, _spec, _free = build_stage(4, start_u=base, log_space=log_space)
+        u = perturbed(problem, base=base)
+        multipliers = Multipliers(np.linspace(-0.4, 0.6, len(problem.constraint_names)), 25.0)
+        numeric = central_difference(
+            lambda x: problem.augmented_at(x, multipliers).value, u)[0]
+        np.testing.assert_allclose(problem.augmented_at(u, multipliers).gradient, numeric,
+                                   rtol=2e-5, atol=1e-6)
+
+    def test_an_unobserved_state_still_carries_continuity_columns(self):
+        """The motivating problem's hard corner: ``w`` has no data term, so its auxiliary
+        states get *no* gradient from the objective and are determined by continuity alone.
+        Both halves of that have to be true, or the fit is silently unconstrained in them."""
+        problem, _spec, _free = build_stage(4)
+        u = perturbed(problem)
+        layout = problem.layout
+        w_columns = [i for i, name in enumerate(layout.names) if name.endswith('::w')]
+        objective = problem.objective_at(u)
+        assert np.allclose(objective.gradient[w_columns], 0.0)
+        constraint = problem.equality_at(u).jacobian.to_dense()
+        assert np.all(np.abs(constraint[:, w_columns]).sum(axis=0) > 0.0)
+
+
+class TestSegmentRouting:
+    """A fitted initial condition affects segment 0 and no other segment, because every
+    later segment's initial state was overridden by an auxiliary variable."""
+
+    def test_an_ic_route_is_dropped_beyond_the_first_segment(self):
+        problem, _spec, _free = build_stage(4)
+        experiment = problem.experiments[0]
+        first = problem._segment_routing(experiment, 0)
+        later = problem._segment_routing(experiment, 2)
+        assert [c.target for c in first.routes['y0'].contributions] == [IC]
+        assert later.routes['y0'].contributions == ()
+        # ...and the parameter route is untouched on both.
+        assert [c.target for c in later.routes['k'].contributions] == [PARAM]
+
+    def test_only_the_segments_own_block_routes_to_its_states(self):
+        problem, _spec, _free = build_stage(4)
+        routing = problem._segment_routing(problem.experiments[0], 2)
+        own = [name for name in routing.routes if name.startswith('exp1@1/2::')]
+        other = [name for name in routing.routes if name.startswith('exp1@1/4::')]
+        assert all(routing.routes[n].contributions for n in own)
+        assert all(routing.routes[n].contributions == () for n in other)
+
+    def test_a_fitted_initial_condition_reaches_the_first_continuity_row(self):
+        """Segment 0 keeps the ``IC`` route, so ``y0`` has a nonzero column in the first
+        knot's continuity block and a zero one in every later knot's."""
+        problem, _spec, _free = build_stage(4)
+        dense = problem.equality_at(perturbed(problem)).jacobian.to_dense()
+        y0 = problem.layout.reported_names.index('y0')
+        rows = {name: i for i, name in enumerate(problem.constraint_names)}
+        assert abs(dense[rows['exp1@1/4::y'], y0]) > 0.0
+        assert dense[rows['exp1@1/2::y'], y0] == pytest.approx(0.0)
+        assert dense[rows['exp1@3/4::y'], y0] == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# Certification
+# ---------------------------------------------------------------------------
+
+class TestCertification:
+
+    def test_certification_scores_the_unsegmented_reconstruction(self):
+        """The certificate is the ordinary single-shoot score of the reported parameters --
+        computed here independently of the transcription -- and *not* the augmented
+        objective, which at an infeasible point is computed on trajectories that do not
+        join up."""
+        times, obs = observations()
+        problem, _spec, _free = build_stage(4)
+        u = perturbed(problem)
+        reported = problem.layout.reported_of(u)
+        certificate = problem.certify(reported)
+        residual = (reported[1] * np.exp(reported[0] * times) - obs) / SIGMA
+        assert certificate.accepted and certificate.certified
+        assert certificate.objective == pytest.approx(0.5 * residual @ residual)
+        assert certificate.objective != pytest.approx(problem.objective_at(u).value)
+
+    def test_a_reconstruction_that_does_not_simulate_is_rejected(self):
+        backend = TwoStateBackend()
+        problem, _spec, _free = build_stage(4, backend=backend)
+        backend.fail_beyond = 0.5
+        certificate = problem.certify(np.array([1.5, 0.8]))
+        assert not certificate.accepted
+        assert 'did not simulate' in certificate.detail
+
+
+# ---------------------------------------------------------------------------
+# The inner solver, and the run
+# ---------------------------------------------------------------------------
+
+class TestGaussNewtonSolver:
+
+    def test_a_failed_segment_backs_the_search_off_rather_than_ending_the_fit(self):
+        """A non-integrable point is a property of the point: the local model comes back
+        non-finite, the trust region shrinks, and the solve returns an iterate."""
+        backend = TwoStateBackend()
+        problem, _spec, _free = build_stage(2, backend=backend)
+        backend.fail_beyond = 0.45
+        loop = AugmentedLagrangian(problem, GaussNewtonSolver(max_iterations=20), max_outer=4)
+        result = loop.run(problem.layout.initial_point([0.4, 0.8]))
+        assert np.all(np.isfinite(result.final_point))
+        assert result.stop_reason in ('converged', 'stalled', 'max_outer', 'unconstrained')
+
+    def test_the_outer_tolerance_reaches_the_inner_solver(self):
+        problem, _spec, _free = build_stage(2)
+        solver = GaussNewtonSolver(max_iterations=30)
+        subproblem_tolerances = []
+
+        class Recording(GaussNewtonSolver):
+            def __call__(self, subproblem, u0, tolerance):
+                subproblem_tolerances.append(tolerance)
+                return GaussNewtonSolver.__call__(self, subproblem, u0, tolerance)
+
+        loop = AugmentedLagrangian(problem, Recording(max_iterations=30), max_outer=3)
+        loop.run(problem.layout.initial_point([0.4, 0.8]))
+        assert subproblem_tolerances
+        assert all(t > 0 for t in subproblem_tolerances)
+        assert solver.n_evaluations == 0          # the shared counter is per instance
+
+
+class TestEquivalence:
+    """At convergence the constrained transcription is the uninterrupted fit.
+
+    Measured against a single-shoot optimum computed by ``scipy.least_squares`` on the
+    unsegmented residual -- an independent oracle, not this package's arithmetic run twice.
+    """
+
+    @pytest.mark.parametrize('n_segments', [2, 4])
+    def test_a_converged_stage_recovers_the_single_shoot_optimum(self, n_segments):
+        times, obs = observations()
+        target, target_objective = single_shoot_optimum(times, obs)
+        problem, _spec, _free = build_stage(n_segments, start_u=(0.55, 0.9))
+        loop = AugmentedLagrangian(problem, GaussNewtonSolver(max_iterations=60),
+                                   schedule=PenaltySchedule(), max_outer=25)
+        result = loop.run(problem.layout.initial_point([0.55, 0.9]))
+        assert result.best is not None
+        np.testing.assert_allclose(result.best.reported, target, rtol=1e-4, atol=1e-5)
+        assert result.best_score == pytest.approx(target_objective, rel=1e-6)
+
+    def test_a_log_scaled_fit_recovers_the_same_optimum(self):
+        """The realistic parameterisation -- a rate constant is normally a
+        ``loguniform_var`` -- so the search coordinate is ``log10(theta)`` and every column
+        of both the objective Jacobian and the continuity block carries a chain factor."""
+        times, obs = observations()
+        target, target_objective = single_shoot_optimum(times, obs)
+        base = (np.log10(0.55), np.log10(0.9))
+        problem, _spec, _free = build_stage(4, start_u=base, log_space=True)
+        loop = AugmentedLagrangian(problem, GaussNewtonSolver(max_iterations=60), max_outer=25)
+        result = loop.run(problem.layout.initial_point(list(base)))
+        assert result.best is not None
+        np.testing.assert_allclose(10.0 ** result.best.reported, target, rtol=1e-4, atol=1e-5)
+        assert result.best_score == pytest.approx(target_objective, rel=1e-6)
+
+    def test_it_converges_from_a_start_whose_knots_are_stale(self):
+        """The realistic case: seeding knots from a nominal trajectory makes the
+        transcription feasible at iteration zero, which is *not* the state a fit is in after
+        theta has moved."""
+        times, obs = observations()
+        target, _objective = single_shoot_optimum(times, obs)
+        problem, _spec, _free = build_stage(4, start_u=(0.55, 0.9))
+        u = perturbed(problem, base=(0.55, 0.9), knot_shift=0.8)
+        loop = AugmentedLagrangian(problem, GaussNewtonSolver(max_iterations=60), max_outer=25)
+        result = loop.run(u)
+        assert result.best is not None
+        np.testing.assert_allclose(result.best.reported, target, rtol=1e-3, atol=1e-4)
+
+
+class TestLadder:
+
+    def test_the_ladder_runs_and_reports_its_best_certified_iterate(self):
+        times, obs = observations()
+        target, target_objective = single_shoot_optimum(times, obs)
+        free = variables()
+        spec = make_spec(times, obs)
+        result = run_multiple_shooting([spec], ChiSquareObjective(), free,
+                                       pset_from_u_for(free), np.array([0.55, 0.9]))
+        assert [stage.name for stage in result.stages] == ['m=4', 'm=2', 'm=1']
+        assert result.certified
+        np.testing.assert_allclose(result.reported, target, rtol=1e-3, atol=1e-4)
+        assert result.best_score <= target_objective * (1 + 1e-6)
+        assert 'm=4' in result.trace() and 'm=1' in result.trace()
+
+    def test_a_rung_the_data_cannot_support_is_dropped_and_reported(self):
+        """No silent caps: a segment count above the experiment's own measurement count
+        would leave every segment determined by continuity alone."""
+        times, obs = observations(n=3)
+        spec = make_spec(times, obs)
+        rungs, dropped = feasible_ladder([spec], ladder=(8, 4, 2, 1))
+        assert rungs == (2, 1)
+        assert dropped == (8, 4)
+
+    def test_the_ladder_always_ends_unsegmented(self):
+        times, obs = observations(n=2)
+        spec = make_spec(times, obs)
+        rungs, _dropped = feasible_ladder([spec], ladder=(8,))
+        assert rungs[-1] == 1

--- a/tests/test_shooting_net.py
+++ b/tests/test_shooting_net.py
@@ -1,0 +1,322 @@
+"""Multiple shooting on the bngsim ``.net`` backend (#563/#577, ADR-0110).
+
+The `.net` peer of ``tests/test_shooting_sbml.py``. Everything above the simulator seam is
+shared and verified offline in ``tests/test_shooting.py``; what is specific here is the one
+thing that makes this backend different from its SBML sibling.
+
+**An experiment scores observables; a continuity row is a difference of species.** On the
+SBML path those are the same columns, so the consumer needed nothing extra. On the ``.net``
+path they are not: ``BngsimModel._build_data`` assembles ``time + observables + expressions``
+and the backend's sensitivity request names ``observable:`` / ``expression:`` selectors, so a
+segment simulation carries neither the state at the knot nor its derivative unless something
+asks. :mod:`pybnf.shooting.net_backend` asks — for **both** selector families, off one
+integration — and these tests hold it to that: the species columns are present *alongside*
+the observable ones, the tensor carries rows for both, and the value columns the objective
+scores are the net backend's own and unchanged.
+
+The rest mirrors the SBML module, because the properties are the same properties: a segment
+restarted from an overridden state rejoins the uninterrupted trajectory, the end-knot
+derivatives match the closed form, a transcription seeded from a continuous trajectory is
+feasible and scores its own single-shoot certificate, and the assembled gradient and
+continuity Jacobian match central differences through the real forward-sensitivity tensor.
+
+The fixture is ``e2e_ode_decay.net`` — one species ``S()`` seeded by parameter ``S0``, one
+rate ``k``, one observable ``Stot`` — whose flow ``S(t) = S0 e^{-kt}`` and both sensitivities
+are closed form. It exercises both routing axes: ``k`` on the parameter axis, ``S0`` on the
+initial-condition axis of ``S()``.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from pybnf._bngsim_caps import BNGSIM_HAS_OUTPUT_SENS
+from pybnf.bngsim_model import BngsimModel
+from pybnf.data import Data
+from pybnf.gradient import IC, PARAM, ExperimentRouting, ParamRoute
+from pybnf.objective import ChiSquareObjective
+from pybnf.pset import FreeParameter, MutationSet, PSet
+from pybnf.shooting import NetSegmentBackend, ShootingExperiment, seed_stage, trace_from_data
+
+from . import recovery_harness as H
+
+pytestmark = [
+    pytest.mark.bngsim,
+    pytest.mark.skipif(not BNGSIM_HAS_OUTPUT_SENS,
+                       reason='needs a bngsim build with the output_sensitivities feature'),
+]
+
+FIXTURES = Path(__file__).resolve().parent / 'bngl_files'
+TRUE_K = 0.3
+TRUE_S0 = 100.0
+HORIZON = 10.0
+SIGMA = 1.0
+STATE = 'S()'
+ACTION = 'simulate({method=>"ode",t_start=>0,t_end=>10,n_steps=>10,suffix=>"tc"})'
+
+
+def _pset(k=TRUE_K, s0=TRUE_S0):
+    return PSet([FreeParameter('k', 'uniform_var', 0.0, 1e6, value=k),
+                 FreeParameter('S0', 'uniform_var', 0.0, 1e6, value=s0)])
+
+
+def _backend(with_sensitivities=True):
+    """A :class:`~pybnf.shooting.net_backend.NetSegmentBackend` over the decay network."""
+    net = FIXTURES / 'e2e_ode_decay.net'
+    model = BngsimModel(net.stem, [ACTION], [('simulate', 'tc')], [], nf=str(net))
+    model.param_set = _pset()
+    if with_sensitivities:
+        model.enable_output_sensitivities(params=['k'], ic=[STATE])
+    from pybnf.bngsim_model.parsing import _parse_simulate_action
+    return NetSegmentBackend(model, _parse_simulate_action(ACTION), MutationSet(), 'tc'), model
+
+
+# ---------------------------------------------------------------------------
+# What makes this backend different: both selector families, one run
+# ---------------------------------------------------------------------------
+
+def test_a_segment_carries_observable_and_species_columns_together():
+    """The data terms read observables and the continuity block reads species, so one
+    segment's ``Data`` has to carry both — and the observable columns must be the net
+    backend's own, unchanged, or the fit would be scoring something else."""
+    backend, _model = _backend()
+    times = np.linspace(0.0, HORIZON, 11)
+    data = backend.simulate(_pset(), times, None)
+
+    assert 'Stot' in data.cols and STATE in data.cols
+    observable = np.asarray(data.data, dtype=float)[:, data.cols['Stot']]
+    species = np.asarray(data.data, dtype=float)[:, data.cols[STATE]]
+    expected = TRUE_S0 * np.exp(-TRUE_K * times)
+    np.testing.assert_allclose(observable, expected, rtol=1e-5, atol=1e-5)
+    np.testing.assert_allclose(species, expected, rtol=1e-5, atol=1e-5)
+
+    sens = data.output_sensitivities
+    assert 'observable:Stot' in sens.selectors        # what the data terms differentiate
+    assert 'species:%s' % STATE in sens.selectors     # what the continuity block does
+    assert sens.d_param is not None and sens.d_ic is not None
+    assert sens.d_param.shape[1] == len(sens.selectors)
+
+
+def test_the_end_knot_carries_both_sensitivity_axes():
+    """``d(end state)/d(start state)`` and ``d(end state)/d(theta)`` come off the same run
+    that produced the data rows. For ``S(t) = z e^{-k dt}``: ``dS/dz = e^{-k dt}`` and
+    ``dS/dk = -z dt e^{-k dt}``."""
+    backend, _model = _backend()
+    start, span, z = 4.0, 3.0, 42.0
+    data = backend.simulate(_pset(), np.linspace(start, start + span, 7), {STATE: z})
+    trace = trace_from_data(data, backend.state_names)
+
+    assert trace.ic_axis == (STATE,) and trace.param_axis == ('k',)
+    assert trace.end_state[0] == pytest.approx(z * np.exp(-TRUE_K * span), rel=1e-5)
+    assert trace.d_end_ic[0, 0] == pytest.approx(np.exp(-TRUE_K * span), rel=1e-5)
+    assert trace.d_end_param[0, 0] == pytest.approx(
+        -z * span * np.exp(-TRUE_K * span), rel=1e-5)
+
+
+def test_a_segment_restarted_from_an_overridden_state_rejoins_the_whole_trajectory():
+    """The property multiple shooting rests on, on a reaction network: cutting a trajectory
+    at a knot and restarting the second half from the state read off the first reproduces
+    the uninterrupted run. Both halves go through the backend's own reused simulator, so
+    this also pins that reusing it across a point's segments does not carry state."""
+    backend, _model = _backend()
+    pset = _pset()
+    times = np.linspace(0.0, HORIZON, 21)
+    whole = backend.simulate(pset, times, None)
+    knot = 10
+
+    first = backend.simulate(pset, times[:knot + 1], None)
+    restart = float(np.asarray(first.data, dtype=float)[-1, first.cols[STATE]])
+    second = backend.simulate(pset, times[knot:], {STATE: restart})
+
+    joined = np.asarray(second.data, dtype=float)[:, second.cols[STATE]]
+    reference = np.asarray(whole.data, dtype=float)[knot:, whole.cols[STATE]]
+    np.testing.assert_allclose(joined, reference, rtol=1e-6)
+
+
+def test_the_scalar_path_is_untouched():
+    """With no sensitivity request the segment still simulates, carrying its species columns
+    but no tensor — so nothing here depends on the gradient path being active."""
+    backend, _model = _backend(with_sensitivities=False)
+    data = backend.simulate(_pset(), np.linspace(0.0, 5.0, 6), None)
+    assert data.output_sensitivities is None
+    assert 'Stot' in data.cols and STATE in data.cols
+
+
+# ---------------------------------------------------------------------------
+# The transcription, through the real tensor
+# ---------------------------------------------------------------------------
+
+def test_a_transcription_seeded_from_a_continuous_trajectory_is_feasible():
+    problem = _stage(n_segments=4)
+    u = problem.layout.initial_point(_start_u())
+
+    assert problem.equality_at(u).defect_norm == pytest.approx(0.0, abs=1e-6)
+    segmented = problem.objective_at(u)
+    certificate = problem.certify(problem.layout.reported_of(u))
+    assert certificate.accepted
+    assert segmented.value == pytest.approx(certificate.objective, rel=1e-6)
+
+
+def test_the_assembled_gradient_matches_central_differences():
+    """The ``IC``-routed objective assembly and the continuity block, against central
+    differences, at a point whose knots are stale so the defects are nonzero — now with the
+    data terms reading an *observable* column while the continuity rows read a species."""
+    problem = _stage(n_segments=2)
+    u = problem.layout.initial_point(_start_u())
+    u[problem.layout.n_reported:] += 0.15
+
+    gradient = problem.objective_at(u).gradient
+    numeric = _central_difference(lambda x: problem.objective_at(x).value, u)
+    np.testing.assert_allclose(gradient, numeric[0], rtol=2e-4, atol=1e-5)
+
+    jacobian = problem.equality_at(u).jacobian.to_dense()
+    numeric_c = _central_difference(lambda x: problem.equality_at(x).residual, u)
+    np.testing.assert_allclose(jacobian, numeric_c, rtol=2e-4, atol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# The fit type resolves and accepts a .net model
+# ---------------------------------------------------------------------------
+
+def test_the_fit_type_accepts_a_net_model_and_resolves_its_action():
+    """The gate that used to refuse this backend by name now admits it, and the action
+    resolution finds the ``simulate()`` line behind the scored suffix (#577)."""
+    from pybnf.algorithms.optimizers.multiple_shooting import MultipleShootingAlgorithm as MS
+
+    _backend_unused, model = _backend()
+    MS._require_carryable_state(None, model)                    # does not raise
+    sim_params, mutant = MS._resolve_net_action(None, model, 'tc')
+    assert sim_params['suffix'] == 'tc' and mutant.suffix == ''
+    MS._require_simple_net_action(None, sim_params, 'tc')       # does not raise
+    from pybnf.algorithms.optimizers.multiple_shooting import _state_names
+    assert _state_names(model) == [STATE]
+
+
+def test_a_non_ode_or_continued_action_is_refused():
+    from pybnf.algorithms.optimizers.multiple_shooting import MultipleShootingAlgorithm as MS
+    from pybnf.printing import PybnfError
+
+    with pytest.raises(PybnfError, match='not deterministic ODE'):
+        MS._require_simple_net_action(None, {'method': '"ssa"', 'suffix': 'tc'}, 'tc')
+    with pytest.raises(PybnfError, match='continues from a previous'):
+        MS._require_simple_net_action(None, {'continue': '1', 'suffix': 'tc'}, 'tc')
+
+
+def test_the_state_sensitivity_request_is_widened_on_the_net_path():
+    """A species no free parameter binds still needs an ``ic`` column, on this backend as on
+    the SBML one — the request the ordinary gradient path builds is not the one multiple
+    shooting needs."""
+    from pybnf.algorithms.optimizers.multiple_shooting import MultipleShootingAlgorithm as MS
+
+    _unused, model = _backend(with_sensitivities=False)
+    model.enable_output_sensitivities(params=['k'], ic=[])
+    MS._request_state_sensitivities(None, model)
+    assert model._sensitivity_request.params == ['k']
+    assert STATE in model._sensitivity_request.ic
+
+
+def test_the_fit_type_builds_a_net_experiment_end_to_end(tmp_path):
+    """Setup only, in default CI: a real ``job_type = ms`` algorithm on a BNGL model builds
+    its segmented experiment through the ``.net`` backend, with the request widened to the
+    carried state — the path that used to be refused outright (#577)."""
+    H.require_bng2pl()
+    alg = H.build(_ms_net_config(tmp_path), 'ms')
+    alg._setup_gradient_path()
+    specs = alg._build_specs()
+
+    assert [spec.key for spec in specs] == [('e2e_ode_decay', 'decay')]
+    assert isinstance(specs[0].backend, NetSegmentBackend)
+    assert specs[0].backend.state_names == (STATE,)
+    for model in alg.model_list:
+        assert STATE in model._sensitivity_request.ic
+
+
+@pytest.mark.recovery
+def test_ms_recovers_the_decay_rate_and_initial_condition_on_a_net_model(tmp_path, monkeypatch):
+    """``job_type = ms`` end to end on a BNGL/``.net`` model: the coarsening ladder runs and
+    the best certified fit is the truth. The peer of the SBML recovery test, and the thing
+    that makes the ``.net`` path first-class rather than merely unrefused."""
+    H.require_bng2pl()
+    H.install(monkeypatch)
+    alg = H.build(_ms_net_config(tmp_path), 'ms')
+    H.drive(alg)
+
+    assert [stage.name for stage in alg.homotopies[0].stages] == ['m=4', 'm=2', 'm=1']
+    assert alg.homotopies[0].certified
+    rec = H.best_params(alg, ('k', 'S0'))
+    assert abs(rec['k'] - TRUE_K) / TRUE_K < 0.02
+    assert abs(rec['S0'] - TRUE_S0) / TRUE_S0 < 0.02
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _ms_net_config(tmp_path):
+    """A real edition-2 ``job_type = ms`` configuration over the BNGL decay model.
+
+    The model goes BNGL -> BNG2.pl -> ``.net`` -> ``BngsimModel``, so this is the genuine
+    net path rather than a hand-built model object. Zero-noise data, so the fit has an exact
+    answer to land on.
+    """
+    times = np.linspace(0.0, HORIZON, 11)
+    obs = TRUE_S0 * np.exp(-TRUE_K * times)
+    exp = Path(tmp_path) / 'decay.exp'
+    exp.write_text('\n'.join(
+        ['#\ttime\tStot\tStot_SD']
+        + ['%.12g\t%.12g\t%.12g' % (t, o, SIGMA) for t, o in zip(times, obs)]) + '\n')
+    model = H.strip_actions_block(FIXTURES / 'e2e_ode_decay.bngl',
+                                  Path(tmp_path) / 'e2e_ode_decay.bngl')
+    return H.make_newera_config(
+        tmp_path, model, str(exp),
+        {'k': ('uniform_var', 1e-2, 3.0), 'S0': ('uniform_var', 20.0, 400.0)},
+        'decay', 'ms', objective='chi_sq', random_seed=1234, population_size=1,
+        max_iterations=12)
+
+
+def _observations():
+    times = np.linspace(0.0, HORIZON, 11)
+    return times, TRUE_S0 * np.exp(-TRUE_K * times)
+
+
+def _start_u():
+    return [0.4, 120.0]          # both parameters are linear, so u == theta
+
+
+def _free():
+    return [FreeParameter('k', 'uniform_var', 0.01, 100.0, value=0.4),
+            FreeParameter('S0', 'uniform_var', 1.0, 1000.0, value=120.0)]
+
+
+def _stage(n_segments):
+    times, obs = _observations()
+    exp_data = Data.from_columns(
+        np.column_stack([times, obs, np.full(len(obs), SIGMA)]), ['time', 'Stot', 'Stot_SD'])
+    routing = ExperimentRouting(routes={
+        'k': ParamRoute.single('k', PARAM, 'k', 1.0),
+        'S0': ParamRoute.single('S0', IC, STATE, 1.0),
+    })
+    free = _free()
+    backend, _model = _backend()
+    spec = ShootingExperiment(('decay', 'tc'), backend, exp_data, routing, label='tc',
+                              start=0.0)
+
+    def pset_from_u(u):
+        return PSet([v.set_value(v.from_sampling_space(u[i])) for i, v in enumerate(free)])
+
+    return seed_stage([spec], n_segments, ChiSquareObjective(), free, pset_from_u,
+                      np.asarray(_start_u(), dtype=float))
+
+
+def _central_difference(fun, u, step=1e-5):
+    base = np.atleast_1d(np.asarray(fun(u), dtype=float))
+    out = np.zeros((len(base), len(u)))
+    for j in range(len(u)):
+        h = step * max(1.0, abs(u[j]))
+        up, down = np.array(u, dtype=float), np.array(u, dtype=float)
+        up[j] += h
+        down[j] -= h
+        out[:, j] = (np.atleast_1d(np.asarray(fun(up), dtype=float))
+                     - np.atleast_1d(np.asarray(fun(down), dtype=float))) / (2.0 * h)
+    return out

--- a/tests/test_shooting_sbml.py
+++ b/tests/test_shooting_sbml.py
@@ -1,0 +1,343 @@
+"""The multiple-shooting segment backend against a real bngsim SBML solve (#563, ADR-0110).
+
+:mod:`tests.test_shooting` verifies everything above the simulator seam against a
+closed-form backend. This module verifies the seam itself, and it checks the three
+primitives the #563 prototype had to establish before any of the rest was worth building --
+restated here as tests of PyBNF's own backend rather than of bngsim's:
+
+* a segment restarted from an **overridden state** partway through reproduces the
+  uninterrupted trajectory (the prototype measured ``4.2e-09`` relative on
+  ``Borghans_BiophysChem1997``);
+* the initial-condition sensitivity at a segment's end knot is ``d(end state)/d(start
+  state)`` -- the block the continuity Jacobian is built from, and the axis whose existence
+  the issue thread called "the long pole of the whole feature";
+* an ``m``-segment transcription seeded from a *continuous* trajectory has zero continuity
+  defect and the same data residuals as single shooting -- the prototype's ``validate.py``
+  gate, and the property that makes a stage feasible at its own iteration zero.
+
+The fixture is the exponential-decay SBML model ``tests/test_gradient_sbml.py`` uses
+(``dS/dt = -k S``, ``S(0) = S0``), whose flow and both sensitivities are closed form.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import pybnf.bngsim_sbml_model as bngsim_sbml_model
+from pybnf._bngsim_caps import BNGSIM_HAS_OUTPUT_SENS
+from pybnf.data import Data
+from pybnf.gradient import IC, PARAM, ExperimentRouting, ParamRoute
+from pybnf.objective import ChiSquareObjective
+from pybnf.printing import PybnfError
+from pybnf.pset import FreeParameter, MutationSet, PSet, TimeCourse
+from pybnf.shooting import (
+    BngsimSegmentBackend,
+    ShootingExperiment,
+    feasible_ladder,
+    seed_stage,
+    trace_from_data,
+)
+
+from . import recovery_harness as H
+
+pytestmark = [
+    pytest.mark.bngsim_sbml,
+    pytest.mark.skipif(not BNGSIM_HAS_OUTPUT_SENS,
+                       reason='needs a bngsim build with the output_sensitivities feature'),
+]
+
+TRUE_K = 0.3
+TRUE_S0 = 100.0
+HORIZON = 10.0
+SIGMA = 1.0
+
+_DECAY_SBML = """<?xml version="1.0" encoding="UTF-8"?>
+<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" level="3" version="1">
+  <model id="sbml_decay">
+    <listOfCompartments><compartment id="c" size="1" constant="true"/></listOfCompartments>
+    <listOfSpecies>
+      <species id="S" compartment="c" initialConcentration="100" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+    </listOfSpecies>
+    <listOfParameters><parameter id="k" value="0.3" constant="true"/></listOfParameters>
+    <listOfReactions>
+      <reaction id="deg" reversible="false" fast="false">
+        <listOfReactants><speciesReference species="S" stoichiometry="1" constant="true"/></listOfReactants>
+        <kineticLaw><math xmlns="http://www.w3.org/1998/Math/MathML"><apply><times/><ci>k</ci><ci>S</ci></apply></math></kineticLaw>
+      </reaction>
+    </listOfReactions>
+  </model>
+</sbml>"""
+
+
+def _pset(k=TRUE_K, s0=TRUE_S0):
+    return PSet([FreeParameter('k', 'uniform_var', 0.0, 1e6, value=k),
+                 FreeParameter('S', 'uniform_var', 0.0, 1e6, value=s0)])
+
+
+def _backend(tmp_path, k=TRUE_K, s0=TRUE_S0):
+    """A :class:`~pybnf.shooting.bngsim_backend.BngsimSegmentBackend` over the decay model,
+    with both sensitivity axes requested (the request the gradient path applies once per
+    fit)."""
+    xml = Path(tmp_path) / 'decay.xml'
+    xml.write_text(_DECAY_SBML)
+    action = TimeCourse({'time': str(HORIZON), 'step': '1'})
+    model = bngsim_sbml_model.BngsimSbmlModelNoTimeout(
+        str(xml), str(xml), pset=_pset(k, s0), actions=(action,))
+    model.enable_output_sensitivities(params=['k'], ic=['S'])
+    return BngsimSegmentBackend(model, action, MutationSet(), 'time_course'), model, action
+
+
+# ---------------------------------------------------------------------------
+# The three primitives
+# ---------------------------------------------------------------------------
+
+def test_a_segment_restarted_from_an_overridden_state_rejoins_the_whole_trajectory(tmp_path):
+    """The property multiple shooting rests on: cutting a trajectory at a knot and
+    restarting the second half from the state read off the first reproduces the
+    uninterrupted run."""
+    backend, _model, _action = _backend(tmp_path)
+    pset = _pset()
+    whole = backend.simulate(pset, np.linspace(0.0, HORIZON, 21), None)
+    times = np.asarray(whole['time'], dtype=float)
+    knot = int(np.searchsorted(times, 5.0))
+
+    first = backend.simulate(pset, times[:knot + 1], None)
+    restart = float(np.asarray(first['S'], dtype=float)[-1])
+    second = backend.simulate(pset, times[knot:], {'S': restart})
+
+    joined = np.asarray(second['S'], dtype=float)
+    reference = np.asarray(whole['S'], dtype=float)[knot:]
+    np.testing.assert_allclose(joined, reference, rtol=1e-7)
+
+
+def test_the_end_knot_carries_both_sensitivity_axes(tmp_path):
+    """``d(end state)/d(start state)`` and ``d(end state)/d(theta)`` come off the *same*
+    run that produced the data rows -- which is why the segment's output grid ends at its
+    knot rather than the span being simulated twice.
+
+    Both are checked against the closed form: for ``S(t) = z e^{-k dt}``,
+    ``dS/dz = e^{-k dt}`` and ``dS/dk = -z dt e^{-k dt}``.
+    """
+    backend, _model, _action = _backend(tmp_path)
+    start, span = 4.0, 3.0
+    z = 42.0
+    data = backend.simulate(_pset(), np.linspace(start, start + span, 7), {'S': z})
+    trace = trace_from_data(data, backend.state_names)
+
+    assert trace.ic_axis == ('S',) and trace.param_axis == ('k',)
+    assert trace.end_state[0] == pytest.approx(z * np.exp(-TRUE_K * span), rel=1e-6)
+    assert trace.d_end_ic[0, 0] == pytest.approx(np.exp(-TRUE_K * span), rel=1e-6)
+    assert trace.d_end_param[0, 0] == pytest.approx(
+        -z * span * np.exp(-TRUE_K * span), rel=1e-6)
+
+
+def test_a_transcription_seeded_from_a_continuous_trajectory_is_feasible(tmp_path):
+    """The prototype's own gate: seeded from a nominal trajectory, an ``m``-segment
+    transcription has zero continuity defect *and* byte-comparable data residuals to the
+    unsegmented fit -- so segmenting has not changed the fit, only how it is searched."""
+    backend, _model, _action = _backend(tmp_path)
+    problem = _stage(backend, n_segments=4)
+    u = problem.layout.initial_point(_start_u())
+
+    assert problem.equality_at(u).defect_norm == pytest.approx(0.0, abs=1e-6)
+    segmented = problem.objective_at(u)
+    certificate = problem.certify(problem.layout.reported_of(u))
+    assert certificate.accepted
+    assert segmented.value == pytest.approx(certificate.objective, rel=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# The assembled derivatives, through the real tensor
+# ---------------------------------------------------------------------------
+
+def test_the_assembled_gradient_matches_central_differences(tmp_path):
+    """The ``IC``-routed objective assembly and the continuity block, both against central
+    differences of the quantities they claim to differentiate -- now over a real
+    forward-sensitivity tensor rather than a closed-form one, at a point whose knots are
+    stale so the defects are nonzero."""
+    backend, _model, _action = _backend(tmp_path)
+    problem = _stage(backend, n_segments=2)
+    u = problem.layout.initial_point(_start_u())
+    u[problem.layout.n_reported:] += 0.15          # stale knots -> nonzero defects
+
+    gradient = problem.objective_at(u).gradient
+    numeric = _central_difference(lambda x: problem.objective_at(x).value, u)[0]
+    np.testing.assert_allclose(gradient, numeric, rtol=1e-4, atol=1e-5)
+
+    jacobian = problem.equality_at(u).jacobian.to_dense()
+    numeric_c = _central_difference(lambda x: problem.equality_at(x).residual, u)
+    np.testing.assert_allclose(jacobian, numeric_c, rtol=1e-4, atol=1e-5)
+
+
+def test_a_state_no_free_parameter_binds_still_gets_an_ic_column(tmp_path):
+    """The request the gradient path builds is not the request multiple shooting needs.
+
+    ``_setup_gradient_path`` asks for the initial-condition axis only where a free parameter
+    *is* a species' initial condition. Multiple shooting reads ``d(.)/d(z_j)`` for every
+    state it carries -- the continuity block is exactly that derivative -- so a state no
+    free parameter happens to seed would come back with no ``ic`` column and the assembly
+    would refuse mid-run. The fit type widens the request to every carried state.
+    """
+    from pybnf.algorithms.optimizers.multiple_shooting import MultipleShootingAlgorithm
+
+    xml = Path(tmp_path) / 'decay.xml'
+    xml.write_text(_DECAY_SBML)
+    action = TimeCourse({'time': str(HORIZON), 'step': '1'})
+    model = bngsim_sbml_model.BngsimSbmlModelNoTimeout(
+        str(xml), str(xml), pset=_pset(), actions=(action,))
+    # What a routing with no IC-bound free parameter would apply.
+    model.enable_output_sensitivities(params=['k'], ic=[])
+    backend = BngsimSegmentBackend(model, action, MutationSet(), 'time_course')
+    assert trace_from_data(backend.simulate(_pset(), np.linspace(0.0, 2.0, 3), None),
+                           backend.state_names).d_end_ic is None
+
+    MultipleShootingAlgorithm._request_state_sensitivities(None, model)
+    assert model._sensitivity_request.params == ['k']       # the parameter axis is kept
+    trace = trace_from_data(backend.simulate(_pset(), np.linspace(0.0, 2.0, 3), None),
+                            backend.state_names)
+    assert trace.ic_axis == ('S',)
+    assert trace.d_end_ic[0, 0] == pytest.approx(np.exp(-TRUE_K * 2.0), rel=1e-6)
+
+
+def test_one_simulator_is_reused_across_a_points_segments(tmp_path):
+    """The prototype's performance finding, made structural: constructing a
+    sensitivity-bearing simulator costs ~17 ms warm against ~50 ms for the integration, so
+    at ``m`` segments per evaluation construction would dominate. One engine model and one
+    simulator per parameter point; a new point builds a new pair."""
+    backend, _model, _action = _backend(tmp_path)
+    first = _pset()
+    backend.simulate(first, np.linspace(0.0, 5.0, 6), None)
+    prepared = backend._sim
+    backend.simulate(first, np.linspace(5.0, 10.0, 6), {'S': 20.0})
+    assert backend._sim is prepared
+    backend.simulate(_pset(k=0.35), np.linspace(0.0, 5.0, 6), None)
+    assert backend._sim is not prepared
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _observations():
+    times = np.linspace(0.0, HORIZON, 11)
+    return times, TRUE_S0 * np.exp(-TRUE_K * times)
+
+
+def _start_u():
+    return [0.4, 120.0]          # both parameters are linear, so u == theta
+
+
+def _stage(backend, n_segments):
+    times, obs = _observations()
+    exp_data = Data.from_columns(
+        np.column_stack([times, obs, np.full(len(obs), SIGMA)]), ['time', 'S', 'S_SD'])
+    routing = ExperimentRouting(routes={
+        'k': ParamRoute.single('k', PARAM, 'k', 1.0),
+        'S': ParamRoute.single('S', IC, 'S', 1.0),
+    })
+    free = [FreeParameter('k', 'uniform_var', 0.01, 100.0, value=0.4),
+            FreeParameter('S', 'uniform_var', 1.0, 1000.0, value=120.0)]
+    spec = ShootingExperiment(('decay', 'time_course'), backend, exp_data, routing,
+                              label='tc', start=0.0)
+
+    def pset_from_u(u):
+        return PSet([v.set_value(v.from_sampling_space(u[i])) for i, v in enumerate(free)])
+
+    return seed_stage([spec], n_segments, ChiSquareObjective(), free, pset_from_u,
+                      np.asarray(_start_u(), dtype=float))
+
+
+# ---------------------------------------------------------------------------
+# The fit type, end to end
+# ---------------------------------------------------------------------------
+
+def _ms_config(tmp_path, **overrides):
+    """A real edition-2 ``job_type = ms`` configuration over the decay SBML model.
+
+    Zero-noise data simulated from the model at its true parameters, so the fit has an
+    exact answer to land on. The decay model does not *need* multiple shooting -- it is
+    monotone, and single shooting fits it in a handful of iterations -- which is the point:
+    a method that changes the transcription has to reproduce the ordinary answer on a
+    problem where the ordinary transcription was never the difficulty.
+    """
+    xml = Path(tmp_path) / 'decay.xml'
+    xml.write_text(_DECAY_SBML)
+    action = TimeCourse({'time': str(HORIZON), 'step': '1'})
+    truth = bngsim_sbml_model.BngsimSbmlModelNoTimeout(
+        str(xml), str(xml), pset=_pset(), actions=(action,))
+    data = truth.execute(str(tmp_path), 'truth', 0)['time_course']
+    t = np.asarray(data['time'])
+    column = np.asarray(data['S'])
+    sd = max(0.02 * float(np.max(column)), 1e-6)
+    exp = Path(tmp_path) / 'tc.exp'
+    exp.write_text('\n'.join(
+        ['# time\tS\tS_SD'] + ['%.12g\t%.12g\t%.12g' % (ti, ci, sd)
+                               for ti, ci in zip(t, column)]) + '\n')
+
+    free = {'k': ('uniform_var', 1e-2, 3.0), 'S': ('uniform_var', 10.0, 300.0)}
+    return H.make_newera_config(
+        tmp_path, str(xml), str(exp), free, 'tc', 'ms', objective='chi_sq',
+        random_seed=1234, population_size=1, max_iterations=12, sbml_backend='bngsim',
+        **overrides)
+
+
+def test_the_fit_type_builds_its_experiments_and_widens_the_ic_request(tmp_path):
+    """Setup only, in default CI: a real ``job_type = ms`` algorithm resolves its scored
+    experiment to the right action, widens the sensitivity request to every carried state,
+    and builds one segmented experiment per scored output -- without running a fit."""
+    alg = H.build(_ms_config(tmp_path), 'ms')
+    alg._setup_gradient_path()
+    specs = alg._build_specs()
+
+    assert [spec.key for spec in specs] == [('decay', 'tc')]
+    assert specs[0].backend.state_names == ('S',)
+    for model in alg.model_list:
+        assert 'S' in model._sensitivity_request.ic     # widened past what the routing asked
+        assert model._scored_suffixes == {'tc'}
+    # The ladder the defaults ask for, ending unsegmented.
+    rungs, dropped = feasible_ladder(specs)
+    assert rungs == (4, 2, 1) and dropped == ()
+
+
+def test_the_fit_type_refuses_a_series_wide_transform(tmp_path):
+    """A normalized fit is refused up front, by name: a normalizer is computed over the
+    whole series, so the segments would be normalized differently from the fit that was
+    requested."""
+    alg = H.build(_ms_config(tmp_path, normalization='peak'), 'ms')
+    alg._setup_gradient_path()
+    with pytest.raises(PybnfError, match='normalizes its data'):
+        alg._build_specs()
+
+
+@pytest.mark.recovery
+def test_ms_recovers_the_decay_rate_and_initial_condition(tmp_path, monkeypatch):
+    """``job_type = ms`` end to end: the coarsening ladder runs, every certified iterate
+    lands in the ordinary trajectory at its ordinary single-shoot score, and the best fit
+    is the truth.
+
+    A tight assertion rather than a smoke bound -- a wrong continuity Jacobian or a
+    mis-routed auxiliary column would move the answer.
+    """
+    H.install(monkeypatch)
+    alg = H.build(_ms_config(tmp_path), 'ms')
+    H.drive(alg)
+
+    assert [stage.name for stage in alg.homotopies[0].stages] == ['m=4', 'm=2', 'm=1']
+    assert alg.homotopies[0].certified
+    rec = H.best_params(alg, ['k', 'S'])
+    assert abs(rec['k'] - TRUE_K) / TRUE_K < 0.02
+    assert abs(rec['S'] - TRUE_S0) / TRUE_S0 < 0.02
+
+
+def _central_difference(fun, u, step=1e-5):
+    base = np.atleast_1d(np.asarray(fun(u), dtype=float))
+    out = np.zeros((len(base), len(u)))
+    for j in range(len(u)):
+        h = step * max(1.0, abs(u[j]))
+        up, down = np.array(u, dtype=float), np.array(u, dtype=float)
+        up[j] += h
+        down[j] -= h
+        out[:, j] = (np.atleast_1d(np.asarray(fun(up), dtype=float))
+                     - np.atleast_1d(np.asarray(fun(down), dtype=float))) / (2.0 * h)
+    return out


### PR DESCRIPTION
Closes the consumer half of #563. ADR-0109 (#571) landed the reusable layer — an augmented variable layout, an equality residual/Jacobian interface, and an optimizer-agnostic augmented-Lagrangian outer loop with its homotopy and its certification — with no simulator call, no configuration key and no `fit_type`. This is what it takes to state *this* fit as that kind of problem, plus the `job_type = ms` that runs it. Recorded as ADR-0110.

Each scored experiment's time course is cut at knots. Segment *j* is integrated from its own start state — segment 0's is the model's own initial conditions, which are often fitted parameters, and each interior knot carries an auxiliary state `z_j` that is searched, bounded and differentiated but is **never** a reported fit result — and continuity `Phi_j(z_j, theta) - z_{j+1} = 0` is enforced by the augmented Lagrangian, whose subproblem is solved by `gntr`'s own Gauss-Newton trust-region step machine.

## A segment is an experiment

The consumer is small because of one structural finding the prototype established: a segment-start state enters the data fit as an `IC` route with chain-rule factor **1** (`sensitivity_ic` is `dy(t)/dy0`, and the transcription sets `y0` directly). So to `assemble_gradient_and_fisher_hessian` an auxiliary variable is an ordinary free parameter with an ordinary route, and the assembly already sums across experiments.

Each segment therefore becomes one item of its `experiments` list — its own simulated `Data`, its own slice of the observations, its own `ExperimentRouting`. The segmented data fit is the unsegmented one rearranged, and its gradient *and* Fisher block come out over the augmented column list in one pass. No second residual assembly and no new chain rule: a condition's factor, a multi-column route, a per-measurement formula and a profiled noise scale all reach a segment exactly as they reach an ordinary experiment, because it is the same code.

Two things the rearrangement has to get right, both structural rather than cosmetic:

* **Segment `j > 0` does not read the model's own initial conditions** — they were overridden by `z_j`. A reported free parameter that *is* a fitted initial condition has its `IC` contribution dropped from that segment's routing. Keeping it would credit `init_Z_state` with a derivative it does not have on `m - 1` of the `m` segments: a column scaled wrongly, which no fit can detect from its own objective. Segment 0 keeps it, which is how a fitted initial condition reaches the first continuity row.
* **Every *other* knot's block gets an empty route, not no route.** The assembly indexes routes by name into the augmented column list, so an absent block would leave an uninitialised column rather than a structural zero.

The continuity block is then the only new assembly surface, and its reported half is folded from the same routing the segment's data rows were assembled through — one helper, so a condition factor cannot reach the data and miss the constraints. Its rows are read off the *same run* that produced the data rows, because a segment's output grid ends at its knot: a segment costs one integration, not two.

## Knots are named by their exact fraction of the horizon

`carry_over` transfers an auxiliary block iff the next stage declares one of the same name and size, and the layer never learns what a knot is — so the naming is load-bearing. `<experiment>@<Fraction>` does it: at `m = 4` the knots are `1/4, 1/2, 3/4`; at `m = 2`, `1/2`; and `Fraction(2, 4) == Fraction(1, 2)`, so the surviving knot carries its solved state down the ladder while the others are discarded. Exact rationals rather than rounded floats, so `1/3` and `0.333333` can never be two names for one knot. If this breaks, the homotopy silently becomes three independent solves — the mechanism ADR-0109 finding 5.2 says the method rests on.

Placement is equal-time. The obvious refinements (knots at the data's quantiles, or at a nominal trajectory's features) place the transcription's structure using a trajectory the fit has not established, and on the motivating problem that trajectory is exactly what is in question.

## `job_type = ms` drives its own search

A segment is not a `PSet` evaluation: it is one span integrated from a state that is in no parameter set, and one augmented-model evaluation is `m` such spans whose forward sensitivities must be assembled together, on one machine, before a step can be taken — which is also why the layer's inner-solver contract is a blocking call. So `ms` overrides `run()`, as `job_type = hmc` does and for the same class of reason.

It does **not** fork the tail. `Algorithm.run`'s end-of-fit path is extracted verbatim as `_finalize_run()` and called unchanged, and every certified outer iterate is entered in the ordinary trajectory at its ordinary single-shoot score. `sorted_params`, the best-fit simulations, the information criteria, the profiled-noise report and the inference-data sidecar are produced by the same code every other fit type uses, from numbers that mean the same thing — and "report the best certified iterate, not the last" falls out of `trajectory.best_fit()` rather than needing a ranking rule of its own. A `-r` resume is refused rather than silently ignored.

The inner solver is `gntr`'s runner, not a new method. ADR-0109 measured that the choice is not free (60/60 converged for a trust-region least-squares solver against 36/60 for a quasi-Newton one), and `_GNTRRunner` is already a headless, backend-free step machine over exactly the `(gradient, PSD hessian)` pair the Gauss-Newton form provides. `pybnf/shooting/solver.py` is a driver; the step math is unchanged and not separately tuned. Its import is lazy — a library reaching into a fit type runs against the usual dependency direction and would close an import cycle — which also keeps `pybnf.shooting` importable on its own, and that is what lets the whole package be exercised against a closed-form backend with no fit type present.

## What it refuses, and why

Beyond the gradient path's own gates, three classes, each because segmenting would change *what is being fitted* rather than how it is searched:

* **a model with no enumerated state to restart from** — a network-free (NFsim) model never enumerates one, and a non-bngsim backend exposes neither the state nor its forward sensitivities. **Both bngsim paths are supported** (#577): see below;
* **an experiment that is not a plain measured time course** — a dose-response scan has no time axis to cut, a pre-equilibration protocol's measured phase already begins from a carried state, a steady-state relaxation has no fixed horizon;
* **a quantity that is a function of a whole series** — an analytic per-series scale, a data normalization, a cumulative-to-incident difference, BPSL constraints.

Each is refused up front and by name, pointing at `gntr`. A rung the data cannot support is dropped and **reported**, never silently capped.

An analytically profiled **noise scale** is deliberately not on that list, and it is the invariant the layer was built around: it is profiled over the pooled residuals of every supplied experiment, so cutting one series into `m` pieces pools exactly the same residuals and yields exactly the same `sigma_hat`. Since the constraint terms never enter `f`, an estimated sigma cannot absorb continuity violation as measurement noise and the certified score stays comparable to a single-shoot one.

## Both backends: `.net` is not second class (#577)

The first cut refused the `.net` path, on a reason that was wrong: that a rule-based model's observables are "sums over species, from which the state is not recoverable". They are not. A `.net` file is a fully expanded reaction network with the same kind of ODE state an SBML model has, and bngsim returns both its species trajectory and `d(species)/d(species_0)` when asked — a mixed selector list comes back from **one** run:

```
output_sensitivities(['observable:Stot', 'species:S()'], axis='parameter')  ->  (11, 2, 1)
output_sensitivities(['observable:Stot', 'species:S()'], axis='ic')         ->  (11, 2, 1)
```

The asymmetry that actually mattered is one level down, and is the whole of what the second backend exists for: **on the SBML path the columns an experiment scores and the columns a continuity row differences are the same columns; on the `.net` path they are not.** `_build_data` assembles `time + observables + expressions` and the net backend's sensitivity request names `observable:` / `expression:` selectors, so a segment carried neither the state at the knot nor its derivative — because nothing asked.

`pybnf/shooting/net_backend.py` asks, for both families together: one tensor over the observable/expression rows the data terms read and the species rows the continuity block reads, requested in a single call so a segment is still **one integration**. The segment's `Data` carries species columns alongside the observable ones, with a collision refused rather than silently overwritten — a species column shadowing an observable would change what the fit scores. Nothing in the net backend is modified; this composes its existing pieces (`_build_data`, the engine clone, `_get_mutant_model_bngsim`, the species-initializer sync) from outside, so every ordinary `.net` fit is byte-identical.

The fit type now dispatches on what a simulation returns rather than refusing by backend. What stays refused is a model with no enumerated state at all, and the message says that instead of implying the model has none.

**The one cost that is genuinely the model's property**: the auxiliary block is `(m-1) × n_species` and the initial-condition sensitivity system is `n_species` wide, so the transcription scales with the *expanded* species count rather than the fitted-parameter count — `egfr_ground.net` (356 species) at `m = 4` adds ~1068 auxiliary variables. A run now prints how many it is adding as it starts, so the cost is visible before it is paid; a size policy is left to measurement.

## Simulator reuse

Constructing a sensitivity-bearing `Simulator` costs ~17 ms warm against ~50 ms for the integration, so at `m` segments per evaluation construction would dominate — and mutating the model behind an existing one and `save_concentrations()` + `reset()`-ing gives bit-identical states *and* sensitivities. The backend keeps one engine model and one simulator per parameter point and restarts them at each knot. The restart is what distinguishes this from the pre-equilibration protocol (ADR-0052/0104), which runs its second phase on the same simulator *without* a reset precisely so the state carries over. A segment that does not integrate is handed back as a failed segment, not an error: the local model comes back non-finite, the trust region shrinks, the search backs off, and the rest of that point's segments are skipped.

## Two defects the tests caught

* **The sensitivity request was too narrow.** The gradient path asks for an `ic` column only where a free parameter *is* a species' initial condition. Multiple shooting reads `d(.)/d(z_j)` for every state it carries — the continuity block is exactly that derivative — so a state no free parameter happens to seed would have come back with no `ic` column and the assembly would have refused mid-run. `ms` now widens the request to every carried state, with its own regression guard: the rest of the suite could not see this, because its one species happens to be a fitted initial condition.
* **The `d theta/d u` factor is applied in two places** — by the gradient assembly for the objective's columns, by this package for the continuity block's. It is 1 for a linear parameter, so a linear-only test cannot distinguish a correct second application from a missing one. Every derivative test now runs in both parameterisations.

## Verification

**`tests/test_shooting.py`** — 30 tests, no simulator, ~3 s, against a closed-form backend for `y' = ky`, `w' = -kw` with only `y` observed. That last part is the point: `w` carries no data term, so half the auxiliary variables are determined by continuity alone — the motivating problem's hard corner at a size that can be checked exactly. It pins:

* the knot naming (a coarser stage's knots are a subset of a finer one's *by name*; a solved knot survives `carry_over` at its solved value);
* the objective gradient, the constraint Jacobian, and the whole augmented gradient at nonzero multipliers and a raised penalty — all against central differences at a point whose knots are deliberately stale, so the `-I` half of the continuity block is tested against something other than zero, and all in both parameterisations;
* the `IC`-route rule (present on segment 0, empty after it; a nonzero column in the *first* knot's continuity block, exactly zero in the rest);
* the unobserved-state corner (exactly zero objective gradient, nonzero continuity columns — both halves have to hold, or the fit is silently unconstrained in them);
* feasibility at iteration zero, and certification through the ordinary path rather than the augmented objective;
* the load-bearing claim — at convergence the transcription is the uninterrupted fit — measured against a single-shoot optimum computed **independently** by `scipy.least_squares`, from nominal and from a start whose knots are stale by a large factor.

**`tests/test_shooting_sbml.py`** — 9 tests through a real bngsim SBML solve. Three are the prototype's own primitives restated as tests of PyBNF's backend: a segment restarted from an overridden state at `t = 5` rejoins the uninterrupted trajectory to `1e-7` relative; the end-knot `d_ic` and `d_param` match the closed form; a transcription seeded from a continuous trajectory has zero continuity defect *and* an objective equal to its own single-shoot certificate. Plus the assembled gradient and continuity Jacobian against central differences through the real forward-sensitivity tensor, the simulator-reuse invariant, and the request-widening guard.

**End to end**, through the real `Configuration` and the real end-of-fit path: `job_type = ms` recovers `k` and `S(0)` from zero-noise data to better than 2 %, running the `4-2-1` ladder and reporting a certified objective of `4.5e-12`. A tight assertion rather than a smoke bound — a wrong continuity Jacobian or a mis-routed auxiliary column would move the answer. The decay model does not *need* multiple shooting, which is the point: a method that changes the transcription has to reproduce the ordinary answer on a problem where the ordinary transcription was never the difficulty. Its setup half runs in default CI; the fit itself is in the opt-in `recovery` tier.

**`tests/test_shooting_net.py`** — 11 tests, the `.net` peer. Its own three primitives (a mid-trajectory restart rejoining to `1e-6`, the end-knot `d_ic` / `d_param` against the closed form, a feasible seeded transcription scoring its own certificate); the assembled gradient and continuity Jacobian against central differences through the real tensor; and the property specific to this backend — one segment's `Data` carries observable *and* species columns, its tensor carries both selector families, and the observable columns match the analytic decay (a segment that quietly rescored something else would still look self-consistent). Plus the scalar path staying tensor-free, the action resolution and its refusals, and the request widening. **End to end**: `job_type = ms` on a BNGL model — BNGL → BNG2.pl → `.net` → `BngsimModel` — recovering `k` and `S(0)` to better than 2 %, ladder `4-2-1`, certified `1.16e-12`.

Run against **bngsim 0.13.0**, the current PyPI release and what CI resolves (`uv.lock` is gitignored and had this machine pinned to 0.12.2, so the branch's first numbers were from the older build): default CI suite **3919 passed / 20 skipped**, `-m recovery` **139 passed / 4 skipped**, `ruff` clean, `sphinx-build -W --keep-going` clean.

## Config surface

New keys `ms_segments`, `ms_coarsening`, `ms_penalty`, `ms_penalty_growth`, `ms_max_penalty`, `ms_feasibility_tol`, `ms_optimality_tol`, `ms_inner_iterations`, `ms_aux_decades`, and the runtime-guarded `ms_max_iterations` — defaulted from ADR-0109's measurements rather than from taste: the ladder starts in the **middle** (`4-2-1`), the penalty schedule starts **tight** (`rho_0 = 10`, `gamma = 5`), and the optimality tolerance is looser than `gntr`'s because it measures the *augmented* Lagrangian's gradient, which carries a factor of `rho`. Documented in `docs/gradient_fitting.rst`.

No behaviour change to any existing fit. `pybnf/transcription` gains its first consumer and nothing in it changed.

## What this does not claim

That multiple shooting improves the typical fit (48 paired convergence-region starts: **24–24**, medians tied at every radius, at 2–7x the simulations), or that it solves Borghans from an uninformed start (0/24 either way). The measured case is the **tail** and the **robustness**, and the acceptance benchmark — framed on those rather than on the median they did not move — is the next piece of work, along with parallel segment simulation, condensing, point-dependent chain-rule factors (#530), and resume. Segments are simulated serially on the master in this cut; stated in the ADR rather than left to be discovered.
