### PR TITLE
feat(shooting): parallel segment lanes, per-knot continuity defects, and the knot placements #563 asked for -- plus ms as a refiner, so its benchmark's fourth arm exists (#563, ADR-0111)

### DIFF
--- a/docs/adr/0111-a-parallel-segment-costs-an-engine-not-a-thread-so-the-scheduler-ships-measured-and-off-by-default-and-a-knots-name-is-its-ordinal-not-its-position-so-any-placement-rule-carries-down-the-ladder.md
+++ b/docs/adr/0111-a-parallel-segment-costs-an-engine-not-a-thread-so-the-scheduler-ships-measured-and-off-by-default-and-a-knots-name-is-its-ordinal-not-its-position-so-any-placement-rule-carries-down-the-ladder.md
@@ -1,0 +1,270 @@
+# A parallel segment costs an *engine*, not a thread, so the scheduler ships measured and off by default — and a knot's name is its **ordinal**, not its position, so any placement rule carries down the ladder (issue #563)
+
+**Status: Accepted and implemented (2026-08-14).** ADR-0109 landed the reusable
+constrained-transcription layer and ADR-0110 the multiple-shooting consumer. This is the
+remainder of what issue #563's *implementation proposal* asks for and neither shipped:
+parallel segment simulation, scaled continuity defects reported per knot, and
+equal-observation or explicit knots alongside the equal-time default. It also registers `ms`
+as a refiner, which is what makes the fourth arm of the issue's acceptance benchmark
+runnable at all.
+
+Nothing here changes what a multiple-shooting fit computes. Every default is chosen so an
+existing configuration produces the same numbers it produced before, and the two claims that
+could break that — that lanes do not change the answer, and that a coarser rung recognises a
+finer rung's knot under every placement — are tested rather than asserted.
+
+## 1. Parallel segment simulation
+
+> "Segment simulations can run in parallel." — #563
+
+They are the one embarrassingly parallel thing in the method: one augmented-model evaluation
+is `m` spans of one trajectory, each integrated from a state the transcription already knows,
+with no data flowing between them. ADR-0110 stated rather than discovered that it shipped
+serial. This adds the scheduler — and the interesting part turned out to be the cost model,
+not the concurrency.
+
+### Threads, because the integration releases the GIL
+
+Measured rather than assumed, on the motivating model itself (`Borghans_BiophysChem1997`:
+3 species, 21 sensitivity parameters, both axes requested). Four warm engine+simulator
+replicas driven from four threads:
+
+| | 160 segment integrations | per segment |
+|---|---:|---:|
+| serial | 0.153 s | 0.96 ms |
+| 4 threads | 0.057 s | 0.36 ms |
+
+**2.7× on 4 workers**, and every trajectory column and every entry of `d(y)/d(theta)` came
+back *bit-identical* — `max |threaded − serial| = 0`, not "agrees to 1e-12". So bngsim drops
+the GIL inside CVODE and the arithmetic above the seam does not have to learn that a
+scheduler exists.
+
+Processes were never a real option. A segment costs one integration, and the #563 prototype
+measured a sensitivity-bearing simulator at ~230 ms cold against ~50 ms for an integration; a
+process pool would pay that per worker per point, or pay to pickle an engine model, which does
+not pickle. That is the same measurement that made `SegmentBackend` keep warm state per
+parameter point in the first place.
+
+### A lane is an engine model, and that is what decides the default
+
+Two segments cannot share one `Simulator`. The backend restarts it from the knot's state with
+`save_concentrations()` + `reset()`, so a second segment on the same object would integrate
+from the first's start state. A *lane* is therefore an independent engine+simulator pair, and
+running `L` segments at once needs `L` of them **at that parameter point** — so the point pays
+`L` preparations instead of one.
+
+That is the whole cost model:
+
+```
+  parallel wins when   (m - 1) * t_integrate  >  (L - 1) * t_prepare
+```
+
+and on the motivating problem it **loses**. Measured on Borghans: `t_prepare` ≈ 4.1 ms,
+`t_integrate` ≈ 1–2.3 ms. At `m = L = 4` the extra lanes cost more than the integrations they
+save. The model is simply too small — three species — for the thing being parallelised to be
+the expensive thing.
+
+So `ms_parallel_segments` defaults to **1**, and the default carries a measurement rather than
+a preference, like every other default in this feature. Both terms move with the *model*
+rather than with the fit, and they do not move together: the initial-condition sensitivity
+system is `n_species` wide, so a segment's integration grows with the state while preparing a
+lane does not grow as fast. The crossover is a property of the model, which is why this is a
+key and not a decision made once here.
+
+Stating the loss is the point. Shipping this on by default would have made the motivating
+problem's own benchmark slower while looking like an optimisation.
+
+### What parallel gives up, stated rather than discovered
+
+The serial pass stops at the first segment that fails to integrate — the rest of that point's
+segments are work whose answer is already decided, which is what keeps a search that has
+wandered into a non-integrable corner from paying `m` simulations per rejected trial. A
+submitted future cannot be un-run, so the parallel pass pays all `m`. The **answer** is
+identical; the **simulation count** a run reports is not, and on a multi-start sweep over an
+uninformed box — where most points do not integrate, and which is exactly the acceptance
+benchmark's regime — that difference is the dominant cost.
+
+### The seam
+
+`SegmentBackend.open_lanes(pset, n)` prepares up to `n` contexts and returns how many it has;
+`simulate(..., lane=k)` runs in one. The default implementation offers one lane, so a backend
+that has no notion of them is correct without changing.
+
+Preparation happens on the **calling thread**, before any worker starts, because that is the
+only place a backend writes to the model it owns (the parameter set, the action suffix). The
+integration path itself was checked to be read-only on the model — no `self.<attr> =` in
+`_run_simulation`, `_result_to_data` or `_run_tolerance_kwargs` — which is what makes threads
+sound here rather than merely observed to work.
+
+A lane is claimed for the whole of one integration through a per-backend queue, not by a
+modulo of the task index: with more segments than lanes, a worker must **wait** for a lane
+rather than two workers sharing one simulator and each integrating from the other's start
+knot. A failed segment drops *its* lane rather than the whole point's, because a parallel pass
+has other segments still running in the others.
+
+`pybnf/shooting/parallel.py` owns all of this. `MultipleShootingProblem._traces` now says
+*which* spans from *which* states and hands them over; whether they run one at a time or
+several at once is a scheduling decision and not a property of the transcription.
+
+## 2. Scaled continuity defects, per knot
+
+`EqualityModel.worst()` existed and nothing called it: a run printed only the aggregate
+`defect_norm`. That says *how far* from continuous a fit ended and never *where*.
+
+Every outer iterate now carries the largest individual scaled defects by name, their RMS, and
+the constraint count — and for multiple shooting a name is `experiment1@1/2::Z_state`, so the
+answer is the knot that did not close *and the state it did not close in*. The reported fit's
+breakdown is written to `Results/continuity_defects.txt` beside the parameters it describes.
+
+Three choices worth recording:
+
+**It lives in the layer, not the consumer.** The numbers are only comparable across states of
+different magnitude because they are *scaled*, and the scaling is ADR-0109's. A consumer-side
+report would have had to reach back for the scales.
+
+**The worst few, not all of them.** A defect list is one entry per (knot, state), so
+`egfr_ground.net` at `m = 4` has 1068 of them. Eight answers "which knot did not close";
+keeping every iterate's whole vector would grow a run's memory with the model's state count
+for numbers nobody reads. The file says "the 8 largest of 1068" rather than reading as the
+whole set.
+
+**An unconstrained rung reports that it is unconstrained.** A converged ladder usually
+finishes at `m = 1`, which has no knots. "No constraints at the reported fit" and "this run
+never wrote a report" are different facts, and the file distinguishes them.
+
+## 3. Equal-observation and explicit knots
+
+> "Support a segment count or explicit knots; default to generic equal-time or
+> equal-observation segments." — #563
+
+`SegmentGrid` did equal-time only. All three now exist, as one rule: **a placement is a map
+from a knot's fraction to a time.**
+
+* `equal_time` (default) — `start + f × span`. Unchanged, and still the default because it uses
+  only the experiment's own time axis.
+* `equal_observations` — the measurement at index `round(f × n)` of the sorted unique times, so
+  every segment owns the same number of points. It reads the *sampling*, not the dynamics.
+  Needs two measurements per segment (a knot sits *on* a measurement, so one-per-segment would
+  put the last knot on the horizon and leave a zero-length final segment), so its segment
+  ceiling is half `equal_time`'s — and `feasible_ladder` now asks each experiment for its own
+  ceiling rather than assuming one rule.
+* explicit `ms_knots` — the times, as given. They **replace** `ms_segments`: the finest rung
+  becomes `len(ms_knots) + 1`, and a configuration that also sets `ms_segments` is told which
+  one was used rather than having it silently overridden.
+
+Still no placement that reads a trajectory — knots at a burst, at a peak. Those are
+start-point dependent: they place the transcription's structure using dynamics the fit has not
+established, and on the motivating problem those dynamics are exactly what is in question.
+That was ADR-0110's reasoning for equal time and it is unchanged; what changes is that the
+*sampling* is also a fact the fit already has, which is why equal-observation qualifies and
+peak-finding does not.
+
+### The knot name is an ordinal, and ADR-0110 said this slightly wrong
+
+ADR-0110 decision 3 names a knot "by its exact fraction of the **horizon**". Under equal time
+that is true and reads naturally. It is not what `carry_over` needs, and it does not survive
+the other two placements — an explicit knot at `t = 1` on a `[0, 8]` horizon is not at `1/2`
+of anything, yet at `m = 2` it must be the same block as the `m = 4` grid's middle knot or the
+ladder reseeds.
+
+The fraction is the knot's **ordinal position among the segments**: knot `i` of `m` is
+`Fraction(i, m)`. `Fraction(2, 4) == Fraction(1, 2)`, so the surviving knot carries its solved
+state down while the others are discarded, which is what coarsening *is* — and that holds for
+every placement, because each maps *the same fraction* to *the same knot* at every rung. Under
+equal time the ordinal and the position coincide, which is why the original wording worked and
+why the distinction only surfaced when a second placement arrived.
+
+The test is the one that matters: for each placement, the coarse grid's knot must equal the
+fine grid's by **name and by time**. A name that carried over onto a different knot would
+reseed the ladder with a state belonging somewhere else — silent, and wrong in a way no
+objective can detect.
+
+## 4. `ms` is a refiner, which is what makes benchmark arm 4 exist
+
+#563's acceptance benchmark has four arms, and the fourth is "BIPOP-CMAES + multiple-shooting
+GNTR". There was no way to run it: `ms` was registered `refiner=False`, so
+`refine_method = ms` was a configuration error.
+
+ADR-0110's registration comment argued that `refiner` classifies "the *start-point*
+optimizers, which take a `var`/`logvar` point", and that `ms` "is not a local polish". The
+first half is a description of Simplex and Powell rather than of the flag — `gntr` is
+`refiner=True` and is a multi-start gradient method — and the second is wrong about what arm 4
+asks for. Seeded at one point, `ms` runs the `4 → 2 → 1` ladder from it and its last rung *is*
+the unsegmented local solve. That is a polish, and it is the shape the issue's own motivation
+argues for: the search finds a basin, and the transcription is what converts it.
+
+Nothing in the seam needed adding. `_refine_best_fit` injects the best fit under
+`START_POINT_KEY`, which `_resolve_start_pset` already prefers over every other source, and
+`_resolve_n_starts` already returns 1 for an injected start. Beyond passing
+`_check_refine_method`, the flag buys the coherent-group config pull-in: an `ms` refiner's
+keys are validated against `MSConfig` on the searching fit's config rather than sitting in it
+as unrecognised extras.
+
+**`start_from_box=True` is required rather than optional, and the first cut of this change was
+wrong to omit it.** `refiner` is what `config._load_variables` reads to classify a fit type as
+*start-point*, and a start-point fit type that is not also `start_from_box` may not be given
+bounded priors at all. `ms` has always drawn its starts from the box (`_is_box_start` reads the
+priors, not the registry), so adding the first flag without the second turned every standalone
+`uniform_var` / `loguniform_var` multiple-shooting fit — which is every one that exists — into
+a configuration error. Caught by the suite, not by review.
+
+The alternative was chaining two runs by hand and seeding the second from the first's
+`sorted_params_final.txt`. That would have produced a benchmark row without producing a PyBNF
+capability, and it would have sat outside the method-chain record and `wall_time_refine_frac`
+(ADR-0107) — so the row would not have measured what a user running arm 4 would get.
+
+## What this is not
+
+* **Not a claim that parallel segments help the motivating problem.** Measured, on Borghans
+  they do not, and the default says so.
+* **Not condensing, and not an SQP/IPOPT inner solver.** Both are "a later full
+  implementation" in the issue body and neither is needed to close it.
+* **Not a trajectory-dependent knot placement.** See decision 3.
+* **Not the acceptance benchmark.** That is the remaining piece of #563 and is reported
+  separately, against what the prototype actually measured — the tail and the robustness,
+  not the median it did not move.
+
+## Verification
+
+`tests/test_shooting.py` gains the placement and scheduler suites, still offline against the
+closed-form backend.
+
+* **Placement** — equal time cuts the horizon evenly; equal observations balances the data on
+  an unevenly sampled course where equal time leaves a segment with 2 points against 8;
+  explicit knots are used as given; a coarser rung keeps the explicit knot its fraction names
+  (`e@1/2` → the middle knot, not the first or last); and for **every** placement the coarse
+  grid's knot equals the fine grid's by name *and* by time. Plus the refusals: out-of-order or
+  outside-the-horizon explicit knots, an unknown placement, and a segment count the sampling
+  cannot support — each named by placement, because the fix differs.
+* **The scheduler** — a parallel pass reproduces a serial one **exactly** (`assert_array_equal`
+  on the objective, its gradient, the continuity residual and its Jacobian, not a tolerance: a
+  segment pass is not an approximation of another segment pass, and a tolerance would hide the
+  lane mix-up this parallelisation can actually have). Two segments never share a lane at once,
+  checked by a backend that records its own concurrency — with 8 segments and 2 lanes the
+  scheduler must make a segment wait. A failed segment still makes the whole point unusable.
+  A serial pool opens no threads at all.
+* **That it really overlaps**, deterministically: a `threading.Barrier` of four, so all four
+  segments of one point must be inside `simulate` simultaneously for any of them to return. A
+  pass that ran them one at a time blocks on the barrier's own timeout rather than failing a
+  timing heuristic that happens to hold on a fast machine.
+
+`tests/test_transcription.py` gains the defect report: every iterate names the constraints it
+did not satisfy, worst first, with the largest agreeing with the norm the loop stops on; the
+run result reports the defects at the point it stopped; and an iterate with no constraints
+reports nothing rather than a zero.
+
+`tests/test_shooting_sbml.py` covers the real-simulator half. Extra lanes at one point are
+*different* simulators holding the *same* parameters, and a new point discards every one of
+them rather than only lane 0. A parallel segment pass through the real bngsim tensor
+reproduces the serial one exactly, at knots deliberately stale so the defects are nonzero and
+the comparison has something to disagree about. The config keys reach where they claim to
+(`ms_knot_placement` through the real parser and `MSConfig`; `ms_knots` replacing
+`ms_segments`; `ms_parallel_segments` reaching the pool). `ms` is a registered refiner that
+starts from the injected point with `n_starts == 1`, and a `cmaes` fit may name it as its
+`refine_method` with the whole `MSConfig` group present.
+
+**End to end**, in the opt-in `recovery` tier: the decay-model `ms` fit now also asserts its
+`continuity_defects.txt` — that the stage, the certified objective and the defect norm agree
+with the trajectory's own best fit — and a second run with `ms_parallel_segments = 4` lands on
+the same score and the same parameters as the serial one, through the real fit type and the
+real config key rather than at the problem level.

--- a/docs/gradient_fitting.rst
+++ b/docs/gradient_fitting.rst
@@ -156,6 +156,13 @@ discarded, the parameters are re-simulated with ordinary single shooting, and th
 reported and ranked. A run that leaves continuity unconverged therefore scores as what it actually
 is, and the number in ``sorted_params_final.txt`` is directly comparable with any other fit's.
 
+Beside it, ``Results/continuity_defects.txt`` records how nearly the transcription that produced
+that fit joined up: the scaled defect norm and RMS, and the largest individual defects named by
+**knot and state** (``myexp@1/2::Z_state``). The numbers are scaled by each state's own magnitude,
+so one of them means the same thing across states spanning orders of magnitude and across models.
+A converged run usually finishes on the unsegmented rung, which has no knots at all; the file says
+so rather than being absent.
+
 **The ladder is the mechanism.** A run does not fix a segment count; it solves a sequence of
 transcriptions, coarsening toward the ordinary unsegmented problem (``4 → 2 → 1`` by default) and
 warm-starting each rung from the previous one. The stage trace is printed as it goes, and on the
@@ -172,9 +179,16 @@ to cut, or a measured phase that already starts from a carried state), and any s
 is a function of a whole series (an analytic per-series ``scale``, a data ``normalization``, a
 ``cumulative`` column, or BPSL constraints). An analytically profiled noise scale
 (``noise_profiling = 1``) is fine and is the recommended pairing: it is profiled over the pooled
