### PR TITLE
fix(shooting): job_type = ms scored a cached segment trajectory twice, so any formula observable killed the fit (#578)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ All notable changes to PyBNF are documented below. This project adheres to
 ## [Unreleased]
 
 ### Fixed
+- **`job_type = ms` no longer dies on a fit with a measurement-model formula observable (#578).**
+  Multiple shooting was unusable on essentially the whole PEtab-imported corpus — including its
+  own motivating problem, `Borghans_BiophysChem1997` — failing on the first outer iteration with
+  `Measurement model 'Ca' would shadow an existing simulation-output column`. The setup was all
+  correct (noise profiling, the `4-2-1` ladder, knot placement); it died the moment the loop
+  asked for a second evaluation.
+  The measurement layer materializes each `observable: <id>, formula: ...` column *into the
+  trajectory in place* (ADR-0036) and deliberately refuses a column that already exists. Every
+  ordinary fit satisfies that for free, because the propose/score loop scores a freshly
+  simulated `Data` every time. Multiple shooting caches its segment trajectories per point — so
+  that one augmented-model evaluation costs one pass of segment simulations rather than two —
+  and the outer loop then re-evaluates at the point the inner solver finished at, which is a
+  cache hit on those very objects.
+  Fixed at the cause: the assembled objective is now memoized on the point, so each simulated
+  trajectory is scored exactly once. That also removes a redundant gradient/Fisher assembly per
+  outer iteration, the larger of the two costs. Sound because the objective at a point does not
+  depend on the multipliers — only the augmented model combines them.
+  The shooting suite structurally could not see this: its fixtures score native columns (a
+  species, an observable), so the measurement layer never ran. The regression tests use a
+  formula-observable fixture, and both fail with the exact production error when the memo is
+  removed.
 - **`job_type = check` runs again (#569).** #564's method-chain record was built from
   `alg.res_dir` on a line that ran before the `job_type != 'check'` branch nine lines below it, so
   every check run died in setup with `AttributeError: 'ModelCheck' object has no attribute

--- a/pybnf/shooting/problem.py
+++ b/pybnf/shooting/problem.py
@@ -231,6 +231,12 @@ class MultipleShootingProblem(TranscriptionProblem, EqualitySystem):
 
         self._cache_key = None
         self._cache = None
+        # The assembled objective at the last point asked for. Separate from the trace cache
+        # above because it must survive an interleaved `equality_at` at another point, and
+        # because it is what guarantees each simulated trajectory is scored once (#578; see
+        # :meth:`objective_at`).
+        self._objective_key = None
+        self._objective_model = None
         self.n_certifications = 0
 
     # -- identity ---------------------------------------------------------------
@@ -331,6 +337,37 @@ class MultipleShootingProblem(TranscriptionProblem, EqualitySystem):
     # -- the objective ----------------------------------------------------------
 
     def objective_at(self, u):
+        """The fit's objective and its derivatives at ``u``, memoised on the point.
+
+        The memo is not an optimisation first — it is what keeps this method **scoring each
+        simulated trajectory exactly once** (#578). Scoring goes through
+        ``objective.evaluate_multiple``, which asks the measurement layer to materialise
+        every ``observable: <id>, formula: ...`` column *into the trajectory in place*
+        (ADR-0036), and that materialisation deliberately refuses a column that already
+        exists. Every ordinary fit satisfies it for free: the propose/score loop scores a
+        freshly simulated :class:`~pybnf.data.Data` each time. Multiple shooting does not,
+        because :meth:`_traces` caches the segment trajectories per point so that one
+        augmented-model evaluation costs one pass of segment simulations rather than two --
+        and the outer loop then re-evaluates at the point the inner solver finished at, which
+        is a cache hit on the very same objects.
+
+        Memoising the assembled model rather than copying the trajectories fixes that at the
+        cause: the second call returns the first call's answer instead of re-scoring
+        anything. It also removes a redundant gradient/Fisher assembly per outer iteration,
+        which is the larger of the two costs. Sound because this method does not depend on
+        the multipliers -- only
+        :class:`~pybnf.transcription.augmented.AugmentedModel` combines them -- so the
+        objective at a point is a property of the point alone.
+        """
+        u = np.asarray(u, dtype=float).reshape(-1)
+        key = u.tobytes()
+        if self._objective_key == key:
+            return self._objective_model
+        model = self._build_objective(u)
+        self._objective_key, self._objective_model = key, model
+        return model
+
+    def _build_objective(self, u):
         cached = self._traces(u)
         if cached is None:
             return self._unusable_objective()

--- a/tests/test_shooting_sbml.py
+++ b/tests/test_shooting_sbml.py
@@ -252,7 +252,7 @@ def _stage(backend, n_segments):
 # The fit type, end to end
 # ---------------------------------------------------------------------------
 
-def _ms_config(tmp_path, **overrides):
+def _ms_config(tmp_path, observables=None, obs_column='S', **overrides):
     """A real edition-2 ``job_type = ms`` configuration over the decay SBML model.
 
     Zero-noise data simulated from the model at its true parameters, so the fit has an
@@ -260,6 +260,10 @@ def _ms_config(tmp_path, **overrides):
     monotone, and single shooting fits it in a handful of iterations -- which is the point:
     a method that changes the transcription has to reproduce the ordinary answer on a
     problem where the ordinary transcription was never the difficulty.
+
+    ``observables`` routes the fit through a **measurement-model formula** column (ADR-0036)
+    instead of scoring the species directly -- the path #578 broke, and the one this
+    module's other fixtures never take.
     """
     xml = Path(tmp_path) / 'decay.xml'
     xml.write_text(_DECAY_SBML)
@@ -268,18 +272,19 @@ def _ms_config(tmp_path, **overrides):
         str(xml), str(xml), pset=_pset(), actions=(action,))
     data = truth.execute(str(tmp_path), 'truth', 0)['time_course']
     t = np.asarray(data['time'])
-    column = np.asarray(data['S'])
+    species = np.asarray(data['S'])
+    column = 2.0 * species if observables else species
     sd = max(0.02 * float(np.max(column)), 1e-6)
     exp = Path(tmp_path) / 'tc.exp'
     exp.write_text('\n'.join(
-        ['# time\tS\tS_SD'] + ['%.12g\t%.12g\t%.12g' % (ti, ci, sd)
-                               for ti, ci in zip(t, column)]) + '\n')
+        ['# time\t%s\t%s_SD' % (obs_column, obs_column)]
+        + ['%.12g\t%.12g\t%.12g' % (ti, ci, sd) for ti, ci in zip(t, column)]) + '\n')
 
     free = {'k': ('uniform_var', 1e-2, 3.0), 'S': ('uniform_var', 10.0, 300.0)}
     return H.make_newera_config(
         tmp_path, str(xml), str(exp), free, 'tc', 'ms', objective='chi_sq',
         random_seed=1234, population_size=1, max_iterations=12, sbml_backend='bngsim',
-        **overrides)
+        observables=observables, **overrides)
 
 
 def test_the_fit_type_builds_its_experiments_and_widens_the_ic_request(tmp_path):
@@ -298,6 +303,54 @@ def test_the_fit_type_builds_its_experiments_and_widens_the_ic_request(tmp_path)
     # The ladder the defaults ask for, ending unsegmented.
     rungs, dropped = feasible_ladder(specs)
     assert rungs == (4, 2, 1) and dropped == ()
+
+
+def test_a_formula_observable_is_scored_once_per_simulated_trajectory(tmp_path):
+    """A scored column that is a **measurement-model formula** (ADR-0036) is materialised
+    into the trajectory *in place*, and materialising it twice is refused by design. Every
+    ordinary fit satisfies that for free -- the propose/score loop scores a freshly
+    simulated ``Data`` each time -- but multiple shooting caches its segment trajectories
+    per point, and the outer loop re-evaluates at the point the inner solver finished at.
+    Before #578 the second evaluation re-scored the same objects and the whole fit died with
+    "would shadow an existing simulation-output column".
+
+    This is the regression the rest of the shooting suite structurally cannot see: its
+    fixtures score native columns (a species, an observable), so the measurement layer never
+    runs at all. Here the scored column is ``Ca = 2*S``, so it does.
+    """
+    pytest.importorskip('petab')       # the measurement layer needs the formula math extra
+    alg = H.build(_ms_config(tmp_path, observables={'Ca': '2*S'}, obs_column='Ca'), 'ms')
+    alg._setup_gradient_path()
+    problem = seed_stage(alg._build_specs(), 2, alg.objective, alg.variables,
+                         alg._pset_from_u, alg._param_vec(alg.start_psets[0]))
+    u = problem.layout.initial_point(alg._param_vec(alg.start_psets[0]))
+
+    first = problem.objective_at(u)
+    second = problem.objective_at(u)          # the call that used to raise
+    assert np.isfinite(first.value)
+    assert second.value == first.value
+    np.testing.assert_array_equal(second.gradient, first.gradient)
+
+
+def test_a_formula_observable_survives_the_outer_loop(tmp_path):
+    """The same defect, through the loop that actually triggers it: the outer loop's
+    re-evaluation at the inner solver's final iterate is a cache hit on already-scored
+    trajectories. Runs a couple of outer iterations rather than asserting a fit quality --
+    what is under test is that the run proceeds at all."""
+    pytest.importorskip('petab')
+    from pybnf.shooting import GaussNewtonSolver
+    from pybnf.transcription import AugmentedLagrangian
+
+    alg = H.build(_ms_config(tmp_path, observables={'Ca': '2*S'}, obs_column='Ca'), 'ms')
+    alg._setup_gradient_path()
+    start = alg._param_vec(alg.start_psets[0])
+    problem = seed_stage(alg._build_specs(), 2, alg.objective, alg.variables,
+                         alg._pset_from_u, start)
+    loop = AugmentedLagrangian(problem, GaussNewtonSolver(max_iterations=8), max_outer=3)
+    result = loop.run(problem.layout.initial_point(start))
+
+    assert result.iterates                      # it got past the first outer iteration
+    assert result.best is not None and np.isfinite(result.best_score)
 
 
 def test_the_fit_type_refuses_a_series_wide_transform(tmp_path):


### PR DESCRIPTION
Fixes #578. Standalone hotfix ahead of the #563 acceptance-benchmark work, since every multiple-shooting arm of that benchmark runs on Borghans and none of them could start.

## The symptom

`job_type = ms` was unusable on essentially the whole PEtab-imported corpus — including the problem it was built for. Every such fit died on the first outer iteration:

```
Error: Measurement model 'Ca' would shadow an existing simulation-output column of the same
name (columns: ['A_state', 'Ca', 'Y_state', 'Z_state', 'time']).
```

Everything before that point was correct — noise profiling, the `4-2-1` ladder, knot placement — which is what made it read as a configuration problem rather than a defect.

## The cause

The measurement layer materializes each `observable: <id>, formula: ...` column into the trajectory **in place** (ADR-0036), and `_add_column` deliberately refuses a column that already exists. That guard is right, and every ordinary fit satisfies it for free: the propose/score loop hands the objective a freshly simulated `Data` on every evaluation, so `apply` runs exactly once per object.

Multiple shooting breaks that assumption, for a good reason. `MultipleShootingProblem` caches each segment's simulated `Data` per point, so one augmented-model evaluation costs one pass of segment simulations rather than two — `objective_at` and `equality_at` are asked for the same point by `AugmentedSubproblem.at`, and a segment simulation is the expensive thing here. The outer loop then re-evaluates at the point the inner solver finished at, which is a cache hit on already-materialized trajectories, and the second `apply` raises.

## The fix

Memoize the assembled `ObjectiveModel` on the point, so each simulated trajectory is scored exactly once.

Copying the trajectories before scoring would also have worked, but it pays an array copy per segment per evaluation to buy back a call that should not be happening — and that redundant call was re-running a full gradient/Fisher assembly every outer iteration, which is the larger of the two costs. Memoizing is sound because the objective at a point does not depend on the multipliers: only `AugmentedModel` combines them, so the objective is a property of the point alone.

## Why the suite could not see it

This is the more useful half. Neither shooting fixture goes through the measurement layer at all — `test_shooting_sbml.py` scored the species column `S` directly, and `test_shooting_net.py` scores the native observable `Stot` — so no formula column is ever materialized and the double call is harmless. 51 tests, none of which *could* fail.

The two regression tests here use a formula-observable fixture (`observable: Ca, formula: 2*S`): one exercising the direct double evaluation, one the outer loop that actually triggers it. Both fail with the exact production error when the memo is removed, which is how they were checked:

```
FAILED test_a_formula_observable_is_scored_once_per_simulated_trajectory
FAILED test_a_formula_observable_survives_the_outer_loop
E   PybnfError: Measurement model 'Ca' would shadow an existing simulation-output column ...
```

## Verification

Beyond the suite, the smoke run that surfaced this now completes. `job_type = ms` on Borghans, from the box centre with a 240 s budget, runs the whole ladder in 30 s:

```
Multiple-shooting ladder: 4-2-1
  finest rung adds 9 internal auxiliary variable(s) to this fit's 22 free parameter(s)
  m=4: scaled defect 0.0241,  best certified objective -166.72   (157 evaluations)
  m=2: scaled defect 0.00445, best certified objective -167.234  (156 evaluations)
  m=1: scaled defect 0,       best certified objective -167.242  (10 evaluations)
Profiled noise scale(s) at the best fit: sigma=0.134434
```

— and writes its information criteria and profiled sigma like any other fit. That score is the no-dynamics region every method reaches on this problem from an uninformed start; the acceptance benchmark is separate work and nothing here claims otherwise.

Full suite **3921 passed / 20 skipped** against bngsim 0.13.0, `ruff` clean.