-data residuals, which continuity defects never enter. Segments are simulated serially, so ``ms``
-does not scale across a cluster the way the metaheuristics do, and a stopped run cannot be resumed
-with ``-r``.
+data residuals, which continuity defects never enter. ``ms`` drives its own search on the master
+rather than across a cluster the way the metaheuristics do (a segment is not a parameter-set
+evaluation), and a stopped run cannot be resumed with ``-r``.
+
+**As a refiner.** ``refine_method = ms`` runs multiple shooting as the polish phase of another
+fit — ``job_type = cmaes`` with ``refine = 1, refine_method = ms`` is a global search followed by
+a multiple-shooting solve seeded at its best basin, which is the pairing the method's motivation
+argues for: the search finds a basin, and the transcription is what converts it. The refine starts
+from that one point rather than re-scattering across the box, and ``wall_time_refine_frac``
+reserves it a share of ``wall_time_fit`` so a long search cannot consume the refine's budget.
 
 **A note on size, for network models.** The transcription's width scales with the model's
 **state**, not with the number of fitted parameters: the finest rung adds
@@ -205,6 +219,35 @@ are worth leaving alone unless you have a reason:
   iterations per rung and defaults to the global ``max_iterations``.
 * ``ms_aux_decades`` (default ``6``) — the half-width, in decades, of a segment-start state's box
   around its own magnitude.
+
+**Where the knots go.** By default the horizon is cut into equal spans, which uses only the
+experiment's own time axis. Two alternatives:
+
+* ``ms_knot_placement = equal_observations`` cuts so every segment owns the same number of
+  measurements. Use it on an unevenly sampled course, where equal spans can leave a segment with
+  no data at all and its start states determined by continuity alone. It needs at least two
+  measurements per segment, so its segment ceiling is half the default's.
+* ``ms_knots = 2.5 5.0 7.5`` names the knot times outright, in the experiments' own
+  independent-variable units. This **replaces** ``ms_segments``: the finest rung becomes
+  ``len(ms_knots) + 1``, and the ladder coarsens by keeping the sub-list each rung's own knot
+  fractions select. A run whose ``ms_segments`` disagrees says which one it used.
+
+None of the three reads a trajectory. Placing knots at the features of a nominal simulation (a
+burst, a peak) is tempting and is deliberately not offered: it would put the transcription's
+structure where the *start point* says the dynamics are, and on the problem this method exists for
+those dynamics are exactly what is in question.
+
+**Running segments in parallel.** ``ms_parallel_segments`` (default ``1``) integrates that many of
+a point's segments at once, on independent warm engine+simulator *lanes*. The answer is unchanged —
+bit-identically so; only the scheduling differs. The default is 1 on a measurement rather than out
+of caution: bngsim does release the GIL during integration (four threads integrate Borghans
+segments 2.7× faster than one), but a lane has to be *built* at every parameter point, and on a
+small model that preparation (~4 ms) costs more than the integration it saves (~1–2 ms). Raise it
+when a single segment's integration is the expensive thing, which is a property of the model's
+state count rather than of the fit. Two caveats: the serial pass stops at the first segment that
+fails to integrate and a parallel one cannot, so a search over an uninformed box (where most points
+do not integrate) will report more simulations; and lanes are per experiment, so ``L`` of them cost
+``L`` model preparations per point.
 
 A minimal run::
 

--- a/docs/modules/shooting.rst
+++ b/docs/modules/shooting.rst
@@ -42,6 +42,12 @@ The segment-simulation seam
 .. automodule:: pybnf.shooting.net_backend
    :members:
 
+The segment pass
+================
+
+.. automodule:: pybnf.shooting.parallel
+   :members:
+
 The transcription
 =================
 

--- a/pybnf/algorithms/optimizers/multiple_shooting.py
+++ b/pybnf/algorithms/optimizers/multiple_shooting.py
@@ -56,16 +56,22 @@ searched:
 """
 
 import logging
-from typing import ClassVar
+from pathlib import Path
+from typing import ClassVar, Literal
+
+from pydantic import Field
 
 from .gradient_base import GradientOptimizer
 from ...config_schema import PyBNFConfigModel
 from ...printing import PybnfError, print0, print1, print2
 from ...registry import register_fit_type
 from ...shooting import (
+    EQUAL_TIME,
+    EXPLICIT,
     BngsimSegmentBackend,
     GaussNewtonSolver,
     NetSegmentBackend,
+    SegmentPool,
     ShootingExperiment,
     feasible_ladder,
     run_multiple_shooting,
@@ -150,6 +156,24 @@ class MSConfig(PyBNFConfigModel):
     is what notices a solver that has stopped achieving anything). Like every other local
     method's, ``ms_max_iterations`` is runtime-guarded -- it defaults to the global
     ``max_iterations`` when unset -- and bounds the outer iterations per rung.
+
+    ``ms_parallel_segments`` is how many of a point's segments are integrated at once, and
+    it defaults to **1** on a measurement rather than on caution. bngsim releases the GIL
+    inside CVODE -- four threads on four warm lanes integrate Borghans segments 2.7x faster
+    than one, bit-identically -- but a lane is an engine+simulator pair that has to be built
+    at every parameter point, and on that model preparing one (~4.1 ms) costs *more* than
+    the integration it saves (~1-2.3 ms). Parallel segments pay when a segment's integration
+    is the expensive thing, which is a property of the model's state count rather than of
+    the fit; :mod:`pybnf.shooting.parallel` carries the cost model and the numbers.
+
+    ``ms_knot_placement`` and ``ms_knots`` are the "a segment count **or** explicit knots;
+    default to generic equal-time **or** equal-observation segments" the issue asks for.
+    ``equal_time`` is the default because it uses only the experiment's own time axis;
+    ``equal_observations`` uses only its sampling; and ``ms_knots`` names the times outright,
+    which *replaces* ``ms_segments`` (the finest rung is then ``len(ms_knots) + 1``). None of
+    the three reads a trajectory, which is deliberate: a placement derived from nominal
+    dynamics would put the transcription's structure where the fit has not established
+    anything, and on the motivating problem those dynamics are exactly what is in question.
     """
 
     ms_segments: int = 4
@@ -161,17 +185,35 @@ class MSConfig(PyBNFConfigModel):
     ms_optimality_tol: float = 1e-6
     ms_inner_iterations: int = 50
     ms_aux_decades: float = 6.0
+    ms_knot_placement: Literal['equal_time', 'equal_observations'] = 'equal_time'
+    ms_knots: list = Field(default_factory=list)
+    ms_parallel_segments: int = 1
 
     RUNTIME_KEYS: ClassVar[frozenset] = frozenset({'ms_max_iterations'})
 
 
-# Neither `refiner` nor `start_from_box`: those two flags classify the *start-point*
-# optimizers, which take a `var` / `logvar` point (ADR-0015/0017). `ms` draws every variable
-# from its prior like the population optimizers do, and it is not a local polish -- so it is
-# in the "everything else" category, and multi-start over a bounded box comes from
-# `_is_box_start`, which reads the priors rather than the registry.
+# The same pair of flags `gntr` carries, and for the same reasons.
+#
+# `refiner=True` makes `refine = 1, refine_method = ms` a search followed by a
+# multiple-shooting polish -- the fourth arm of #563's acceptance benchmark, and the shape
+# the issue's own motivation argues for: a global search finds a basin, and the
+# transcription is what converts it. Nothing in the seam needed adding. `_refine_best_fit`
+# injects the search's best fit under `START_POINT_KEY`, which `_resolve_start_pset` already
+# prefers over every other source, and `_resolve_n_starts` already returns 1 for an injected
+# start (a refine polishes one point; it does not re-scatter). Beyond passing
+# `_check_refine_method`, the flag buys the coherent-group config pull-in: an `ms` refiner's
+# keys are validated against `MSConfig` on the searching fit's config rather than sitting in
+# it as unrecognised extras.
+#
+# `start_from_box=True` is then required rather than optional, and the first cut of this
+# registration was wrong to omit it: `refiner` is what `_load_variables` reads to classify a
+# fit_type as *start-point*, and a start-point fit_type that is not also `start_from_box`
+# may not be given bounded priors at all. `ms` has always drawn its starts from the box
+# (`_is_box_start` reads the priors), so without the second flag adding the first would have
+# made every standalone `uniform_var` / `loguniform_var` multiple-shooting fit -- which is
+# every one that exists -- a configuration error.
 @register_fit_type('ms', family='optimizer', display_name='Multiple Shooting',
-                   schema=MSConfig)
+                   schema=MSConfig, refiner=True, start_from_box=True)
 class MultipleShootingAlgorithm(GradientOptimizer):
     """The multiple-shooting fit type.
 
@@ -191,10 +233,18 @@ class MultipleShootingAlgorithm(GradientOptimizer):
         super().__init__(config, refine=refine)
         self.max_outer = config.config.get('ms_max_iterations',
                                            config.config['max_iterations'])
-        self.n_segments = int(config.config['ms_segments'])
+        self.knots = tuple(float(t) for t in (config.config.get('ms_knots') or ()))
+        self.placement = (EXPLICIT if self.knots
+                          else str(config.config.get('ms_knot_placement', EQUAL_TIME)))
+        # Explicit knots *are* the finest rung, so they set the segment count rather than
+        # sitting alongside it. Refusing a contradictory ms_segments would be pedantic (the
+        # knots are unambiguous); silently ignoring it would not be, so it is reported.
+        self.n_segments = (len(self.knots) + 1 if self.knots
+                           else int(config.config['ms_segments']))
         self.coarsening = int(config.config['ms_coarsening'])
         self.inner_iterations = int(config.config['ms_inner_iterations'])
         self.aux_decades = float(config.config['ms_aux_decades'])
+        self.pool = SegmentPool(config.config.get('ms_parallel_segments', 1))
         self.schedule = PenaltySchedule(
             initial_penalty=config.config['ms_penalty'],
             growth=config.config['ms_penalty_growth'],
@@ -204,9 +254,10 @@ class MultipleShootingAlgorithm(GradientOptimizer):
         self.homotopies = []
 
     def _start_banner(self):
-        return ('Running multiple shooting: coarsening ladder from %i segment(s), up to %i '
-                'outer iteration(s) per rung, from %i start point(s)'
-                % (self.n_segments, self.max_outer, self.n_starts))
+        return ('Running multiple shooting: coarsening ladder from %i segment(s) placed by '
+                '%s, up to %i outer iteration(s) per rung, from %i start point(s)'
+                % (self.n_segments, self.placement.replace('_', ' '), self.max_outer,
+                   self.n_starts))
 
     def _make_runner(self, u0):
         """Never called: this fit type does not drive per-start step machines through the
@@ -237,6 +288,14 @@ class MultipleShootingAlgorithm(GradientOptimizer):
         print2(self._start_banner())
 
         self._setup_gradient_path()
+        if self.knots and 'ms_segments' in self.config.config \
+                and int(self.config.config['ms_segments']) != self.n_segments:
+            # No silent override: ms_knots fixes the finest rung, so an ms_segments that
+            # disagrees with it did not take effect and the run says which one won.
+            print1('ms_knots supplies %i explicit knot(s), which fixes the finest rung at '
+                   '%i segment(s); the configured ms_segments = %s was not used.'
+                   % (len(self.knots), self.n_segments,
+                      self.config.config['ms_segments']))
         specs = self._build_specs()
         rungs, dropped = feasible_ladder(
             specs, coarsening_ladder(start=self.n_segments, factor=self.coarsening))
@@ -259,6 +318,22 @@ class MultipleShootingAlgorithm(GradientOptimizer):
         for spec in specs:
             print2(spec.grid(rungs[0]).describe())
 
+        print1('  %s' % self.pool.describe())
+        try:
+            self._run_starts(specs, rungs)
+        finally:
+            # The thread pool outlives a single start, so it is closed once the ladder is
+            # done -- including when a budget or an error ends the run early, since a live
+            # pool would keep the interpreter's non-daemon threads alive past the fit.
+            self.pool.close()
+
+        if self._budget_spent():
+            self.stop_reason = self._wall_time_stop_reason(self.completed_simulations)
+        self._finalize_run()
+        self._emit_continuity_defects()
+
+    def _run_starts(self, specs, rungs):
+        """Drive the ladder from every start point, newest result first in the log."""
         for index, start in enumerate(self.start_psets):
             if self._budget_spent():
                 break
@@ -269,7 +344,8 @@ class MultipleShootingAlgorithm(GradientOptimizer):
                 self._param_vec(start), ladder=rungs, schedule=self.schedule,
                 inner_solver=solver, max_outer=self.max_outer,
                 aux_decades=self.aux_decades, stop_check=self._budget_spent,
-                on_iterate=self._record_iterate, on_stage=self._report_stage)
+                on_iterate=self._record_iterate, on_stage=self._report_stage,
+                pool=self.pool)
             # Segment integrations, not augmented-model evaluations: one evaluation is m
             # integrations plus the certification's, and reporting evaluations would
             # understate the cost by the factor the method is judged on.
@@ -284,10 +360,6 @@ class MultipleShootingAlgorithm(GradientOptimizer):
                 print0('Warning: some of this run\'s scores did not go through the '
                        'ordinary single-shoot path and are not comparable with an '
                        'ordinary fit\'s.')
-
-        if self._budget_spent():
-            self.stop_reason = self._wall_time_stop_reason(self.completed_simulations)
-        self._finalize_run()
 
     def _record_iterate(self, record):
         """Enter one certified outer iterate in the ordinary trajectory.
@@ -310,6 +382,9 @@ class MultipleShootingAlgorithm(GradientOptimizer):
 
     def _report_stage(self, stage):
         print2('  %s' % stage.outer.summary())
+        report = stage.outer.defect_report()
+        if report:
+            print2('    worst scaled continuity defect(s): %s' % report)
 
     # --- the experiments --------------------------------------------------- #
     def _build_specs(self):
@@ -341,7 +416,9 @@ class MultipleShootingAlgorithm(GradientOptimizer):
                         hint='Fit this model with job_type = gntr, which resolves the '
                              'routing per evaluation.')
                 specs.append(ShootingExperiment((model.name, suffix), backend, exp_data,
-                                                routing, label=label, start=0.0))
+                                                routing, label=label, start=0.0,
+                                                placement=self.placement,
+                                                knots=self.knots or None))
         if not specs:
             raise PybnfError('Multiple shooting found no scored experiment to segment.')
         return specs
@@ -556,6 +633,13 @@ class MultipleShootingAlgorithm(GradientOptimizer):
                      'whole trajectory.')
 
     # --- reporting --------------------------------------------------------- #
+    def _best_homotopy(self):
+        """The start whose ladder produced this run's best certified fit, or ``None``."""
+        finished = [h for h in self.homotopies if h.best is not None]
+        if not finished:
+            return None
+        return min(finished, key=lambda h: h.best_score)
+
     def best_stage_trace(self):
         """The stage trace of the start that produced the run's best certified fit.
 
@@ -563,10 +647,77 @@ class MultipleShootingAlgorithm(GradientOptimizer):
         coarsening is converting the segmented stages, which is the mechanism the method
         rests on. ``None`` before any start has run.
         """
-        finished = [h for h in self.homotopies if h.best is not None]
-        if not finished:
-            return None
-        return min(finished, key=lambda h: h.best_score).trace()
+        homotopy = self._best_homotopy()
+        return None if homotopy is None else homotopy.trace()
+
+    def _emit_continuity_defects(self):
+        """Write ``Results/continuity_defects.txt``: how nearly the transcription that
+        produced the reported fit joined up, per knot.
+
+        The issue asks a multiple-shooting run to "report scaled continuity defects", and
+        the plural is the point. The aggregate norm says how far from continuous the run
+        ended; this says *which knot* did not close and *in which state* -- which is the
+        difference between a fit whose one unobserved species drifts at a single knot and
+        one whose whole transcription never converged.
+
+        The numbers are **scaled** (ADR-0109): each defect is divided by its state's own
+        magnitude, so one number means the same thing across states spanning orders of
+        magnitude, and the norm is comparable across models. The row this describes is the
+        run's best *certified* iterate -- the reported fit -- so the file pairs with
+        ``sorted_params_final.txt`` rather than describing some other point.
+
+        The unsegmented rung of a ladder has no constraints, and that is where a converged
+        run usually finishes; the file says so rather than being absent, because "no
+        constraints at the reported fit" and "this run never wrote a report" are different
+        facts. Every failure is logged and swallowed: the run has completed, and a report
+        must never abort it.
+        """
+        homotopy = self._best_homotopy()
+        if homotopy is None:
+            return
+        best = homotopy.best
+        lines = [
+            '# Scaled continuity defects at the best certified iterate (job_type = ms).',
+            '# A continuity defect is c_j = Phi_j(z_j, theta) - z_{j+1}, the gap between the',
+            '#   state a segment integrates to and the state the next segment starts from,',
+            '#   divided by that state\'s own magnitude. Scaling is what makes one number',
+            '#   mean one thing across states of different size (ADR-0109), so the norms',
+            '#   below are dimensionless and comparable across models.',
+            '# The iterate described here is the fit reported in sorted_params_final.txt:',
+            '#   its objective is an ordinary single-shoot reconstruction, and these defects',
+            '#   say how nearly the transcription it came from joined up.',
+            'stage\t%s' % best.stage,
+            'outer_iteration\t%i' % best.iteration,
+            'certified_objective\t%.10g' % best.certificate.objective,
+            'n_constraints\t%i' % best.n_constraints,
+            'scaled_defect_norm_inf\t%.10g' % best.defect_norm,
+            'scaled_defect_rms\t%.10g' % best.defect_rms,
+        ]
+        if not best.n_constraints:
+            lines.append('# This iterate came from the unsegmented rung (m = 1), which has no')
+            lines.append('#   knots and therefore no continuity constraints to violate.')
+        else:
+            lines.append('# The %i largest of %i, worst first.'
+                         % (min(len(best.worst_defects), best.n_constraints),
+                            best.n_constraints))
+            lines.append('# knot\tstate\tscaled_defect')
+            for name, value in best.worst_defects:
+                knot, _, state = name.partition('::')
+                lines.append('%s\t%s\t%.10g' % (knot, state or '-', value))
+        path = str(Path(self.res_dir) / 'continuity_defects.txt')
+        try:
+            Path(self.res_dir).mkdir(parents=True, exist_ok=True)
+            with open(path, 'w') as f:
+                f.write('\n'.join(lines) + '\n')
+        except Exception:
+            logger.exception('Failed to write continuity_defects.txt')
+            return
+        logger.info('Wrote scaled continuity defects %s' % path)
+        report = best.defect_report()
+        print1('Scaled continuity defect at the best certified fit (%s): norm %.3g, rms %.3g'
+               % (best.stage, best.defect_norm, best.defect_rms))
+        if report:
+            print1('  worst knot(s): %s' % report)
 
     def start_run(self):
         raise PybnfError('job_type = ms drives its own search and does not use the '

--- a/pybnf/parse.py
+++ b/pybnf/parse.py
@@ -58,7 +58,10 @@ numkeys_int = ['verbosity', 'parallel_count', 'delete_old_files', 'population_si
                # coarsening ladder and the factor between rungs, the per-outer-iteration
                # inner-solve cap, and the outer-iteration budget per rung (a runtime-guarded
                # RUNTIME_KEY, defaulting to max_iterations).
+               # ms_parallel_segments is how many of a point's segments are integrated at
+               # once, on warm engine+simulator lanes (1 = serially on the master).
                'ms_segments', 'ms_coarsening', 'ms_inner_iterations', 'ms_max_iterations',
+               'ms_parallel_segments',
                # DREAM multi-try count (ADR-0067 Stage 2, #357): candidate proposals
                # per chain per generation (n_try = 1 is the classic single-try engine).
                'n_try',
@@ -114,7 +117,12 @@ numkeys_float = ['min_objective', 'cognitive', 'social', 'particle_weight',
                  # leaves rtol at the backend default and DERIVES atol from the model's
                  # own state scale; stating either pins it.
                  'sbml_rtol', 'sbml_atol']
-multnumkeys = ['credible_intervals', 'beta', 'beta_range', 'starting_params', 'calculate_covari']
+multnumkeys = ['credible_intervals', 'beta', 'beta_range', 'starting_params', 'calculate_covari',
+               # multiple shooting (job_type = ms, #563): explicit knot times for the
+               # finest rung, in the experiments' own independent-variable units. Supplying
+               # them fixes the finest segment count at len(ms_knots) + 1, so it replaces
+               # ms_segments rather than accompanying it.
+               'ms_knots']
 # The prior-family var keywords are derived from the registry (ADR-0010): each
 # family yields {base}_var (linear) + log{base}_var (log10). Bounded-support
 # families (b_var_def_keys) take the optional b/u flag in the grammar and have
@@ -133,6 +141,9 @@ strkeylist = ['bng_command', 'output_dir', 'fit_type', 'job_type', 'objfunc', 'o
               'outlier_method', 'refine_method', 'noise_location',
               # CMA-ES restart schedule (job_type = cmaes, #498/ADR-0070): ipop | bipop.
               'cmaes_restart_strategy',
+              # multiple shooting (job_type = ms, #563): where the knots go --
+              # equal_time | equal_observations. Explicit knots come from ms_knots.
+              'ms_knot_placement',
               # Global qualitative (BPSL) penalty-family override:
               # auto | hinge | probit | logit.
               'qualitative_loss']

--- a/pybnf/shooting/__init__.py
+++ b/pybnf/shooting/__init__.py
@@ -45,6 +45,8 @@ The pieces
   :mod:`~pybnf.shooting.bngsim_backend`, its implementation against bngsim;
 * :mod:`~pybnf.shooting.problem` -- the transcription itself: the ``IC``-routed objective
   assembly, the continuity block, and the certified reconstruction;
+* :mod:`~pybnf.shooting.parallel` -- the segment pass: serial, or across warm
+  engine+simulator lanes, with the measured cost model that decides which;
 * :mod:`~pybnf.shooting.solver` -- the Gauss-Newton inner solver, which is ``gntr``'s runner
   driven synchronously;
 * :mod:`~pybnf.shooting.driver` -- the ladder.
@@ -57,7 +59,15 @@ from .backend import SegmentBackend, SegmentSimulationFailed, SegmentTrace, trac
 from .bngsim_backend import BngsimSegmentBackend
 from .net_backend import NetSegmentBackend
 from .driver import coarsening_stages, feasible_ladder, run_multiple_shooting
-from .grid import SegmentGrid
+from .grid import (
+    EQUAL_OBSERVATIONS,
+    EQUAL_TIME,
+    EXPLICIT,
+    PLACEMENTS,
+    SegmentGrid,
+    max_segments,
+)
+from .parallel import SERIAL, SegmentPool, SegmentTask
 from .problem import (
     AUX_DECADES,
     STATE_FLOOR,
@@ -70,6 +80,11 @@ from .solver import GaussNewtonSolver
 
 __all__ = [
     'AUX_DECADES',
+    'EQUAL_OBSERVATIONS',
+    'EQUAL_TIME',
+    'EXPLICIT',
+    'PLACEMENTS',
+    'SERIAL',
     'STATE_FLOOR',
     'BngsimSegmentBackend',
     'GaussNewtonSolver',
@@ -77,12 +92,15 @@ __all__ = [
     'NetSegmentBackend',
     'SegmentBackend',
     'SegmentGrid',
+    'SegmentPool',
     'SegmentSimulationFailed',
+    'SegmentTask',
     'SegmentTrace',
     'SegmentedExperiment',
     'ShootingExperiment',
     'coarsening_stages',
     'feasible_ladder',
+    'max_segments',
     'run_multiple_shooting',
     'seed_stage',
     'trace_from_data',

--- a/pybnf/shooting/backend.py
+++ b/pybnf/shooting/backend.py
@@ -121,6 +121,24 @@ class SegmentBackend(ABC):
     #: :meth:`simulate`.
     n_simulations = 0
 
+    def open_lanes(self, pset, n_lanes):
+        """Prepare up to ``n_lanes`` independent simulation contexts at ``pset``; return how
+        many are actually available (at least 1).
+
+        A *lane* is whatever state :meth:`simulate` restarts to run one span -- for the
+        bngsim backends, a warm engine model and ``Simulator``. Two segments cannot share
+        one, because a segment is run by resetting that state to its own start knot, so a
+        second segment on the same object would integrate from the first's start. Lanes are
+        what makes :class:`~pybnf.shooting.parallel.SegmentPool` able to run ``L`` segments
+        of one experiment at once.
+
+        Called on the **calling thread**, before any worker starts, because preparing a lane
+        is where a backend touches the model it owns. The default implementation offers one
+        lane, which is the serial behaviour and needs no preparation of its own.
+        """
+        del pset, n_lanes
+        return 1
+
     @property
     @abstractmethod
     def state_names(self):
@@ -143,7 +161,7 @@ class SegmentBackend(ABC):
         """
 
     @abstractmethod
-    def simulate(self, pset, sample_times, initial_state=None):
+    def simulate(self, pset, sample_times, initial_state=None, lane=0):
         """Integrate one span and return its :class:`~pybnf.data.Data`.
 
         :param pset: The reported parameter set, exactly as an ordinary evaluation would
@@ -153,6 +171,9 @@ class SegmentBackend(ABC):
         :param initial_state: ``{state name: value}`` overriding the model's own initial
             conditions, or ``None`` for the first segment, which starts from the model as
             configured.
+        :param lane: Which of the contexts :meth:`open_lanes` prepared to run in. ``0`` is
+            the only one a serial pass ever uses, and the only one a backend that offers no
+            lanes has to honour. A caller must never run two segments in one lane at once.
 
         Raises :class:`SegmentSimulationFailed` for a point that does not integrate.
         """

--- a/pybnf/shooting/bngsim_backend.py
+++ b/pybnf/shooting/bngsim_backend.py
@@ -42,7 +42,16 @@ keeps one engine model and one ``Simulator`` per parameter point and restarts th
 knot. The restart is what distinguishes this from the pre-equilibration protocol (ADR-0052),
 which runs a second phase on the same simulator *without* a reset precisely so the state
 carries over.
+
+It is also why running two segments at once needs *two* of them: the restart is a mutation
+of the simulator's own state, so a second segment sharing it would integrate from the
+first's start knot. ``open_lanes`` builds one engine+simulator pair per lane at a point, on
+the calling thread, and each lane is then claimed by one segment for the whole of its
+integration (:mod:`pybnf.shooting.parallel`, which also carries the cost model that decides
+whether extra lanes are worth their preparation).
 """
+
+import threading
 
 import numpy as np
 
@@ -56,8 +65,12 @@ class BngsimSegmentBackend(SegmentBackend):
     :param model: The PyBNF model object, already built and with its sensitivity request
         applied (``enable_output_sensitivities``). This backend **owns** it: it assigns the
         parameter set in place rather than deep-copying per evaluation, which is sound
-        because the whole multiple-shooting driver runs single-threaded on the master (a
-        segment is not a :class:`~pybnf.pset.PSet` evaluation and never reaches a worker).
+        because the multiple-shooting driver runs on the master (a segment is not a
+        :class:`~pybnf.pset.PSet` evaluation and never reaches a worker) and because the two
+        places that *write* to the model -- the parameter set and the action suffix -- are
+        done once per point under this backend's lock, before any segment runs. The
+        integration path itself only reads the model, which is what lets several segments of
+        one point run at once on separate lanes.
     :param action: The ``TimeCourse`` action this experiment is measured by.
     :param mutant: The ``MutationSet`` (condition) it is measured under.
     :param suffix: The full output suffix, ``action.suffix + mutant.suffix``.
@@ -83,9 +96,13 @@ class BngsimSegmentBackend(SegmentBackend):
         self._states = tuple(model.species_names)
         self._nominal = _nominal_state(model, self._states)
         self.n_simulations = 0
-        self._point = None          # identity of the PSet the prepared engine holds
-        self._engine = None
-        self._sim = None
+        self._point = None          # identity of the PSet the prepared lanes hold
+        self._lanes = []            # one (engine, Simulator) pair per lane; None = dead
+        # Guards the lane list and the simulation counter. Preparation and counting are the
+        # only shared state a parallel pass touches -- the integration itself runs on a
+        # lane's own engine and reads the model without mutating it, which is what makes
+        # threads sound here (pybnf.shooting.parallel).
+        self._lock = threading.RLock()
 
     # -- the contract -----------------------------------------------------------
 
@@ -97,12 +114,33 @@ class BngsimSegmentBackend(SegmentBackend):
     def nominal_state(self):
         return self._nominal
 
-    def simulate(self, pset, sample_times, initial_state=None):
+    def open_lanes(self, pset, n_lanes):
+        """Build up to ``n_lanes`` engine+simulator pairs at ``pset``; return how many.
+
+        Called on the master before a parallel pass, so every lane a worker can claim is
+        already built and no thread ever enters the construction path. A lane that cannot be
+        built is not an error here -- the pass simply runs at the width that succeeded, and
+        the failure resurfaces as a failed segment if it was going to.
+        """
+        wanted = max(1, int(n_lanes))
+        with self._lock:
+            self._sync_point(pset)
+            for lane in range(wanted):
+                try:
+                    self._context(pset, lane)
+                except SegmentSimulationFailed:
+                    return max(1, lane)
+            return wanted
+
+    def simulate(self, pset, sample_times, initial_state=None, lane=0):
         times = [float(t) for t in np.asarray(sample_times, dtype=float).reshape(-1)]
         if len(times) < 2:
             raise PybnfError('A multiple-shooting segment needs at least two output times; '
                              'got %r.' % (times,))
-        engine, sim = self._prepare(pset)
+        with self._lock:
+            self._sync_point(pset)
+            engine, sim = self._context(pset, lane)
+            self.n_simulations += 1
         if initial_state:
             for name, value in initial_state.items():
                 if not self.model._set_engine_value_if_present(engine, name, float(value)):
@@ -112,7 +150,6 @@ class BngsimSegmentBackend(SegmentBackend):
                             getattr(self.model, 'name', '?'), name))
             engine.save_concentrations()
         engine.reset()
-        self.n_simulations += 1
         try:
             result = self.model._run_simulation(
                 engine, times[-1], len(times), method=self.method, timeout=self.timeout,
@@ -120,33 +157,49 @@ class BngsimSegmentBackend(SegmentBackend):
             data = self.model._result_to_data(result)
         except Exception as exc:
             # A non-integrable point is a property of the point, not of the run: hand it
-            # back as a failed segment so the inner solver's trust region shrinks. The
-            # prepared engine is dropped, because whatever state a failed CVODE call left
-            # it in is not one to restart the next segment from.
-            self._point = None
+            # back as a failed segment so the inner solver's trust region shrinks. The lane
+            # is dropped -- whatever state a failed CVODE call left it in is not one to
+            # restart another segment from -- but only *that* lane, because a parallel pass
+            # has other segments still running in the others.
+            self._drop_lane(lane)
             raise SegmentSimulationFailed('%s: %s' % (type(exc).__name__, exc)) from exc
         if not np.all(np.isfinite(np.asarray(data.data, dtype=float))):
             raise SegmentSimulationFailed('the segment produced a non-finite trajectory')
         return data
 
-    # -- one engine + one simulator per parameter point --------------------------
+    # -- one engine + one simulator per parameter point, per lane ----------------
 
-    def _prepare(self, pset):
-        """The engine model and ``Simulator`` for ``pset``, built once and reused across
-        that point's segments (see the module docstring on why that matters).
+    def _sync_point(self, pset):
+        """Point this backend's lanes at ``pset``, discarding any built for another.
 
         Keyed on the PSet's *identity*: the caller
         (:meth:`~pybnf.shooting.problem.MultipleShootingProblem._traces`) builds one PSet per
         augmented evaluation and simulates every segment from it, so identity is exactly the
         right granularity and needs no hashing of the parameter vector.
         """
-        if self._point is pset and self._engine is not None:
-            return self._engine, self._sim
+        if self._point is pset:
+            return
+        self._lanes = []
         self.model.param_set = pset
         # The per-action sensitivity gate (#475/#482) reads this: without it a scored
         # experiment's segments would run sensitivity-free and the assembly would find no
         # tensor to differentiate.
         self.model._current_action_suffix = self.suffix
+        self._point = pset
+
+    def _context(self, pset, lane):
+        """Lane ``lane``'s engine model and ``Simulator``, built on demand.
+
+        The #563 prototype measured that constructing a sensitivity-bearing ``Simulator``
+        costs ~230 ms cold and ~17 ms warm against ~50 ms for the integration itself, which
+        is why one is kept per point rather than built per segment -- and why a *lane* is
+        not free (:mod:`pybnf.shooting.parallel` has the cost model that follows from it).
+        """
+        del pset
+        while len(self._lanes) <= lane:
+            self._lanes.append(None)
+        if self._lanes[lane] is not None:
+            return self._lanes[lane]
         try:
             engine = self.model._engine_model_for_action(mut=self.mutant)
             sim = self.model._make_simulator(engine, self.method)
@@ -155,11 +208,17 @@ class BngsimSegmentBackend(SegmentBackend):
             raise SegmentSimulationFailed(
                 'the model could not be prepared at this point (%s: %s)'
                 % (type(exc).__name__, exc)) from exc
-        self._point, self._engine, self._sim = pset, engine, sim
-        return engine, sim
+        self._lanes[lane] = (engine, sim)
+        return self._lanes[lane]
+
+    def _drop_lane(self, lane):
+        with self._lock:
+            if 0 <= lane < len(self._lanes):
+                self._lanes[lane] = None
 
     def __repr__(self):
-        return 'BngsimSegmentBackend(%r, states=%i)' % (self.suffix, len(self._states))
+        return 'BngsimSegmentBackend(%r, states=%i, lanes=%i)' % (
+            self.suffix, len(self._states), len(self._lanes))
 
 
 def _nominal_state(model, states):

--- a/pybnf/shooting/driver.py
+++ b/pybnf/shooting/driver.py
@@ -29,8 +29,6 @@ about, and its last rung is the one whose objective needs no certification becau
 the certificate.
 """
 
-import numpy as np
-
 from ..transcription import PenaltySchedule, coarsening_ladder, run_homotopy
 from .problem import AUX_DECADES, seed_stage
 from .solver import GaussNewtonSolver
@@ -39,16 +37,20 @@ from .solver import GaussNewtonSolver
 def feasible_ladder(specs, ladder=None):
     """The requested ladder, clamped to what the data can support.
 
-    A segment count above an experiment's own measurement count places knots between
+    A segment count above what an experiment's data supports places knots between
     observations everywhere and leaves segments with nothing to fit -- a transcription whose
     auxiliary states are determined by continuity alone in *every* segment, which is not the
     method, it is an ODE solver with extra variables. Rungs above that are dropped and the
     caller is told which (a silent cap would read as "we ran the ladder you asked for").
 
+    The ceiling is the experiment's own, because it depends on the knot placement: equal
+    time needs one measurement per segment, equal observations needs two, and an explicit
+    knot list *is* the finest rung (:func:`~pybnf.shooting.grid.max_segments`).
+
     Returns ``(rungs, dropped)``.
     """
     rungs = tuple(int(m) for m in (coarsening_ladder() if ladder is None else ladder))
-    limit = min((len(np.unique(spec.times)) for spec in specs), default=1)
+    limit = min((spec.max_segments for spec in specs), default=1)
     kept = tuple(m for m in rungs if m <= max(1, limit))
     dropped = tuple(m for m in rungs if m not in kept)
     if 1 not in kept:
@@ -59,12 +61,12 @@ def feasible_ladder(specs, ladder=None):
 
 
 def coarsening_stages(specs, rungs, objective, variables, pset_from_u,
-                      aux_decades=AUX_DECADES):
+                      aux_decades=AUX_DECADES, pool=None):
     """One stage factory per rung, in the order ``run_homotopy`` will run them."""
     def factory(n_segments):
         def build(reported):
             return seed_stage(specs, n_segments, objective, variables, pset_from_u, reported,
-                              aux_decades=aux_decades)
+                              aux_decades=aux_decades, pool=pool)
         return build
     return [factory(m) for m in rungs]
 
@@ -72,7 +74,7 @@ def coarsening_stages(specs, rungs, objective, variables, pset_from_u,
 def run_multiple_shooting(specs, objective, variables, pset_from_u, reported_start,
                           ladder=None, schedule=None, inner_solver=None, max_outer=25,
                           aux_decades=AUX_DECADES, stop_check=None, on_iterate=None,
-                          on_stage=None):
+                          on_stage=None, pool=None):
     """Solve one fit by multiple shooting, down the coarsening ladder.
 
     :param specs: The :class:`~pybnf.shooting.problem.ShootingExperiment`\\ s -- one per
@@ -91,6 +93,8 @@ def run_multiple_shooting(specs, objective, variables, pset_from_u, reported_sta
     :param stop_check: The wall-clock-budget seam, passed to the outer loop *and* to the
         default inner solver, so a deadline lands inside a long inner solve rather than
         after it.
+    :param pool: The :class:`~pybnf.shooting.parallel.SegmentPool` every rung's segment
+        passes run through. Defaults to the serial one.
 
     Returns the :class:`~pybnf.transcription.homotopy.HomotopyResult`, whose ``best`` is the
     best **certified** iterate over the whole ladder -- not its last, which on one prototype
@@ -100,7 +104,7 @@ def run_multiple_shooting(specs, objective, variables, pset_from_u, reported_sta
     if inner_solver is None:
         inner_solver = GaussNewtonSolver(stop_check=stop_check)
     stages = coarsening_stages(specs, rungs, objective, variables, pset_from_u,
-                               aux_decades=aux_decades)
+                               aux_decades=aux_decades, pool=pool)
     return run_homotopy(stages, inner_solver, reported_start,
                         schedule=schedule or PenaltySchedule(), max_outer=max_outer,
                         stop_check=stop_check, on_iterate=on_iterate, on_stage=on_stage)

--- a/pybnf/shooting/grid.py
+++ b/pybnf/shooting/grid.py
@@ -6,16 +6,33 @@ things that are easy to get subtly wrong are testable in isolation: which segmen
 point belongs to, and whether a coarser grid's knots are recognisably *the same knots* as a
 finer grid's.
 
-Equal time, because the alternative needs information a fit does not have
---------------------------------------------------------------------------
-The #563 prototype cut ``[0, T]`` into ``m`` equal spans and solved the motivating problem
-that way, so that is what ships. The obvious refinements -- knots at the data's own
-quantiles, or at the features of a nominal trajectory (a burst, a peak) -- are *start-point
-dependent*: they place the transcription's structure using a trajectory the fit has not
-established yet, and on the motivating problem the nominal trajectory is exactly what is in
-question (an oscillator whose period is wrong everywhere except a 3 % window). Equal spans
-place the knots using only the experiment's own time axis, which is a fact rather than a
-guess. ``knot_times`` is a plain attribute, so a future consumer can hand in its own.
+Three placements, and one of them is the default for a measured reason
+----------------------------------------------------------------------
+The issue asks for "a segment count or explicit knots; default to generic equal-time or
+equal-observation segments", and all three are here:
+
+``equal_time`` (the default)
+    ``[start, horizon]`` cut into ``m`` equal spans. This is what the #563 prototype solved
+    the motivating problem with, and it is the default because it places the knots using
+    only the experiment's own time axis -- a fact rather than a guess. The obvious
+    refinements that read a *trajectory* (knots at a burst, at a peak) are start-point
+    dependent: they place the transcription's structure using dynamics the fit has not
+    established, and on the motivating problem those dynamics are exactly what is in
+    question (an oscillator whose period is wrong everywhere except a 3 % window).
+
+``equal_observations``
+    Cut so each segment owns the same number of measurements. It reads the data's own time
+    axis and nothing else, so it is not start-point dependent either -- what it uses is the
+    *sampling*, not the dynamics. It is the right placement when a time course is sampled
+    unevenly, where equal spans leave some segments with nothing to fit and the auxiliary
+    states of those segments are determined by continuity alone (ADR-0109 finding 5.2's
+    under-determination, arrived at through the sampling rather than through ``m``). It
+    needs at least two measurements per segment, so its own segment ceiling is half
+    ``equal_time``'s.
+
+explicit knots
+    The caller supplies the times. Nothing here second-guesses them; they are validated for
+    order and for lying strictly inside the horizon, and the run reports them.
 
 Names, because the homotopy transfers by name
 ---------------------------------------------
@@ -26,11 +43,19 @@ here is load-bearing: a knot must get the same name at every segment count that 
 the ``4 -> 2 -> 1`` ladder reseeds instead of continuing and the coarsening (the mechanism,
 ADR-0109 finding 5.2) buys nothing.
 
-Naming a knot by its **exact fraction of the horizon** does that. At ``m = 4`` the knots are
-``1/4, 1/2, 3/4``; at ``m = 2``, ``1/2`` -- and ``Fraction(2, 4) == Fraction(1, 2)``, so the
-surviving knot carries its solved state down the ladder while ``1/4`` and ``3/4`` are
-discarded, which is what coarsening *is*. Exact rational arithmetic rather than a rounded
-float, so ``1/3`` and ``0.333333`` can never be two names for one knot (or one name for two).
+Naming a knot by its **exact fraction of the segment count** does that: knot ``i`` of ``m``
+is ``Fraction(i, m)``. At ``m = 4`` the knots are ``1/4, 1/2, 3/4``; at ``m = 2``, ``1/2`` --
+and ``Fraction(2, 4) == Fraction(1, 2)``, so the surviving knot carries its solved state
+down the ladder while ``1/4`` and ``3/4`` are discarded, which is what coarsening *is*.
+Exact rational arithmetic rather than a rounded float, so ``1/3`` and ``0.333333`` can never
+be two names for one knot (or one name for two).
+
+The fraction is an **ordinal**, not a claim about where the knot sits. Under ``equal_time``
+the two coincide, which is why the naming reads so naturally there; under the other two
+placements ``exp1@1/2`` is "the knot halfway along this grid's knot list", which is exactly
+what carry-over needs to match on and is independent of what time it landed at. Every
+placement therefore maps *the same fraction* to *the same knot*, at every rung -- which is
+the whole property the ladder rests on.
 
 Which segment owns a data point
 -------------------------------
@@ -54,6 +79,39 @@ from ..printing import PybnfError
 #: one does not.
 KNOT = '@'
 
+#: Knots at equal spans of the experiment's own time axis. The default, and what the #563
+#: prototype solved the motivating problem with.
+EQUAL_TIME = 'equal_time'
+
+#: Knots placed so every segment owns the same number of measurements.
+EQUAL_OBSERVATIONS = 'equal_observations'
+
+#: Knots supplied by the caller (``ms_knots``), rather than derived from a rule.
+EXPLICIT = 'explicit'
+
+PLACEMENTS = (EQUAL_TIME, EQUAL_OBSERVATIONS, EXPLICIT)
+
+#: Measurements a segment needs under :data:`EQUAL_OBSERVATIONS`. Two rather than one,
+#: because a knot is placed *at* a measurement (that point then belongs to the later
+#: segment, read at ``dt = 0``), so a one-observation-per-segment grid would put the last
+#: knot on the horizon itself and leave a zero-length final segment.
+OBSERVATIONS_PER_SEGMENT = 2
+
+
+def max_segments(times, placement=EQUAL_TIME, knots=None):
+    """The finest segment count ``times`` can support under ``placement``.
+
+    Above it a rung is not the method: knots fall between observations everywhere and the
+    auxiliary states of segments with no data are determined by continuity alone.
+    :func:`~pybnf.shooting.driver.feasible_ladder` drops rungs above this and reports it.
+    """
+    if placement == EXPLICIT:
+        return max(1, len(knots or ()) + 1)
+    unique = len(np.unique(np.asarray(times, dtype=float).reshape(-1)))
+    if placement == EQUAL_OBSERVATIONS:
+        return max(1, unique // OBSERVATIONS_PER_SEGMENT)
+    return max(1, unique)
+
 
 class SegmentGrid:
     """The knots of one experiment's time course at one segment count.
@@ -68,9 +126,15 @@ class SegmentGrid:
         first measurement is after the model's ``t = 0`` still integrates from ``0``, so a
         caller that knows the simulation's own start passes it.
     :param horizon: The horizon's end. Defaults to ``max(times)``.
+    :param placement: One of :data:`PLACEMENTS`. See the module docstring.
+    :param knots: Explicit knot times, which force ``placement = 'explicit'``. These are the
+        **finest** rung's knots: a coarser rung of the same ladder keeps the sublist its own
+        fractions select, so a ``4 -> 2 -> 1`` ladder over three explicit knots keeps the
+        middle one at ``m = 2`` -- by the same fraction identity every other placement uses.
     """
 
-    def __init__(self, times, n_segments, label='exp', start=None, horizon=None):
+    def __init__(self, times, n_segments, label='exp', start=None, horizon=None,
+                 placement=EQUAL_TIME, knots=None):
         self.times = np.asarray(times, dtype=float).reshape(-1)
         if self.times.size == 0:
             raise PybnfError('A multiple-shooting segment grid needs at least one '
@@ -83,6 +147,11 @@ class SegmentGrid:
         if KNOT in self.label:
             raise PybnfError("A multiple-shooting experiment label may not contain %r, the "
                              "knot-name separator; got %r." % (KNOT, self.label))
+        self.placement = EXPLICIT if knots else str(placement)
+        if self.placement not in PLACEMENTS:
+            raise PybnfError('Unknown multiple-shooting knot placement %r; expected one of '
+                             '%s.' % (placement, ', '.join(PLACEMENTS)))
+        self.explicit_knots = tuple(float(t) for t in (knots or ()))
         self.start = float(np.min(self.times) if start is None else start)
         self.horizon = float(np.max(self.times) if horizon is None else horizon)
         if not self.horizon > self.start:
@@ -94,13 +163,15 @@ class SegmentGrid:
                 'Experiment %r has measurement times outside its own [%g, %g] horizon.'
                 % (self.label, self.start, self.horizon))
 
-        span = self.horizon - self.start
-        #: Each interior knot's exact fraction of the horizon -- the identity
-        #: :meth:`~pybnf.transcription.layout.AugmentedLayout.carry_over` matches on.
+        #: Each interior knot's exact fraction of the segment count -- the identity
+        #: :meth:`~pybnf.transcription.layout.AugmentedLayout.carry_over` matches on. An
+        #: ordinal, not a claim about where the knot sits (see the module docstring); under
+        #: :data:`EQUAL_TIME` the two coincide.
         self.fractions = tuple(Fraction(i, self.n_segments)
                                for i in range(1, self.n_segments))
         #: Interior knot times (``m - 1`` of them; empty at ``m = 1``).
-        self.knot_times = tuple(self.start + float(f) * span for f in self.fractions)
+        self.knot_times = self._place()
+        self._check_knots()
         #: Each segment's start time: the horizon's start, then every interior knot.
         self.starts = (self.start,) + self.knot_times
         #: Each segment's end time.
@@ -109,6 +180,69 @@ class SegmentGrid:
         self.segment_of = np.clip(
             np.searchsorted(np.asarray(self.starts, dtype=float), self.times, side='right') - 1,
             0, self.n_segments - 1)
+
+    # -- placement --------------------------------------------------------------
+
+    def _place(self):
+        """Map each fraction to a knot time under this grid's placement rule."""
+        if not self.fractions:
+            return ()
+        if self.placement == EQUAL_TIME:
+            span = self.horizon - self.start
+            return tuple(self.start + float(f) * span for f in self.fractions)
+        if self.placement == EQUAL_OBSERVATIONS:
+            unique = np.unique(self.times)
+            n = len(unique)
+            # Segment j owns unique[round(j n / m) : round((j+1) n / m)], so knot j sits at
+            # unique[round(j n / m)] -- a *measurement* time, which by this module's
+            # half-open convention belongs to the later segment and is read at dt = 0 from
+            # that knot's own auxiliary state. Balanced by construction, and it is the same
+            # index at every rung whose fraction coincides, which is what carries over.
+            return tuple(float(unique[int(round(float(f) * n))]) for f in self.fractions)
+        # Explicit: the fractions select from the finest rung's own list. At the finest
+        # rung that is the whole list in order; at a rung whose fraction i/m equals a finest
+        # fraction j/M it is knot j - 1, which is exactly the knot that carries over.
+        finest = len(self.explicit_knots) + 1
+        return tuple(self.explicit_knots[
+            min(max(int(round(float(f) * finest)) - 1, 0), finest - 2)]
+            for f in self.fractions)
+
+    def _check_knots(self):
+        """Knots must be strictly increasing and lie strictly inside the horizon.
+
+        A repeated or out-of-order knot is a zero-length or negative-length segment, which
+        no simulator can integrate and which would otherwise surface as an opaque failure
+        several layers down. The message names the placement, because the fix differs: for a
+        derived placement it is a segment count the data cannot support, and for an explicit
+        one it is the supplied list.
+        """
+        bad = None
+        previous = self.start
+        for time in self.knot_times:
+            if not previous < time:
+                bad = time
+                break
+            previous = time
+        if bad is None and self.knot_times and not self.knot_times[-1] < self.horizon:
+            bad = self.knot_times[-1]
+        if bad is None:
+            return
+        if self.placement == EXPLICIT:
+            raise PybnfError(
+                'The explicit multiple-shooting knots for experiment %r are not strictly '
+                'increasing inside its own (%g, %g) horizon: %s.'
+                % (self.label, self.start, self.horizon,
+                   ', '.join('%g' % t for t in self.explicit_knots)),
+                hint='Supply knot times in increasing order, each strictly between the '
+                     'experiment\'s first and last measurement.')
+        raise PybnfError(
+            'Multiple shooting cannot cut experiment %r into %i segments by %s: the knots '
+            'it places are not strictly increasing inside its (%g, %g) horizon.'
+            % (self.label, self.n_segments, self.placement.replace('_', ' '),
+               self.start, self.horizon),
+            hint='Lower ms_segments, or use the default ms_knot_placement = equal_time, '
+                 'which needs one measurement per segment rather than %i.'
+                 % OBSERVATIONS_PER_SEGMENT)
 
     # -- identity ---------------------------------------------------------------
 
@@ -174,10 +308,12 @@ class SegmentGrid:
             return ('%s: 1 segment over [%g, %g] (the ordinary unsegmented problem)'
                     % (self.label, self.start, self.horizon))
         counts = [len(self.rows_in(j)) for j in range(self.n_segments)]
-        return ('%s: %i segments over [%g, %g], knots at %s, %s data point(s) per segment'
-                % (self.label, self.n_segments, self.start, self.horizon,
-                   ', '.join('%g' % t for t in self.knot_times),
-                   '/'.join(str(c) for c in counts)))
+        return ('%s: %i segments over [%g, %g] by %s, knots at %s, %s data point(s) per '
+                'segment' % (self.label, self.n_segments, self.start, self.horizon,
+                             self.placement.replace('_', ' '),
+                             ', '.join('%g' % t for t in self.knot_times),
+                             '/'.join(str(c) for c in counts)))
 
     def __repr__(self):
-        return 'SegmentGrid(%r, m=%i, knots=%i)' % (self.label, self.n_segments, self.n_knots)
+        return 'SegmentGrid(%r, m=%i, knots=%i, %s)' % (self.label, self.n_segments,
+                                                        self.n_knots, self.placement)

--- a/pybnf/shooting/net_backend.py
+++ b/pybnf/shooting/net_backend.py
@@ -42,6 +42,8 @@ the state of a rule-based model, not something this backend can arrange away, so
 it from the run time.
 """
 
+import threading
+
 import numpy as np
 
 from ..data import Data, OutputSensitivities
@@ -54,9 +56,12 @@ class NetSegmentBackend(SegmentBackend):
 
     :param model: The :class:`~pybnf.bngsim_model.net_model.BngsimModel`. This backend
         **owns** it, assigning the parameter set in place rather than deep-copying per
-        evaluation -- sound because the whole multiple-shooting driver runs single-threaded
-        on the master (a segment is not a :class:`~pybnf.pset.PSet` evaluation and never
-        reaches a worker).
+        evaluation -- sound because the multiple-shooting driver runs on the master (a
+        segment is not a :class:`~pybnf.pset.PSet` evaluation and never reaches a worker),
+        and because the writes to it happen once per point under this backend's lock, before
+        any segment of that point runs. A *lane* is one such per-point clone plus its engine
+        and ``Simulator``, and two segments cannot share one (see
+        :mod:`pybnf.shooting.parallel`).
     :param sim_params: The parsed ``simulate()`` action this experiment is measured by, as
         :func:`~pybnf.bngsim_model.parsing._parse_simulate_action` returns it.
     :param mutant: The ``MutationSet`` (condition) it is measured under.
@@ -74,10 +79,9 @@ class NetSegmentBackend(SegmentBackend):
         self._states = tuple(model._engine_model.species_names)
         self._nominal = self._declared_state()
         self.n_simulations = 0
-        self._point = None          # identity of the PSet the prepared engine holds
-        self._prepared = None       # the per-point model copy (base or mutant)
-        self._engine = None
-        self._sim = None
+        self._point = None          # identity of the PSet the prepared lanes hold
+        self._lanes = []            # one (model copy, engine, Simulator) per lane
+        self._lock = threading.RLock()
 
     # -- the contract -----------------------------------------------------------
 
@@ -89,12 +93,35 @@ class NetSegmentBackend(SegmentBackend):
     def nominal_state(self):
         return self._nominal
 
-    def simulate(self, pset, sample_times, initial_state=None):
+    def open_lanes(self, pset, n_lanes):
+        """Build up to ``n_lanes`` model-copy + engine + simulator triples at ``pset``.
+
+        The ``.net`` peer of
+        :meth:`~pybnf.shooting.bngsim_backend.BngsimSegmentBackend.open_lanes`, and the more
+        expensive of the two: a lane here is a whole cloned PyBNF model, so the cost model in
+        :mod:`pybnf.shooting.parallel` tilts further toward serial on a small network and
+        further toward parallel on a large one, where the ``n_species``-wide
+        initial-condition sensitivity system dominates a segment.
+        """
+        wanted = max(1, int(n_lanes))
+        with self._lock:
+            self._sync_point(pset)
+            for lane in range(wanted):
+                try:
+                    self._context(lane)
+                except (PybnfError, SegmentSimulationFailed):
+                    return max(1, lane)
+            return wanted
+
+    def simulate(self, pset, sample_times, initial_state=None, lane=0):
         times = [float(t) for t in np.asarray(sample_times, dtype=float).reshape(-1)]
         if len(times) < 2:
             raise PybnfError('A multiple-shooting segment needs at least two output times; '
                              'got %r.' % (times,))
-        prepared, engine, sim = self._prepare(pset)
+        with self._lock:
+            self._sync_point(pset)
+            prepared, engine, sim = self._context(lane)
+            self.n_simulations += 1
         if initial_state:
             for name, value in initial_state.items():
                 if name not in self._state_set:
@@ -105,30 +132,47 @@ class NetSegmentBackend(SegmentBackend):
                 engine.set_concentration(name, float(value))
             engine.save_concentrations()
         engine.reset()
-        self.n_simulations += 1
         try:
             result = sim.run(t_span=(times[0], times[-1]), n_points=len(times),
                              sample_times=times, **self._run_kwargs())
             data = self._data_with_state(prepared, result)
         except Exception as exc:
-            # A non-integrable point is a property of the point, not of the run. The
-            # prepared engine is dropped: whatever state a failed solve left it in is not
-            # one to restart the next segment from.
-            self._point = None
+            # A non-integrable point is a property of the point, not of the run. That lane
+            # is dropped -- whatever state a failed solve left it in is not one to restart
+            # another segment from -- but only that lane, because a parallel pass has other
+            # segments still running in the others.
+            self._drop_lane(lane)
             raise SegmentSimulationFailed('%s: %s' % (type(exc).__name__, exc)) from exc
         if not np.all(np.isfinite(np.asarray(data.data, dtype=float))):
             raise SegmentSimulationFailed('the segment produced a non-finite trajectory')
         return data
 
-    # -- one engine + one simulator per parameter point --------------------------
+    # -- one engine + one simulator per parameter point, per lane ----------------
 
     @property
     def _state_set(self):
         return set(self._states)
 
-    def _prepare(self, pset):
-        """The per-point model copy, engine model and ``Simulator``, built once and reused
-        across that point's segments.
+    def _sync_point(self, pset):
+        """Point this backend's lanes at ``pset``, discarding any built for another."""
+        if self._point is pset:
+            return
+        self._lanes = []
+        self.model.param_set = pset
+        # The per-action sensitivity gate (#475) reads this: without it a scored
+        # experiment's segments would run sensitivity-free and the assembly would find no
+        # tensor to differentiate.
+        self.model._current_action_suffix = self.sim_params.get('suffix', 'time_course')
+        self._point = pset
+
+    def _drop_lane(self, lane):
+        with self._lock:
+            if 0 <= lane < len(self._lanes):
+                self._lanes[lane] = None
+
+    def _context(self, lane):
+        """Lane ``lane``'s model copy, engine model and ``Simulator``, built on demand and
+        reused across that point's segments.
 
         Mirrors ``BngsimModel.execute``'s preamble -- apply the parameter set, re-derive the
         species initial concentrations from it (a free parameter that only seeds an IC is a
@@ -137,13 +181,10 @@ class NetSegmentBackend(SegmentBackend):
         ``MutationSet`` goes through it too, so there is one code path rather than a special
         case that could drift from it.
         """
-        if self._point is pset and self._engine is not None:
-            return self._prepared, self._engine, self._sim
-        self.model.param_set = pset
-        # The per-action sensitivity gate (#475) reads this: without it a scored
-        # experiment's segments would run sensitivity-free and the assembly would find no
-        # tensor to differentiate.
-        self.model._current_action_suffix = self.sim_params.get('suffix', 'time_course')
+        while len(self._lanes) <= lane:
+            self._lanes.append(None)
+        if self._lanes[lane] is not None:
+            return self._lanes[lane]
         try:
             prepared = self.model._get_mutant_model_bngsim(self.mutant)
             engine = prepared._engine_model
@@ -167,8 +208,8 @@ class NetSegmentBackend(SegmentBackend):
             raise SegmentSimulationFailed(
                 'the model could not be prepared at this point (%s: %s)'
                 % (type(exc).__name__, exc)) from exc
-        self._point, self._prepared, self._engine, self._sim = pset, prepared, engine, sim
-        return prepared, engine, sim
+        self._lanes[lane] = (prepared, engine, sim)
+        return self._lanes[lane]
 
     def _run_kwargs(self):
         """The action's own tolerances and this fit's ``wall_time_sim``, as the ordinary

--- a/pybnf/shooting/parallel.py
+++ b/pybnf/shooting/parallel.py
@@ -1,0 +1,210 @@
+"""Running one point's segments: serially, or across a pool of lanes (#563).
+
+Issue #563's implementation proposal ends "Segment simulations can run in parallel", and
+they are the one embarrassingly parallel thing in the method: one augmented-model
+evaluation is ``m`` spans of one trajectory integrated from ``m`` states the transcription
+already knows, with no data flowing between them. This module is that scheduler.
+
+Threads, because the integration releases the GIL
+-------------------------------------------------
+The choice between threads and processes is not a matter of taste here, and it was
+measured rather than assumed. On the motivating model (``Borghans_BiophysChem1997``: 3
+species, 21 sensitivity parameters, both axes requested), four warm engine+simulator
+replicas driven from four threads integrated 160 segments in 0.057 s against 0.153 s
+serially -- a **2.7x** speedup on 4 workers -- and every trajectory column and every entry
+of ``d(y)/d(theta)`` came back *bit-identical* to the serial run. So bngsim drops the GIL
+inside CVODE, and the arithmetic above this seam does not have to change to accommodate a
+scheduler.
+
+Processes were never a real option: a segment costs one integration, and the #563
+prototype measured that constructing a sensitivity-bearing simulator costs ~230 ms cold
+against ~50 ms for an integration. A process pool would pay that per worker per point (or
+pay to pickle an engine model, which does not pickle), which is why
+:class:`~pybnf.shooting.backend.SegmentBackend` keeps warm state per parameter point in
+the first place.
+
+A lane is a warm engine + simulator, and it is not free
+-------------------------------------------------------
+Two segments cannot share one ``Simulator``: the backend restarts it from the knot's state
+with ``save_concentrations()`` + ``reset()``, so a second segment on the same object would
+be integrating from the first's start state. A *lane* is therefore an independent
+engine+simulator pair, and running ``L`` segments at once needs ``L`` of them **at that
+parameter point** -- so the point pays ``L`` preparations instead of one.
+
+That is the whole cost model, and it decides the default:
+
+    parallel wins when   (m - 1) * t_integrate  >  (L - 1) * t_prepare
+
+On Borghans, measured, ``t_prepare`` is ~4.1 ms and ``t_integrate`` is ~1-2.3 ms, so at
+``m = L = 4`` parallel segments would *lose* -- the model is small enough that preparing
+the extra lanes costs more than the integrations they save. On a model where a segment is
+the expensive thing, it wins nearly linearly, and both cost terms move with the model
+rather than with the fit: the initial-condition sensitivity system is ``n_species`` wide,
+so a segment's integration grows with the state while a lane's preparation does not grow
+as fast.
+
+So ``ms_parallel_segments`` defaults to **1** (serial), which is the measured right answer
+for the model this feature was built for, and a run that sets it reports what it measured
+(:meth:`SegmentPool.describe`) rather than leaving a user to guess whether it helped.
+
+What parallel gives up
+----------------------
+The serial pass stops at the first segment that fails to integrate -- the rest of that
+point's segments are work whose answer is already decided, which is what keeps a search
+that has wandered into a non-integrable corner from paying ``m`` simulations per rejected
+trial. A submitted future cannot be un-run, so the parallel pass pays all ``m``. The
+answer is identical; the *simulation count* a run reports is not, and on a multi-start
+sweep over an uninformed box (where most points do not integrate) that difference is the
+dominant cost. Stated here rather than discovered from a benchmark table.
+"""
+
+import queue
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+from .backend import SegmentSimulationFailed, trace_from_data
+
+
+class SegmentTask:
+    """One span to integrate: everything :meth:`SegmentPool.run` needs and nothing else."""
+
+    __slots__ = ('backend', 'times', 'initial_state', 'state_names')
+
+    def __init__(self, backend, times, initial_state, state_names):
+        self.backend = backend
+        self.times = times
+        self.initial_state = initial_state
+        self.state_names = tuple(state_names)
+
+
+class SegmentPool:
+    """The segment pass, at one degree of parallelism.
+
+    :param n_lanes: How many segments to integrate at once. ``1`` (the default) runs them
+        on the calling thread, in order, short-circuiting at the first failure -- byte-for-
+        byte the behaviour that shipped with ADR-0110.
+
+    One pool is built per fit and shared by every rung of the ladder and every start, so a
+    thread pool is created at most once per run.
+    """
+
+    def __init__(self, n_lanes=1):
+        self.n_lanes = max(1, int(n_lanes))
+        self._executor = None
+
+    @property
+    def parallel(self):
+        return self.n_lanes > 1
+
+    def describe(self):
+        if not self.parallel:
+            return 'segments simulated serially on the master'
+        return ('segments simulated %i at a time, on %i warm engine+simulator lane(s) per '
+                'experiment' % (self.n_lanes, self.n_lanes))
+
+    def run(self, pset, tasks):
+        """Integrate every task at ``pset``.
+
+        Returns ``(traces, ok)``: the per-task :class:`~pybnf.shooting.backend.SegmentTrace`
+        list and whether *every* one integrated to a finite trajectory. A pass with
+        ``ok = False`` returns ``None`` for the traces, because the caller turns any failure
+        into a non-finite local model and never reads the partial result -- and returning a
+        half-filled list would invite someone to.
+        """
+        tasks = list(tasks)
+        if not self.parallel or len(tasks) < 2:
+            return self._run_serial(pset, tasks)
+        return self._run_parallel(pset, tasks)
+
+    # -- serial -----------------------------------------------------------------
+
+    def _run_serial(self, pset, tasks):
+        traces = []
+        for task in tasks:
+            trace = _integrate(task, pset, 0)
+            if trace is None or not trace.is_finite():
+                # One unusable segment makes the whole local model unusable, so the rest of
+                # this point's segments are work whose answer is already decided.
+                return None, False
+            traces.append(trace)
+        return traces, True
+
+    # -- parallel ---------------------------------------------------------------
+
+    def _run_parallel(self, pset, tasks):
+        lanes = self._open_lanes(pset, tasks)
+        executor = self._pool()
+        futures = []
+        for task in tasks:
+            lane_queue = lanes[id(task.backend)]
+            futures.append(executor.submit(_integrate_in_lane, task, pset, lane_queue))
+        traces = [future.result() for future in futures]
+        if any(trace is None or not trace.is_finite() for trace in traces):
+            return None, False
+        return traces, True
+
+    def _open_lanes(self, pset, tasks):
+        """Prepare each backend's lanes **on the calling thread**, and hand back one queue of
+        lane indices per backend.
+
+        Preparation is where a backend touches shared model state (it assigns the parameter
+        set on the model it owns), so it happens here, once, before any worker starts --
+        rather than being raced for inside :meth:`SegmentBackend.simulate`. A queue rather
+        than a modulo of the task index because a backend with more segments than lanes must
+        make a worker *wait* for a lane instead of two workers sharing one simulator, which
+        would have each integrating from the other's start state.
+        """
+        lanes = {}
+        for task in tasks:
+            key = id(task.backend)
+            if key in lanes:
+                continue
+            available = task.backend.open_lanes(pset, self.n_lanes)
+            lane_queue = queue.Queue()
+            for lane in range(max(1, int(available))):
+                lane_queue.put(lane)
+            lanes[key] = lane_queue
+        return lanes
+
+    def _pool(self):
+        if self._executor is None:
+            self._executor = ThreadPoolExecutor(
+                max_workers=self.n_lanes, thread_name_prefix='ms-segment')
+        return self._executor
+
+    def close(self):
+        """Shut the thread pool down. Idempotent; a serial pool never opened one."""
+        if self._executor is not None:
+            self._executor.shutdown(wait=True)
+            self._executor = None
+
+    def __repr__(self):
+        return 'SegmentPool(lanes=%i)' % self.n_lanes
+
+
+def _integrate(task, pset, lane):
+    """One span, in one lane. ``None`` when it did not integrate."""
+    try:
+        data = task.backend.simulate(pset, task.times, task.initial_state, lane=lane)
+    except SegmentSimulationFailed:
+        return None
+    return trace_from_data(data, task.state_names)
+
+
+def _integrate_in_lane(task, pset, lane_queue):
+    """Claim a lane for the whole integration, then give it back.
+
+    The claim spans the *simulation*, not just the dispatch: a lane is a stateful
+    engine+simulator that is reset to this segment's start knot, so releasing it early would
+    let a second segment restart it underneath the first.
+    """
+    lane = lane_queue.get()
+    try:
+        return _integrate(task, pset, lane)
+    finally:
+        lane_queue.put(lane)
+
+
+#: The pool a problem built without one uses -- serial, so nothing changes for a caller
+#: that does not ask for lanes.
+SERIAL = SegmentPool(1)

--- a/pybnf/shooting/parallel.py
+++ b/pybnf/shooting/parallel.py
@@ -59,7 +59,6 @@ dominant cost. Stated here rather than discovered from a benchmark table.
 """
 
 import queue
-import threading
 from concurrent.futures import ThreadPoolExecutor
 
 from .backend import SegmentSimulationFailed, trace_from_data

--- a/pybnf/shooting/problem.py
+++ b/pybnf/shooting/problem.py
@@ -73,8 +73,9 @@ from ..transcription import (
     TranscriptionProblem,
     VariableBlock,
 )
-from .backend import SegmentSimulationFailed, trace_from_data
-from .grid import SegmentGrid
+from .backend import SegmentSimulationFailed
+from .grid import EQUAL_TIME, SegmentGrid, max_segments
+from .parallel import SERIAL, SegmentTask
 
 #: Floor under a state magnitude, so a species that is identically zero over the whole
 #: horizon still gets a strictly positive constraint scale and a finite auxiliary box. The
@@ -111,10 +112,15 @@ class ShootingExperiment:
     :param label: The label its knots are named under. Defaults to the suffix.
     :param start: Where the simulation starts. Defaults to the first measurement time; a
         time course whose first measurement is after ``t = 0`` should pass ``0.0``.
+    :param placement: How this experiment's knots are placed -- one of
+        :data:`~pybnf.shooting.grid.PLACEMENTS`. Fixed for the whole fit, so every rung of
+        the ladder places its knots by the same rule and their fractions mean one thing.
+    :param knots: Explicit knot times for the finest rung, which force
+        ``placement = 'explicit'``.
     """
 
     def __init__(self, key, backend, exp_data, routing, times=None, label=None, start=None,
-                 horizon=None):
+                 horizon=None, placement=EQUAL_TIME, knots=None):
         self.key = (str(key[0]), str(key[1]))
         self.backend = backend
         self.exp_data = exp_data
@@ -125,11 +131,19 @@ class ShootingExperiment:
         self.label = str(label if label is not None else self.key[1])
         self.start = start
         self.horizon = horizon
+        self.placement = str(placement)
+        self.knots = tuple(float(t) for t in (knots or ()))
 
     def grid(self, n_segments):
         """This experiment's knots at one segment count."""
         return SegmentGrid(self.times, n_segments, label=self.label, start=self.start,
-                           horizon=self.horizon)
+                           horizon=self.horizon, placement=self.placement,
+                           knots=self.knots or None)
+
+    @property
+    def max_segments(self):
+        """The finest rung this experiment's data supports under its own placement."""
+        return max_segments(self.times, self.placement, self.knots or None)
 
     @property
     def state_names(self):
@@ -195,11 +209,15 @@ class MultipleShootingProblem(TranscriptionProblem, EqualitySystem):
     :param scales: ``{experiment key: per-state constraint scale}`` -- the magnitude each
         continuity defect is measured against.
     :param name: The stage label for the trace (``'m=4'``).
+    :param pool: The :class:`~pybnf.shooting.parallel.SegmentPool` that runs this stage's
+        segment passes. Defaults to the serial one, so a caller that does not ask for lanes
+        gets exactly the behaviour that shipped with ADR-0110.
     """
 
     def __init__(self, experiments, objective, variables, pset_from_u, blocks, scales,
-                 name=None):
+                 name=None, pool=None):
         self.experiments = list(experiments)
+        self._pool = pool or SERIAL
         self.objective = objective
         self.variables = list(variables)
         self._pset_from_u = pset_from_u
@@ -277,39 +295,29 @@ class MultipleShootingProblem(TranscriptionProblem, EqualitySystem):
         together) and a segment simulation is the expensive thing here. ``None`` when any
         segment failed to integrate: the caller turns that into a non-finite local model,
         which is the signal the inner solver's trust region backs off on.
+
+        The pass itself belongs to :class:`~pybnf.shooting.parallel.SegmentPool` -- the
+        segments of one point are independent (each is one span from a state the
+        transcription already knows, with no data flowing between them), so whether they run
+        one at a time or several at once is a scheduling decision and not a property of the
+        transcription. This method's job is to say *which* spans, from *which* states.
         """
         u = np.asarray(u, dtype=float).reshape(-1)
         key = u.tobytes()
         if self._cache_key == key:
             return self._cache
         pset = self._pset_from_u(self._layout.reported_of(u))
-        traces = []
-        ok = True
+        tasks, shape = [], []
         for experiment in self.experiments:
-            per_segment = []
+            shape.append(experiment.grid.n_segments)
             for segment in range(experiment.grid.n_segments):
                 times, _rows = experiment.grid.sample_times(segment)
-                try:
-                    data = experiment.backend.simulate(
-                        pset, times, self._knot_state(u, experiment, segment))
-                    trace = trace_from_data(data, experiment.state_names)
-                except SegmentSimulationFailed:
-                    trace, ok = None, False
-                else:
-                    if not trace.is_finite():
-                        ok = False
-                per_segment.append(trace)
-                if not ok:
-                    # One unusable segment makes the whole local model unusable, so the
-                    # rest of this point's segments are work whose answer is already
-                    # decided. Stopping here is what keeps a search that has wandered into
-                    # a non-integrable corner from paying m simulations per rejected trial.
-                    break
-            traces.append(per_segment)
-            if not ok:
-                break
+                tasks.append(SegmentTask(experiment.backend, times,
+                                         self._knot_state(u, experiment, segment),
+                                         experiment.state_names))
+        flat, ok = self._pool.run(pset, tasks)
         self._cache_key = key
-        self._cache = (pset, traces) if ok else None
+        self._cache = (pset, _regroup(flat, shape)) if ok else None
         return self._cache
 
     def _free_params(self, u, pset):
@@ -546,7 +554,7 @@ class MultipleShootingProblem(TranscriptionProblem, EqualitySystem):
 # ---------------------------------------------------------------------------
 
 def seed_stage(specs, n_segments, objective, variables, pset_from_u, reported,
-               aux_decades=AUX_DECADES, name=None):
+               aux_decades=AUX_DECADES, name=None, pool=None):
     """Build one rung of the ladder, with its auxiliary states seeded from ``reported``.
 
     Each experiment is simulated **once**, unsegmented, at the incoming parameters, and the
@@ -582,7 +590,7 @@ def seed_stage(specs, n_segments, objective, variables, pset_from_u, reported,
                                         initial))
         staged.append(experiment)
     return MultipleShootingProblem(staged, objective, variables, pset_from_u, blocks, scales,
-                                   name=name or ('m=%i' % n_segments))
+                                   name=name or ('m=%i' % n_segments), pool=pool)
 
 
 def _seed_knots(experiment, pset, nominal):
@@ -617,6 +625,15 @@ def _seed_knots(experiment, pset, nominal):
 # ---------------------------------------------------------------------------
 # Small helpers
 # ---------------------------------------------------------------------------
+
+def _regroup(flat, shape):
+    """A flat per-segment list back into one list per experiment."""
+    out, start = [], 0
+    for n in shape:
+        out.append(flat[start:start + n])
+        start += n
+    return out
+
 
 def _fold_route(route, trace):
     """``d(end state)/d(one free parameter)``: the route's contributions, summed.

--- a/pybnf/transcription/__init__.py
+++ b/pybnf/transcription/__init__.py
@@ -54,6 +54,7 @@ from .outer import (
     CertifiedIterate,
     InnerOutcome,
     OuterResult,
+    WORST_DEFECTS,
     PenaltySchedule,
     projected_gradient_norm,
 )
@@ -79,6 +80,7 @@ __all__ = [
     'CertifiedIterate',
     'InnerOutcome',
     'OuterResult',
+    'WORST_DEFECTS',
     'PenaltySchedule',
     'projected_gradient_norm',
     'HomotopyResult',

--- a/pybnf/transcription/outer.py
+++ b/pybnf/transcription/outer.py
@@ -66,6 +66,16 @@ Stalling is a state to *report*, not a failure: a feasible, stalled run has foun
 it found and could not certify a KKT residual for it, which is different from failing and
 different again from having converged.
 
+The defect report
+-----------------
+The aggregate scaled defect norm says *how far* an iterate is from feasible; it does not say
+*where*. Every iterate therefore also carries the largest individual scaled defects by name
+(:data:`WORST_DEFECTS` of them) and their RMS, which for multiple shooting reads
+``experiment1@1/2::Z_state`` -- the knot that did not close and the state it did not close
+in. That is the "report scaled continuity defects" (plural) the issue asks for, and it is
+stated here rather than in the consumer because the *scaling* is what makes the numbers
+comparable across states of different magnitude, and the scaling lives in this layer.
+
 Best-iterate certification
 --------------------------
 The loop certifies **every** outer iterate, not just the last, and reports the best
@@ -252,14 +262,25 @@ def projected_gradient_norm(point, gradient, lower, upper):
     return float(np.max(np.abs(step)))
 
 
+#: How many individual scaled defects an iterate carries for the report. A defect list is
+#: one entry per (knot, state), so a big model at a fine rung has thousands of them; the
+#: *worst* few are what answers "which knot did not close, and in which state", and keeping
+#: every iterate's whole vector would grow a run's memory with the model's state count for
+#: numbers nobody reads. The aggregate :attr:`~CertifiedIterate.defect_norm` and
+#: :attr:`~CertifiedIterate.defect_rms` are kept in full alongside.
+WORST_DEFECTS = 8
+
+
 class CertifiedIterate:
     """One outer iterate, with the certificate earned by its reported parameters."""
 
     __slots__ = ('stage', 'iteration', 'reported', 'point', 'certificate', 'defect_norm',
-                 'objective_value', 'augmented_value', 'penalty', 'optimality')
+                 'objective_value', 'augmented_value', 'penalty', 'optimality',
+                 'defect_rms', 'worst_defects', 'n_constraints')
 
     def __init__(self, stage, iteration, reported, point, certificate, defect_norm,
-                 objective_value, augmented_value, penalty, optimality):
+                 objective_value, augmented_value, penalty, optimality,
+                 defect_rms=0.0, worst_defects=(), n_constraints=0):
         self.stage = stage
         self.iteration = int(iteration)
         self.reported = np.array(reported, dtype=float, copy=True)
@@ -270,16 +291,37 @@ class CertifiedIterate:
         self.augmented_value = float(augmented_value)
         self.penalty = float(penalty)
         self.optimality = float(optimality)
+        #: Root-mean-square scaled defect, the aggregate companion to the infinity norm.
+        self.defect_rms = float(defect_rms)
+        #: The largest individual scaled defects as ``(name, value)``, worst first --
+        #: :meth:`~pybnf.transcription.equality.EqualityModel.worst`. For multiple shooting
+        #: a name is ``'<experiment>@<fraction>::<state>'``, so this says *which knot* did
+        #: not close and *in which state* rather than only how far off the worst one was.
+        self.worst_defects = tuple((str(name), float(value)) for name, value in worst_defects)
+        #: How many constraints there were in total, so a report that lists only the worst
+        #: few can say so ("the 8 largest of 1068") rather than reading as the whole set.
+        self.n_constraints = int(n_constraints)
 
     @property
     def score(self):
         """The ranking key: the certified objective."""
         return self.certificate.objective
 
+    def defect_report(self, count=None):
+        """The per-constraint defect breakdown, as one line, or ``''`` when there are no
+        constraints (the unsegmented rung of a ladder)."""
+        return _format_defects(self.worst_defects, count)
+
     def __repr__(self):
         return 'CertifiedIterate(%s #%i, certified=%.6g, defect=%.3g, opt=%.3g)' % (
             self.stage, self.iteration, self.certificate.objective, self.defect_norm,
             self.optimality)
+
+
+def _format_defects(worst, count=None):
+    """``'a::x 1.2e-03, a::y -4.5e-04'`` -- shared by the iterate and the run result."""
+    items = list(worst) if count is None else list(worst)[:int(count)]
+    return ', '.join('%s %.3g' % (name, value) for name, value in items)
 
 
 class CertifiedBest:
@@ -319,7 +361,8 @@ class OuterResult:
     """What one augmented-Lagrangian run produced."""
 
     def __init__(self, stage, iterates, best, final_point, multipliers, converged, stop_reason,
-                 certified, n_inner_evaluations, n_outer_evaluations, defect_norm, optimality):
+                 certified, n_inner_evaluations, n_outer_evaluations, defect_norm, optimality,
+                 defect_rms=0.0, worst_defects=()):
         self.stage = stage
         self.iterates = tuple(iterates)
         self.best = best
@@ -334,6 +377,10 @@ class OuterResult:
         #: Projected-gradient first-order optimality at :attr:`final_point`, measured under
         #: the last multipliers -- the other half of the KKT test the defect norm starts.
         self.optimality = float(optimality)
+        #: RMS scaled defect at :attr:`final_point`.
+        self.defect_rms = float(defect_rms)
+        #: The largest individual scaled defects at :attr:`final_point`, worst first.
+        self.worst_defects = tuple((str(name), float(value)) for name, value in worst_defects)
 
     @property
     def n_evaluations(self):
@@ -351,6 +398,14 @@ class OuterResult:
                 % (self.stage, len(self.iterates), self.stop_reason, self.defect_norm,
                    self.optimality, best, self.n_evaluations,
                    '' if self.certified else ' [UNCERTIFIED]'))
+
+    def defect_report(self, count=None):
+        """The per-constraint defect breakdown at :attr:`final_point`, as one line.
+
+        The aggregate :attr:`defect_norm` says *how far* from continuous the transcription
+        ended; this says *where*. Empty when there are no constraints, which is the
+        unsegmented rung of a ladder rather than a degenerate case."""
+        return _format_defects(self.worst_defects, count)
 
     def __repr__(self):
         return 'OuterResult(%s, %s, best=%.6g)' % (self.stage, self.stop_reason, self.best_score)
@@ -436,6 +491,8 @@ class AugmentedLagrangian:
         certified = True
         prev_defect = np.inf
         stalled_for = 0
+        defect_rms = 0.0
+        worst_defects = ()
 
         for iteration in range(1, self.max_outer + 1):
             if self.stop_check is not None and self.stop_check():
@@ -468,6 +525,8 @@ class AugmentedLagrangian:
                 stop_reason = 'inner_failed'
                 break
             defect_norm = model.defect_norm
+            defect_rms = model.equality.defect_rms
+            worst_defects = model.equality.worst(WORST_DEFECTS)
             optimality = projected_gradient_norm(u, model.gradient, layout.lower,
                                                  layout.upper)
 
@@ -531,7 +590,8 @@ class AugmentedLagrangian:
 
         return OuterResult(self.problem.name, iterates, best.record, u, multipliers,
                            converged, stop_reason, certified, inner_evals, outer_evals,
-                           defect_norm, optimality)
+                           defect_norm, optimality, defect_rms=defect_rms,
+                           worst_defects=worst_defects)
 
     def _certify(self, iteration, u, model, penalty, optimality):
         """Reconstruct this iterate's reported parameters and wrap it as a
@@ -553,4 +613,6 @@ class AugmentedLagrangian:
                 % type(certificate).__name__)
         return CertifiedIterate(self.problem.name, iteration, reported, u, certificate,
                                 model.defect_norm, model.objective_value, model.value, penalty,
-                                optimality)
+                                optimality, defect_rms=model.equality.defect_rms,
+                                worst_defects=model.equality.worst(WORST_DEFECTS),
+                                n_constraints=model.equality.n_constraints)

--- a/tests/test_pybnf_main_helpers.py
+++ b/tests/test_pybnf_main_helpers.py
@@ -103,21 +103,39 @@ def test_refiners_are_the_start_point_optimizers():
     """The ``refiner`` flag (refine_method targets, #403/ADR-0015) marks the
     start-point local optimizers: Simplex, Powell, CMA-ES, and the gradient-based
     methods (#386/#481) -- TRF (trust-region least-squares), L-BFGS-B (scalar quasi-Newton),
-    and GNTR (general-objective Fisher/Gauss-Newton trust region)."""
-    assert {c for c, e in FIT_TYPE_REGISTRY.items() if e.refiner} == {'sim', 'powell', 'cmaes', 'trf', 'lbfgs', 'gntr'}
+    and GNTR (general-objective Fisher/Gauss-Newton trust region).
+
+    Plus multiple shooting (``ms``, #563/ADR-0111), which is the least obvious member and
+    the reason this set is pinned. Seeded at one point it runs its ``4 -> 2 -> 1`` ladder
+    from that point and its last rung *is* the unsegmented local solve, so it is a polish --
+    and ``refine = 1, refine_method = ms`` is the "global search, then let the transcription
+    convert the basin" pairing #563's acceptance benchmark asks for as its fourth arm.
+    """
+    assert {c for c, e in FIT_TYPE_REGISTRY.items() if e.refiner} == {
+        'sim', 'powell', 'cmaes', 'trf', 'lbfgs', 'gntr', 'ms'}
 
 
 def test_box_start_optimizers_are_a_subset_of_refiners():
     """The ``start_from_box`` flag (#404/ADR-0017) marks the start-point optimizers
     that may *also* run as a standalone search over a bounded-prior box: the derivative-free
     local methods -- CMA-ES (the global covariance-adaptation search) plus Simplex and Powell,
-    which learned box/global-start mode + concurrent multi-start (#498/ADR-0072) -- and the
+    which learned box/global-start mode + concurrent multi-start (#498/ADR-0072) -- the
     bounded gradient methods (#386/#481) -- TRF, L-BFGS-B, and GNTR, whose box IS the
-    parameter bounds they project/reflect into. It is a strict subset of the refiners: a box
-    optimizer is a refiner that learned a second start mode."""
+    parameter bounds they project/reflect into -- and multiple shooting (#563), which has
+    always drawn its starts from the box.
+
+    The two sets happen to be coextensive today; the invariant that matters and is asserted
+    is the containment. A box optimizer is a refiner that learned a second start mode, so
+    ``start_from_box`` without ``refiner`` would be a classification with no meaning -- and
+    ``refiner`` without ``start_from_box`` is the trap ``ms`` fell into first: ``refiner`` is
+    what ``config._load_variables`` reads to classify a fit type as *start-point*, and a
+    start-point type that is not also ``start_from_box`` may not be given bounded priors at
+    all, which would have made every standalone ``loguniform_var`` multiple-shooting fit a
+    configuration error.
+    """
     box = {c for c, e in FIT_TYPE_REGISTRY.items() if e.start_from_box}
     refiners = {c for c, e in FIT_TYPE_REGISTRY.items() if e.refiner}
-    assert box == {'cmaes', 'sim', 'powell', 'trf', 'lbfgs', 'gntr'}
+    assert box == {'cmaes', 'sim', 'powell', 'trf', 'lbfgs', 'gntr', 'ms'}
     assert box <= refiners
 
 

--- a/tests/test_shooting.py
+++ b/tests/test_shooting.py
@@ -32,6 +32,8 @@ single-shoot reconstruction -- and it has the motivating problem's hard corner: 
 no data term at all, so half the auxiliary variables are determined by continuity alone.
 """
 
+import threading
+
 import numpy as np
 import pytest
 from scipy.optimize import least_squares
@@ -42,12 +44,17 @@ from pybnf.objective import ChiSquareObjective
 from pybnf.printing import PybnfError
 from pybnf.pset import FreeParameter, PSet
 from pybnf.shooting import (
+    EQUAL_OBSERVATIONS,
+    EQUAL_TIME,
+    EXPLICIT,
     GaussNewtonSolver,
     SegmentBackend,
     SegmentGrid,
+    SegmentPool,
     SegmentSimulationFailed,
     ShootingExperiment,
     feasible_ladder,
+    max_segments,
     run_multiple_shooting,
     seed_stage,
 )
@@ -72,9 +79,21 @@ class TwoStateBackend(SegmentBackend):
     :meth:`simulate` therefore runs unmodified.
     """
 
-    def __init__(self):
+    def __init__(self, n_lanes=1):
         self.n_simulations = 0
         self.fail_beyond = None    # |k| above which this "model" refuses to integrate
+        self._n_lanes = int(n_lanes)
+        #: Lanes currently mid-integration, so a test can assert that a scheduler never puts
+        #: two segments in one lane at once -- the invariant a stateful simulator needs and
+        #: this closed-form one cannot notice being violated.
+        self.busy = set()
+        self.max_concurrent = 0
+        self.collisions = 0
+        #: An optional :class:`threading.Barrier` every simulation waits on, which turns
+        #: "did these actually overlap?" from a timing observation into a deterministic one:
+        #: a pass that runs its segments one at a time cannot get past it.
+        self.barrier = None
+        self._lock = threading.Lock()
 
     @property
     def state_names(self):
@@ -84,8 +103,25 @@ class TwoStateBackend(SegmentBackend):
     def nominal_state(self):
         return np.array([1.0, W0])
 
-    def simulate(self, pset, sample_times, initial_state=None):
-        self.n_simulations += 1
+    def open_lanes(self, pset, n_lanes):
+        return min(int(n_lanes), self._n_lanes)
+
+    def simulate(self, pset, sample_times, initial_state=None, lane=0):
+        with self._lock:
+            self.n_simulations += 1
+            if lane in self.busy:
+                self.collisions += 1
+            self.busy.add(lane)
+            self.max_concurrent = max(self.max_concurrent, len(self.busy))
+        try:
+            if self.barrier is not None:
+                self.barrier.wait()
+            return self._simulate(pset, sample_times, initial_state)
+        finally:
+            with self._lock:
+                self.busy.discard(lane)
+
+    def _simulate(self, pset, sample_times, initial_state=None):
         k = float(pset['k'])
         if self.fail_beyond is not None and abs(k) > self.fail_beyond:
             raise SegmentSimulationFailed('the closed-form backend refuses |k| > %g'
@@ -153,7 +189,8 @@ def make_spec(times, obs, backend=None):
                               routing, label='exp1', start=0.0)
 
 
-def build_stage(n_segments, start_u=(0.4, 0.8), seed=4, backend=None, log_space=False):
+def build_stage(n_segments, start_u=(0.4, 0.8), seed=4, backend=None, log_space=False,
+                pool=None):
     """One rung, seeded at ``start_u``, plus the pieces a caller needs to poke at it.
 
     ``start_u`` is in **sampling space**, so under ``log_space`` it is ``log10(theta)``.
@@ -162,7 +199,7 @@ def build_stage(n_segments, start_u=(0.4, 0.8), seed=4, backend=None, log_space=
     free = variables(log_space=log_space)
     spec = make_spec(times, obs, backend=backend)
     problem = seed_stage([spec], n_segments, ChiSquareObjective(), free,
-                         pset_from_u_for(free), np.asarray(start_u, dtype=float))
+                         pset_from_u_for(free), np.asarray(start_u, dtype=float), pool=pool)
     return problem, spec, free
 
 
@@ -219,6 +256,89 @@ class TestSegmentGrid:
     def test_a_label_may_not_contain_the_knot_separator(self):
         with pytest.raises(PybnfError, match='knot-name separator'):
             SegmentGrid(np.linspace(0, 1, 3), 2, label='a%sb' % KNOT)
+
+
+# ---------------------------------------------------------------------------
+# Where the knots go (#563: "a segment count or explicit knots; default to generic
+# equal-time or equal-observation segments")
+# ---------------------------------------------------------------------------
+
+#: An unevenly sampled course: 8 points crowded into the first fifth of the horizon, 2 in
+#: the rest. Equal *time* leaves a segment with nothing to fit; equal *observations* does
+#: not. That difference is the whole reason the second placement exists.
+_BURSTY = np.array([0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 5.0, 10.0])
+
+
+class TestKnotPlacement:
+
+    def test_equal_time_is_the_default_and_cuts_the_horizon_evenly(self):
+        grid = SegmentGrid(np.linspace(0.0, 8.0, 17), 4, label='e', start=0.0)
+        assert grid.placement == EQUAL_TIME
+        np.testing.assert_allclose(grid.knot_times, (2.0, 4.0, 6.0))
+
+    def test_equal_observations_balances_the_data_where_equal_time_does_not(self):
+        """The measured difference, on one unevenly sampled course rather than in the
+        abstract: equal spans leave a segment empty, equal observations do not."""
+        by_time = SegmentGrid(_BURSTY, 2, label='e', start=0.0, placement=EQUAL_TIME)
+        by_data = SegmentGrid(_BURSTY, 2, label='e', start=0.0,
+                              placement=EQUAL_OBSERVATIONS)
+        assert [len(by_time.rows_in(j)) for j in range(2)] == [8, 2]
+        assert [len(by_data.rows_in(j)) for j in range(2)] == [5, 5]
+
+    def test_every_placement_names_a_knot_the_same_way_so_the_ladder_carries_it(self):
+        """The property the homotopy rests on, which is *not* automatic once the knot time
+        stops being a fraction of the horizon: the coarse grid's knot must be the same knot,
+        by name and by time, as the fine grid's."""
+        for placement in (EQUAL_TIME, EQUAL_OBSERVATIONS):
+            fine = SegmentGrid(_BURSTY, 4, label='e', start=0.0, placement=placement)
+            mid = SegmentGrid(_BURSTY, 2, label='e', start=0.0, placement=placement)
+            assert mid.block_names == ('e@1/2',)
+            assert set(mid.block_names) < set(fine.block_names)
+            # Same name *and* same time -- a name that carried over onto a different knot
+            # would reseed the ladder with a state belonging somewhere else.
+            assert mid.knot_times[0] == fine.knot_times[fine.block_names.index('e@1/2')]
+
+    def test_explicit_knots_are_used_as_given(self):
+        grid = SegmentGrid(np.linspace(0.0, 8.0, 17), 4, label='e', start=0.0,
+                           knots=[0.5, 1.0, 7.0])
+        assert grid.placement == EXPLICIT
+        np.testing.assert_allclose(grid.knot_times, (0.5, 1.0, 7.0))
+        assert grid.block_names == ('e@1/4', 'e@1/2', 'e@3/4')
+
+    def test_a_coarser_rung_keeps_the_explicit_knot_its_fraction_names(self):
+        times = np.linspace(0.0, 8.0, 17)
+        fine = SegmentGrid(times, 4, label='e', start=0.0, knots=[0.5, 1.0, 7.0])
+        mid = SegmentGrid(times, 2, label='e', start=0.0, knots=[0.5, 1.0, 7.0])
+        assert mid.block_names == ('e@1/2',)
+        assert mid.knot_times == (1.0,)     # the fine grid's e@1/2, not its first or last
+        assert mid.knot_times[0] == fine.knot_times[fine.block_names.index('e@1/2')]
+
+    def test_out_of_order_explicit_knots_are_refused_by_name(self):
+        with pytest.raises(PybnfError, match='not strictly increasing'):
+            SegmentGrid(np.linspace(0.0, 8.0, 17), 3, label='e', start=0.0,
+                        knots=[5.0, 2.0])
+
+    def test_an_explicit_knot_outside_the_horizon_is_refused(self):
+        with pytest.raises(PybnfError, match='not strictly increasing'):
+            SegmentGrid(np.linspace(0.0, 8.0, 17), 2, label='e', start=0.0, knots=[9.0])
+
+    def test_an_unknown_placement_is_refused(self):
+        with pytest.raises(PybnfError, match='knot placement'):
+            SegmentGrid(np.linspace(0.0, 8.0, 17), 2, label='e', placement='at_the_peaks')
+
+    def test_each_placement_declares_the_segment_count_its_data_supports(self):
+        """The ceiling ``feasible_ladder`` drops rungs against, and it is not one number:
+        equal time needs a measurement per segment, equal observations two, and an explicit
+        list *is* the finest rung."""
+        times = np.linspace(0.0, 1.0, 10)
+        assert max_segments(times, EQUAL_TIME) == 10
+        assert max_segments(times, EQUAL_OBSERVATIONS) == 5
+        assert max_segments(times, EXPLICIT, knots=[0.3, 0.6]) == 3
+
+    def test_equal_observations_refuses_a_count_the_sampling_cannot_support(self):
+        with pytest.raises(PybnfError, match='equal observations'):
+            SegmentGrid(np.linspace(0.0, 1.0, 4), 4, label='e', start=0.0,
+                        placement=EQUAL_OBSERVATIONS)
 
 
 # ---------------------------------------------------------------------------
@@ -533,3 +653,112 @@ class TestLadder:
         spec = make_spec(times, obs)
         rungs, _dropped = feasible_ladder([spec], ladder=(8,))
         assert rungs[-1] == 1
+
+
+# ---------------------------------------------------------------------------
+# The segment pass: serial, or across lanes (#563, "segment simulations can run in
+# parallel")
+# ---------------------------------------------------------------------------
+
+class TestSegmentPool:
+
+    def test_lanes_change_when_a_segment_runs_and_nothing_else(self):
+        """The claim the scheduler has to earn: the objective, its gradient, the continuity
+        residual and its Jacobian come back **exactly** equal, not merely close.
+
+        Exactly, because a segment pass is not an approximation of another segment pass --
+        the same spans are integrated from the same states, only on different threads. A
+        tolerance here would hide a lane mix-up, which is the failure this parallelisation
+        can actually have.
+        """
+        serial, _spec, _free = build_stage(4, backend=TwoStateBackend(n_lanes=4))
+        u = _stale(serial, serial.layout.initial_point([0.45, 0.85]))
+        want = (serial.objective_at(u), serial.equality_at(u))
+
+        pool = SegmentPool(4)
+        try:
+            parallel, _s, _f = build_stage(4, backend=TwoStateBackend(n_lanes=4), pool=pool)
+            got = (parallel.objective_at(u), parallel.equality_at(u))
+        finally:
+            pool.close()
+
+        assert got[0].value == want[0].value
+        np.testing.assert_array_equal(got[0].gradient, want[0].gradient)
+        np.testing.assert_array_equal(got[1].residual, want[1].residual)
+        np.testing.assert_array_equal(got[1].jacobian.to_dense(), want[1].jacobian.to_dense())
+
+    def test_two_segments_never_share_a_lane_at_once(self):
+        """A lane is a stateful simulator restarted at its segment's knot, so two segments
+        in one lane at one time is silent corruption rather than an error. With more
+        segments than lanes the scheduler must make a segment *wait*."""
+        backend = TwoStateBackend(n_lanes=2)
+        pool = SegmentPool(4)
+        try:
+            problem, _spec, _free = build_stage(8, backend=backend, pool=pool)
+            problem.objective_at(problem.layout.initial_point([0.45, 0.85]))
+        finally:
+            pool.close()
+        assert backend.collisions == 0
+        assert backend.max_concurrent <= 2      # capped by what the backend offered
+
+    def test_a_parallel_pass_really_overlaps(self):
+        """The whole point, asserted rather than assumed -- and deterministically.
+
+        A barrier of four is the proof: all four segments of one point must be inside
+        :meth:`simulate` at the same moment for any of them to return. A pass that ran them
+        one at a time would block there and fail on the barrier's own timeout, not on a
+        timing heuristic that happens to be true on a fast machine.
+        """
+        backend = TwoStateBackend(n_lanes=4)
+        pool = SegmentPool(4)
+        try:
+            problem, _spec, _free = build_stage(4, backend=backend, pool=pool)
+            # Armed only after seeding, which runs one unsegmented simulation on the calling
+            # thread -- a party of four would have nothing to wait with.
+            backend.barrier = threading.Barrier(4, timeout=30)
+            problem.objective_at(problem.layout.initial_point([0.45, 0.85]))
+        finally:
+            pool.close()
+        assert backend.max_concurrent == 4
+
+    def test_a_failed_segment_still_makes_the_whole_point_unusable(self):
+        """Parallel gives up the serial pass's short-circuit, not its verdict."""
+        backend = TwoStateBackend(n_lanes=4)
+        backend.fail_beyond = 0.5
+        pool = SegmentPool(4)
+        try:
+            problem, _spec, _free = build_stage(4, backend=backend, pool=pool)
+            model = problem.objective_at(problem.layout.initial_point([1.5, 0.85]))
+        finally:
+            pool.close()
+        assert not np.isfinite(model.value)
+
+    def test_a_serial_pool_opens_no_threads(self):
+        pool = SegmentPool(1)
+        assert not pool.parallel
+        problem, _spec, _free = build_stage(4, pool=pool)
+        problem.objective_at(problem.layout.initial_point([0.45, 0.85]))
+        assert pool._executor is None
+        pool.close()
+
+    def test_a_backend_that_offers_one_lane_is_still_correct(self):
+        """The default :meth:`SegmentBackend.open_lanes` says "one", and a pool asked for
+        more must honour that rather than run two segments in the one context."""
+        backend = TwoStateBackend(n_lanes=1)
+        pool = SegmentPool(4)
+        try:
+            problem, _spec, _free = build_stage(4, backend=backend, pool=pool)
+            model = problem.objective_at(problem.layout.initial_point([0.45, 0.85]))
+        finally:
+            pool.close()
+        assert np.isfinite(model.value)
+        assert backend.collisions == 0
+        assert backend.max_concurrent == 1
+
+
+def _stale(problem, u, factor=1.6):
+    """Knots pushed off the seeded (feasible) trajectory, so the defects are nonzero."""
+    u = np.array(u, dtype=float, copy=True)
+    for block in problem.layout.blocks:
+        u[problem.layout.slice_of(block.name)] += np.log10(factor)
+    return u

--- a/tests/test_shooting_sbml.py
+++ b/tests/test_shooting_sbml.py
@@ -31,8 +31,10 @@ from pybnf.gradient import IC, PARAM, ExperimentRouting, ParamRoute
 from pybnf.objective import ChiSquareObjective
 from pybnf.printing import PybnfError
 from pybnf.pset import FreeParameter, MutationSet, PSet, TimeCourse
+from pybnf.algorithms.optimizers.multiple_shooting import MultipleShootingAlgorithm
 from pybnf.shooting import (
     BngsimSegmentBackend,
+    SegmentPool,
     ShootingExperiment,
     feasible_ladder,
     seed_stage,
@@ -208,11 +210,64 @@ def test_one_simulator_is_reused_across_a_points_segments(tmp_path):
     backend, _model, _action = _backend(tmp_path)
     first = _pset()
     backend.simulate(first, np.linspace(0.0, 5.0, 6), None)
-    prepared = backend._sim
+    prepared = backend._lanes[0]
     backend.simulate(first, np.linspace(5.0, 10.0, 6), {'S': 20.0})
-    assert backend._sim is prepared
+    assert backend._lanes[0] is prepared
     backend.simulate(_pset(k=0.35), np.linspace(0.0, 5.0, 6), None)
-    assert backend._sim is not prepared
+    assert backend._lanes[0] is not prepared
+
+
+def test_extra_lanes_are_independent_simulators_at_the_same_point(tmp_path):
+    """A lane is what makes two segments runnable at once, so the lanes of one point have to
+    be *different* simulators holding the *same* parameters -- and a new point has to discard
+    every one of them, not just lane 0."""
+    backend, _model, _action = _backend(tmp_path)
+    point = _pset()
+    assert backend.open_lanes(point, 3) == 3
+    lanes = [backend._lanes[i] for i in range(3)]
+    assert len({id(sim) for _engine, sim in lanes}) == 3
+    assert len({id(engine) for engine, _sim in lanes}) == 3
+
+    # Same parameters in every lane: a segment must not depend on which one ran it.
+    times = np.linspace(0.0, 5.0, 6)
+    reference = np.asarray(backend.simulate(point, times, None, lane=0)['S'], dtype=float)
+    for lane in (1, 2):
+        other = np.asarray(backend.simulate(point, times, None, lane=lane)['S'], dtype=float)
+        np.testing.assert_allclose(other, reference, rtol=0.0, atol=0.0)
+
+    backend.simulate(_pset(k=0.35), times, None)
+    assert backend._lanes[0] is not lanes[0]
+    assert len(backend._lanes) == 1     # the other point's lanes were discarded, not reused
+
+
+def test_a_parallel_segment_pass_reproduces_the_serial_one_exactly(tmp_path):
+    """The claim that makes the scheduler safe to turn on: lanes change *when* segments are
+    integrated and nothing else.
+
+    Checked on the objective, its gradient and the continuity Jacobian rather than on a
+    trajectory, because those are what a step is taken from -- and at knots deliberately
+    stale, so the defects are nonzero and the comparison has something to disagree about.
+    """
+    backend, _model, _action = _backend(tmp_path)
+    serial = _stage(backend, 4)
+    u = serial.layout.initial_point(_start_u())
+    u = _stale_knots(serial, u)
+    reference = (serial.objective_at(u), serial.equality_at(u))
+
+    parallel_backend, _m, _a = _backend(tmp_path)
+    pool = SegmentPool(4)
+    try:
+        parallel = _stage(parallel_backend, 4, pool=pool)
+        assert pool.parallel
+        got = (parallel.objective_at(u), parallel.equality_at(u))
+    finally:
+        pool.close()
+
+    assert got[0].value == reference[0].value
+    np.testing.assert_array_equal(got[0].gradient, reference[0].gradient)
+    np.testing.assert_array_equal(got[1].residual, reference[1].residual)
+    np.testing.assert_array_equal(got[1].jacobian.to_dense(),
+                                  reference[1].jacobian.to_dense())
 
 
 # ---------------------------------------------------------------------------
@@ -228,7 +283,16 @@ def _start_u():
     return [0.4, 120.0]          # both parameters are linear, so u == theta
 
 
-def _stage(backend, n_segments):
+def _stale_knots(stage, u, factor=1.7):
+    """Push every auxiliary block off the seeded (feasible) trajectory, so the continuity
+    defects are nonzero and a comparison has something to disagree about."""
+    u = np.array(u, dtype=float, copy=True)
+    for block in stage.layout.blocks:
+        u[stage.layout.slice_of(block.name)] += np.log10(factor)
+    return u
+
+
+def _stage(backend, n_segments, pool=None):
     times, obs = _observations()
     exp_data = Data.from_columns(
         np.column_stack([times, obs, np.full(len(obs), SIGMA)]), ['time', 'S', 'S_SD'])
@@ -245,7 +309,7 @@ def _stage(backend, n_segments):
         return PSet([v.set_value(v.from_sampling_space(u[i])) for i, v in enumerate(free)])
 
     return seed_stage([spec], n_segments, ChiSquareObjective(), free, pset_from_u,
-                      np.asarray(_start_u(), dtype=float))
+                      np.asarray(_start_u(), dtype=float), pool=pool)
 
 
 # ---------------------------------------------------------------------------
@@ -353,6 +417,69 @@ def test_a_formula_observable_survives_the_outer_loop(tmp_path):
     assert result.best is not None and np.isfinite(result.best_score)
 
 
+def test_the_fit_type_carries_equal_observation_placement_to_its_experiments(tmp_path):
+    """``ms_knot_placement`` reaches the grid through the real config surface, not just the
+    constructor: the key is parsed, validated against ``MSConfig``, and the knots it produces
+    are the data's own quantiles rather than the horizon's."""
+    alg = H.build(_ms_config(tmp_path, ms_knot_placement='equal_observations'), 'ms')
+    alg._setup_gradient_path()
+    specs = alg._build_specs()
+    grid = specs[0].grid(2)
+    assert grid.placement == 'equal_observations'
+    assert [len(grid.rows_in(j)) for j in range(2)] == [6, 5]
+
+
+def test_explicit_knots_replace_the_segment_count(tmp_path):
+    """"A segment count **or** explicit knots": supplying the times fixes the finest rung at
+    ``len(ms_knots) + 1``, so a stale ``ms_segments`` cannot silently win."""
+    alg = H.build(_ms_config(tmp_path, ms_knots='2 5 8', ms_segments=4), 'ms')
+    assert alg.placement == 'explicit'
+    assert alg.n_segments == 4          # three knots -> four segments, which agrees here
+    alg._setup_gradient_path()
+    grid = alg._build_specs()[0].grid(4)
+    np.testing.assert_allclose(grid.knot_times, (2.0, 5.0, 8.0))
+
+    other = H.build(_ms_config(tmp_path, ms_knots='2 5', ms_segments=8), 'ms')
+    assert other.n_segments == 3        # the knots win, and run() says so
+
+
+def test_the_parallel_segment_key_reaches_the_pool(tmp_path):
+    alg = H.build(_ms_config(tmp_path, ms_parallel_segments=3), 'ms')
+    assert alg.pool.n_lanes == 3 and alg.pool.parallel
+    assert H.build(_ms_config(tmp_path), 'ms').pool.parallel is False
+
+
+def test_ms_is_a_registered_refiner_that_starts_from_the_injected_point(tmp_path):
+    """Arm 4 of #563's acceptance benchmark -- a global search followed by a
+    multiple-shooting polish -- is ``refine_method = ms``, so ``ms`` has to be a registered
+    refiner *and* has to actually begin from the point it is handed rather than re-scattering
+    across the box."""
+    from pybnf.registry import FIT_TYPE_REGISTRY
+    entry = FIT_TYPE_REGISTRY['ms']
+    assert entry.refiner and entry.start_from_box
+
+    config = _ms_config(tmp_path)
+    injected = PSet([FreeParameter('k', 'uniform_var', 1e-2, 3.0, value=0.123),
+                     FreeParameter('S', 'uniform_var', 10.0, 300.0, value=222.0)])
+    config.config[MultipleShootingAlgorithm.START_POINT_KEY] = injected
+    alg = MultipleShootingAlgorithm(config, refine=True)
+
+    assert alg.n_starts == 1            # a refine polishes one point; it does not re-scatter
+    assert alg.start_psets[0]['k'] == pytest.approx(0.123)
+    assert alg.start_psets[0]['S'] == pytest.approx(222.0)
+
+
+def test_a_cmaes_fit_may_name_ms_as_its_refiner(tmp_path):
+    """The config half of the same arm: ``refine_method = ms`` passes validation on a fit
+    that is not itself ``ms``, and ``MSConfig``'s keys come along as a coherent group rather
+    than sitting in the config as unrecognised extras."""
+    config = _ms_config(tmp_path, job_type='cmaes', refine=1, refine_method='ms',
+                        ms_segments=2)
+    assert config.config['refine_method'] == 'ms'
+    assert config.config['ms_segments'] == 2
+    assert config.config['ms_penalty'] == 10.0      # the whole group, defaults included
+
+
 def test_the_fit_type_refuses_a_series_wide_transform(tmp_path):
     """A normalized fit is refused up front, by name: a normalizer is computed over the
     whole series, so the segments would be normalized differently from the fit that was
@@ -381,6 +508,43 @@ def test_ms_recovers_the_decay_rate_and_initial_condition(tmp_path, monkeypatch)
     rec = H.best_params(alg, ['k', 'S'])
     assert abs(rec['k'] - TRUE_K) / TRUE_K < 0.02
     assert abs(rec['S'] - TRUE_S0) / TRUE_S0 < 0.02
+
+    # "Report scaled continuity defects": the run says how nearly the transcription that
+    # produced the reported fit joined up, beside the fit itself.
+    report = (Path(alg.res_dir) / 'continuity_defects.txt').read_text()
+    fields = dict(line.split('\t', 1) for line in report.splitlines()
+                  if line.strip() and not line.startswith('#') and '\t' in line)
+    assert fields['stage'] in ('m=4', 'm=2', 'm=1')
+    assert float(fields['certified_objective']) == pytest.approx(
+        alg.trajectory.best_score(), rel=1e-9)
+    assert float(fields['scaled_defect_norm_inf']) >= 0.0
+
+
+@pytest.mark.recovery
+def test_parallel_segments_reach_the_same_answer_as_serial(tmp_path, monkeypatch):
+    """The scheduler is an implementation of the same pass, so a run with lanes has to land
+    where the serial run lands -- end to end, through the real fit type and the real config
+    key rather than at the problem level.
+
+    The decay model is far too small for lanes to *pay* (a lane costs more to prepare than
+    the integration it saves; see :mod:`pybnf.shooting.parallel`), which is beside the point
+    here: what is under test is that turning them on does not change the fit.
+    """
+    H.install(monkeypatch)
+    (tmp_path / 'a').mkdir()
+    (tmp_path / 'b').mkdir()
+    serial = H.build(_ms_config(tmp_path / 'a'), 'ms')
+    H.drive(serial)
+    parallel = H.build(_ms_config(tmp_path / 'b', ms_parallel_segments=4), 'ms')
+    H.drive(parallel)
+
+    assert parallel.pool.parallel
+    assert (parallel.homotopies[0].best_score
+            == pytest.approx(serial.homotopies[0].best_score, rel=1e-9))
+    got = H.best_params(parallel, ['k', 'S'])
+    want = H.best_params(serial, ['k', 'S'])
+    assert got['k'] == pytest.approx(want['k'], rel=1e-6)
+    assert got['S'] == pytest.approx(want['S'], rel=1e-6)
 
 
 def _central_difference(fun, u, step=1e-5):

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -41,6 +41,7 @@ from pybnf.transcription import (
     Multipliers,
     ObjectiveModel,
     PenaltySchedule,
+    WORST_DEFECTS,
     TranscriptionError,
     TranscriptionProblem,
     VariableBlock,
@@ -1210,6 +1211,57 @@ class TestLadder:
             coarsening_ladder(4, factor=1)
         with pytest.raises(TranscriptionError, match='end at 1 or above'):
             coarsening_ladder(4, stop=0)
+
+
+# ---------------------------------------------------------------------------
+# The defect report (#563: "report scaled continuity defects", plural)
+# ---------------------------------------------------------------------------
+
+class TestDefectReport:
+
+    def test_every_iterate_names_the_constraints_it_did_not_satisfy(self):
+        """The aggregate norm says how far from feasible an iterate is; this says *where*.
+        Carried per iterate rather than only for the last, because the run's answer is its
+        best certified iterate and that is usually not the last one."""
+        problem = ShootingProblem(4, *shooting_data(n=17), theta_seed=0.5)
+        start = problem.layout.initial_point([0.5])
+        start = _stale(problem, start, factor=3.0)
+        result = AugmentedLagrangian(problem, least_squares_inner_solver,
+                                     max_outer=1).run(start)
+
+        first = result.iterates[0]
+        assert first.n_constraints == problem.n_constraints
+        assert len(first.worst_defects) <= WORST_DEFECTS
+        # Named, worst first, and the largest agrees with the norm the loop stops on.
+        names, values = zip(*first.worst_defects)
+        assert all(name in problem.constraint_names for name in names)
+        assert abs(values[0]) == pytest.approx(first.defect_norm)
+        assert list(np.abs(values)) == sorted(np.abs(values), reverse=True)
+        assert first.defect_rms <= first.defect_norm + 1e-12
+        assert names[0] in first.defect_report()
+
+    def test_the_run_result_reports_the_defects_at_the_point_it_stopped(self):
+        problem = ShootingProblem(4, *shooting_data(n=17), theta_seed=0.5)
+        result = AugmentedLagrangian(problem, least_squares_inner_solver,
+                                     max_outer=40).run(problem.layout.initial_point([0.5]))
+        assert len(result.worst_defects) <= WORST_DEFECTS
+        assert abs(result.worst_defects[0][1]) == pytest.approx(result.defect_norm)
+        assert result.defect_report()
+
+    def test_an_unconstrained_problem_reports_nothing_rather_than_a_zero(self):
+        """The one-segment rung of a ladder has no knots, so it has no defects -- which is a
+        different fact from "every defect was zero" and reads differently in a report."""
+        empty = CertifiedIterate('m=1', 1, [0.0], [0.0], Certificate.accept(1.0), 0.0, 1.0,
+                                 1.0, 10.0, 0.0)
+        assert empty.defect_report() == ''
+        assert empty.n_constraints == 0
+
+
+def _stale(problem, u, factor=2.0):
+    u = np.array(u, dtype=float, copy=True)
+    for block in problem.layout.blocks:
+        u[problem.layout.slice_of(block.name)] *= factor
+    return u
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes the implementation half of #563. ADR-0109 landed the reusable
constrained-transcription layer and ADR-0110 the multiple-shooting consumer; this is the
remainder of what #563's *implementation proposal* asks for and neither shipped, plus the
registry flag that makes the fourth arm of its acceptance benchmark runnable at all.

**#563 stays open on the acceptance benchmark**, which is a batch job rather than a code
change. The prediction and the reasoning are posted on the issue.

Nothing here changes what a multiple-shooting fit computes. Every default is chosen so an
existing configuration produces the numbers it produced before, and the two claims that
could break that — that lanes do not change the answer, and that a coarser rung recognises a
finer rung's knot under every placement — are tested rather than asserted.

Design and measurements: **ADR-0111**.

---

### 1. Parallel segment simulation

> "Segment simulations can run in parallel." — #563

ADR-0110 stated rather than discovered that it shipped serial. The interesting part turned
out to be the cost model, not the concurrency.

**Threads work: bngsim releases the GIL inside CVODE.** Four warm engine+simulator replicas
driven from four threads, on the motivating model itself:

| | 160 segment integrations | per segment |
|---|---:|---:|
| serial | 0.153 s | 0.96 ms |
| 4 threads | 0.057 s | 0.36 ms |

2.7× on 4 workers, and every trajectory column and every entry of `d(y)/d(theta)` came back
**bit-identical** — `max |threaded − serial| = 0`, not "agrees to 1e-12". Processes were
never an option: a sensitivity-bearing simulator costs ~230 ms cold against ~50 ms for an
integration, and an engine model does not pickle.

**But a lane is an engine model, not a thread**, and that is what decides the default. Two
segments cannot share one `Simulator` — the backend restarts it from the knot's state, so a
second segment would integrate from the first's start — so running `L` segments at once
needs `L` engine+simulator pairs *at that parameter point*:

```
parallel wins when   (m - 1) * t_integrate  >  (L - 1) * t_prepare
```

On the motivating model it **loses**. Measured on Borghans, `t_prepare` ≈ 4.1 ms and
`t_integrate` ≈ 1–2.3 ms; at `m = L = 4` the extra lanes cost more than the integrations they
save, because three species is too small for the thing being parallelised to be the expensive
thing. So `ms_parallel_segments` defaults to **1**, and the default carries a measurement
rather than a preference. Both terms move with the *model* rather than the fit, and not
together — the initial-condition sensitivity system is `n_species` wide — which is why this
is a key rather than a decision made once.

Stating the loss is the point: shipping this on by default would have made the motivating
problem's own benchmark slower while looking like an optimisation.

What parallel gives up is stated rather than discovered: the serial pass stops at the first
segment that fails to integrate and a submitted future cannot be un-run, so a parallel pass
pays all `m`. The answer is identical; the *simulation count* a run reports is not, and over
an uninformed box — the benchmark's own regime — that is the dominant cost.

### 2. Scaled continuity defects, per knot

`EqualityModel.worst()` existed and nothing called it, so a run printed only the aggregate
`defect_norm`: how far from continuous a fit ended, never *where*. Every outer iterate now
carries the largest individual scaled defects by name, their RMS and the constraint count,
and the reported fit's breakdown is written to `Results/continuity_defects.txt` beside the
parameters it describes:

```
stage	m=4
certified_objective	-165.9821134
n_constraints	9
scaled_defect_norm_inf	9.999999999e-07
scaled_defect_rms	5.773502757e-07
# The 8 largest of 9, worst first.
# knot	state	scaled_defect
experiment1@1/4	Y_state	-9.999999999e-07
experiment1@1/2	Y_state	-9.999999999e-07
...
```

It lives in the layer rather than the consumer because the numbers are only comparable across
states of different magnitude by virtue of being *scaled*, and the scaling is ADR-0109's.
Only the worst few are kept — a defect list is one entry per (knot, state), so
`egfr_ground.net` at `m = 4` has 1068 — and the file says "the 8 largest of 1068" rather than
reading as the whole set. An unconstrained rung says it is unconstrained: "no constraints at
the reported fit" and "this run wrote no report" are different facts.

### 3. Equal-observation and explicit knots

> "Support a segment count or explicit knots; default to generic equal-time or
> equal-observation segments." — #563

All three now exist as one rule: **a placement is a map from a knot's fraction to a time.**
`equal_time` stays the default; `ms_knot_placement = equal_observations` cuts so every
segment owns the same number of measurements (needing two per segment, so its ceiling is half
`equal_time`'s); `ms_knots` names the times and *replaces* `ms_segments` rather than sitting
alongside it.

Still no placement that reads a trajectory. Knots at a burst or a peak are start-point
dependent — they place the transcription's structure using dynamics the fit has not
established, and on the motivating problem those dynamics are exactly what is in question.
What changes is that the *sampling* is also a fact the fit already has, which is why
equal-observation qualifies and peak-finding does not.

**ADR-0110 decision 3 needed a correction.** It names a knot "by its exact fraction of the
horizon". Under equal time that is true and reads naturally; it is not what `carry_over`
needs, and it does not survive the other placements — an explicit knot at `t = 1` on a
`[0, 8]` horizon is not at `1/2` of anything, yet it must still be the same block as the
`m = 4` grid's middle knot or the ladder reseeds. The fraction is the knot's **ordinal**
position among the segments. ADR-0111 records it.

### 4. `ms` is a refiner

#563's benchmark arm 4 is "BIPOP-CMAES + multiple-shooting GNTR", and there was no way to run
it: `ms` was registered `refiner=False`, so `refine_method = ms` was a configuration error.

ADR-0110's registration comment argued that `refiner` classifies the start-point optimizers
"which take a `var`/`logvar` point" and that `ms` "is not a local polish". The first is a
description of Simplex and Powell rather than of the flag — `gntr` is `refiner=True` and is a
multi-start gradient method — and the second is wrong about what arm 4 asks for: seeded at one
point, `ms` runs the `4 → 2 → 1` ladder from it and its last rung *is* the unsegmented local
solve. Nothing in the seam needed adding.

`start_from_box=True` is required rather than optional, and the first cut of this change was
wrong to omit it: `refiner` is what `_load_variables` reads to classify a fit type as
start-point, and a start-point type that is not also `start_from_box` may not be given
bounded priors — which would have made every standalone `loguniform_var` multiple-shooting
fit a configuration error. Caught by the suite, not by review.

Verified end to end on the motivating model: `cmaes → ms` runs, `method_chain.json` records
both phases with per-phase simulation counts, and the refine reports its own continuity
defects.

---

### Verification

* `tests/test_shooting.py` — the placement suite (every placement's coarse knot equals the
  fine one by **name and time**; the refusals, each named by placement) and the scheduler
  suite (a parallel pass reproduces a serial one *exactly* — `assert_array_equal`, not a
  tolerance, because a tolerance would hide the lane mix-up this parallelisation can actually
  have; two segments never share a lane; a serial pool opens no threads). That it really
  overlaps is proved with a `threading.Barrier`, not a timing heuristic.
* `tests/test_transcription.py` — the defect report: names, ordering, agreement with the norm
  the loop stops on, and an unconstrained iterate reporting nothing rather than a zero.
* `tests/test_shooting_sbml.py` — lanes at one point are different simulators holding the same
  parameters and a new point discards all of them; a parallel pass through the real bngsim
  tensor reproduces the serial one exactly at deliberately stale knots; the config keys reach
  where they claim to; `ms` is a registered refiner that starts from its injected point.
* Opt-in `recovery` tier — the decay-model `ms` fit asserts its `continuity_defects.txt`
  against the trajectory's own best fit, and a run with `ms_parallel_segments = 4` lands on
  the same score and parameters as the serial one, through the real fit type.
* Docs build clean under the `-W` gate.
