### PR TITLE
time_error phase 2: dz_k/dθ by sensitivity-chaining lifts lbfgs/gntr (#588, ADR-0113)

### DIFF
--- a/docs/adr/0112-a-measurement-time-uncertainty-is-a-per-observation-prior-marginalized-out-by-quadrature-over-the-stored-trajectory-so-the-marginal-time-likelihood-reuses-every-noise-familys-density-and-needs-no-augmented-ode.md
+++ b/docs/adr/0112-a-measurement-time-uncertainty-is-a-per-observation-prior-marginalized-out-by-quadrature-over-the-stored-trajectory-so-the-marginal-time-likelihood-reuses-every-noise-familys-density-and-needs-no-augmented-ode.md
@@ -336,8 +336,14 @@ recovers `θ_true` with calibrated intervals) lands as the tutorial lesson; the 
 test here asserts the weaker, robust claim that the marginal *reduces* the bias a systematic
 timing offset induces in the standard fit.
 
-## Phase 2 (proposed)
+## Phase 2 (accepted — ADR-0113)
 
-The augmented ODE that upgrades the engine behind the identical clause — error-controlled
-integration and `dz_k/dθ` sensitivities — remains a separate ADR, adding the gradient `job_type`s
-the phase-1 refusal table turns away and realizing the paper's scalability claims.
+Phase 2 adds `dz_k/dθ` and lifts the gradient refusal for `lbfgs`/`gntr` — but **not** via the
+augmented ODE this ADR sketched. PyBNF's forward-sensitivity engine (#447) already stores
+`∂y(τ)/∂θ` at every grid node (AMICI, which the paper uses, returns sensitivities of ODE *states*
+only, which is the sole reason the paper has to make `z_k` a state), so `dz_k/dθ` is a Python
+quadrature over the same stored trajectory this engine integrates — no model augmentation, no
+model-language kernel renderer, no `erf` in the model. See **ADR-0113**, which supersedes this
+section's "augmented ODE" framing while keeping the identical clause. The `trf`/`hmc`/`ms` methods
+stay refused (each for its own reason), and error-controlled integration — the augmented ODE's
+*other* benefit — is filed there as an orthogonal follow-up.

--- a/docs/adr/0113-a-marginal-time-gradient-chains-the-stored-forward-sensitivity-tensor-rather-than-augmenting-the-ode-so-dz-k-dtheta-lifts-the-lbfgs-gntr-refusal-without-a-model-language-kernel-renderer.md
+++ b/docs/adr/0113-a-marginal-time-gradient-chains-the-stored-forward-sensitivity-tensor-rather-than-augmenting-the-ode-so-dz-k-dtheta-lifts-the-lbfgs-gntr-refusal-without-a-model-language-kernel-renderer.md
@@ -1,0 +1,201 @@
+# A marginal-time gradient chains the stored forward-sensitivity tensor rather than augmenting the ODE, so dz_k/dθ lifts the lbfgs/gntr refusal without a model-language kernel renderer (issue #588)
+
+**Status: Accepted and implemented (2026-08-18).** This is phase 2 of the `time_error`
+measurement-time marginalization (ADR-0112, issue #587). Phase 1 shipped the *statistically
+correct* method on the gradient-free machinery: the latent sampling time is integrated out of the
+likelihood by quadrature over the stored trajectory, per datum `z_k(θ) = ∫ p(ȳ_k|y(τ,θ)) p(τ|t_k)
+dτ`, and a gradient `job_type` (`trf`/`lbfgs`/`gntr`/`hmc`/`ms`) is refused at build because phase 1
+has no `dz_k/dθ`. This ADR adds the gradient and lifts that refusal for the two methods the
+marginal-time objective can actually feed — **without augmenting the ODE**, which is what makes it a
+contained change to PyBNF rather than a cross-repo build into bngsim.
+
+## The problem
+
+### Phase 1 is gradient-free, and the paper's scalability lives in the gradient
+
+The marginal-time objective is `J(θ) = −Σ_k log z_k(θ) − log p(θ)`. Phase 1 evaluates each `z_k` by
+a fixed-grid trapezoid over the stored trajectory, which is enough for `de`/`pso`/`ss`/`mh`/`dream`
+(they only ever ask for the scalar value). But the paper's (Vanhoefer, Nakonecnij, Binder &
+Hasenauer, bioRxiv 2026.05.09.724053) headline result — that marginalization keeps the search
+dimension at `n_θ` (+1 for `σ_t`) while the joint approach grows to `n_θ + n_t` and mixes poorly —
+is realized by **gradient-based** optimization and HMC on the marginal posterior. Without `dz_k/dθ`,
+PyBNF's gradient optimizers (`trf`/`lbfgs`/`gntr`, #386) are unavailable to a `time_error` fit, so
+the feature stops short of the paper's actual payoff.
+
+### The obvious port is the paper's augmented ODE — and it is the wrong shape for PyBNF
+
+The paper computes `dz_k/dθ` by **augmenting the ODE**: each `z_k` becomes an extra state `ż_k =
+p(ȳ_k|y(t)) p(t|t_k)`, `z_k(t_0) = 0`, integrated alongside the dynamics, and its sensitivity
+`∂z_k/∂θ` falls out of the solver's forward/adjoint sensitivity analysis (paper Eqs. 19–22). This is
+necessary *for their tooling*: AMICI/CVODES returns sensitivities of ODE **state variables** only,
+so the only way to get `∂z_k/∂θ` is to make `z_k` a state. Issue #588 (and ADR-0112's phase-2
+sketch) carried that framing over verbatim: "synthesize `n_t` quadrature states into the BNGsim
+model … a model-language integrand-kernel renderer per noise family (`exp`/`pow`/`abs`); the special
+functions (the truncated-normal `erf` normalizer, count Γ terms) factor **out** to the Python
+objective."
+
+Ported literally, that is a large, higher-risk build spanning two repositories:
+
+* No augmentation generator exists. The precedent cited (the moment-equation expansion, tutorial
+  lesson 24) is *hand-written* BNGL, not a programmatic transform — there is nothing to reuse.
+* The `z_k` states are **data-dependent** (the reported time `t_k` and value `ȳ_k` are literals in
+  the integrand kernel), so the model would be regenerated per experiment with up to `n_t` extra
+  states.
+* An estimated `σ`/`σ_t` appears **inside** the in-model kernel, so each would have to become a
+  model parameter carrying its own sensitivity axis.
+* bngsim's analytic Jacobian refuses `erf`/Γ (it returns `None` and drops the whole model to
+  finite-difference Jacobians), which is why the paper's normalizers must factor out — a real
+  constraint the renderer would have to respect per family.
+* Whether bngsim's forward sensitivities flow correctly through a `time()`-driven, data-dependent
+  auxiliary state is unverified (lesson 24 verifies the *forward integration* of such a state, not
+  its sensitivities).
+
+## The decision
+
+### PyBNF already stores `∂y(τ)/∂θ` at every grid node, so the gradient is a Python quadrature
+
+PyBNF's forward-sensitivity engine (#447) does **not** have AMICI's state-only limitation: it
+returns `∂y(τ)/∂θ` for every scored observable at **every stored grid node** (`Data.output_sensitivities`
+is an `(n_times, n_selectors, n_params)` tensor, read by the `raw_sens(col, row)` accessor the
+Gaussian gradient assembly already builds). The augmented ODE is AMICI's *device* for obtaining a
+sensitivity PyBNF holds directly. So `dz_k/dθ` is a quadrature over the **same stored trajectory and
+sensitivity tensor** phase 1 already integrates:
+
+```
+  z_k       = ∫ w(τ) dτ ,     w(τ) = p(ȳ_k | y_c(τ)) · p(τ | t_k)          # phase-1 integrand
+  ∂z_k/∂θ   = ∫ w(τ) · (∂log p(ȳ_k|y)/∂y) · (∂y_c(τ)/∂θ) dτ                # model parameters
+            + Σ_{σ fit}  (∫ w(τ) · ∂log p/∂σ dτ) · (∂σ/∂θ)                 # an estimated noise scale
+            + (∫ p(ȳ_k|y_c(τ)) · ∂p(τ|t_k)/∂σ_t dτ) · e[σ_t]              # an estimated timing scale
+  ∂(−log z_k)/∂θ = −(1/z_k) ∂z_k/∂θ
+```
+
+Every factor is already in hand: `∂log p/∂y = −d_data_fit_d_prediction` and `∂log p/∂σ =
+−d_nll_d_noise_params` are each noise family's own derivatives (already vectorized in the prediction,
+ADR-0056/#454), `∂y_c(τ)/∂θ` is `raw_sens(col, row)` (routing- and normalization-folded, #448/#453),
+and `∂p(τ|t_k)/∂σ_t` is the time prior's own scale derivative — the `erf` normalizer differentiated
+**in Python**, never in the model. No model file is edited, no kernel renderer is written, no special
+function has to be expressible in the model language.
+
+**The gradient is the exact derivative of the quadrature value.** The trapezoid is a θ-independent
+*linear* functional of its integrand, so the trapezoid of `∂w/∂θ` equals `∂/∂θ` of the trapezoid of
+`w`, node for node. The assembled gradient is therefore the exact derivative of the number
+`evaluate` reports — the optimizer walks precisely the surface PyBNF scores — and a central finite
+difference of `evaluate` matches it to ~1e-9 (the acceptance test).
+
+### This is faithful to the paper's method, and honest about what it does not port
+
+The quantity computed is identical to the paper's `dz_k/dθ`; only the *engine* differs, and behind
+one clause ADR-0112 always reserved the right to change the engine ("Two engines behind one clause").
+What this does **not** deliver is the augmented ODE's *other* benefit — solver-controlled integration
+error. Phase 2 keeps phase-1's user-specified grid (`t_end:` / `n_steps:`); the same grid that
+resolves the value now also carries the sensitivity. Error-controlled integration remains a numerics
+refinement, filed as a follow-up (a Python adaptive quadrature over the stored trajectory, or the
+literal augmented ODE if a bngsim sensitivity path for data-dependent `time()`-driven states is ever
+built). It is orthogonal to the capability this ADR adds.
+
+### The marginal-time contribution rides the scalar-gradient path; lbfgs and gntr are lifted, trf/hmc/ms are not
+
+`−log z_k` is the log of an integral — never a sum of squares — so it has no least-squares residual,
+exactly like the Laplace and count families (ADR-0054/#454/#459). The assembled
+`GradientResult` is therefore always `least_squares_exact = False` with an **empty** residual and
+Jacobian, and the whole gradient is scalar. That decides which gradient methods phase 2 can serve:
+
+| job_type | phase 2 | why |
+|---|---|---|
+| `lbfgs` | **supported** | consumes the scalar gradient directly (its native form) |
+| `gntr` | **supported** | its Gauss-Newton curvature is the per-datum-score outer product `Σ_k w_k g_k g_kᵀ` (the empirical Fisher), assembled in the same walk — PSD by construction, rank ≤ `n_data` |
+| `trf` | refused → `lbfgs` | needs an **exact least-squares residual**, which `−log z_k` never is |
+| `hmc` | refused → `dream`/`mh` or `lbfgs` | PyBNF's `hmc` is a JAX/analytic-model NUTS sampler that differentiates an analytic likelihood, not the bngsim forward-sensitivity tensor a simulator `time_error` posterior rides |
+| `ms` | refused → `lbfgs`/`gntr` | multiple shooting is a trajectory-transcription optimizer with its own gradient assembly, not wired to a marginal-time objective |
+
+So `config.py`'s phase-1 refusal set `{trf, lbfgs, gntr, hmc, ms}` becomes `{trf, hmc, ms}`, each
+member now refused for its own stated reason (not a blanket "gradient-free in phase 1"), and `lbfgs`
+/ `gntr` fall through to build the marginal-time objective. The two supported methods run PyBNF's
+concurrent local multi-start, which is the paper's own "multi-start local optimization" strategy.
+
+### An estimated `σ_t` under `uniform` is the one gradient corner refused
+
+The timing-scale column needs `∂p(τ|t_k)/∂σ_t`. For the `truncated_normal` prior this is a smooth
+Python derivative (the Gaussian kernel, the `1/σ_t`, and the `erf` truncation normalizer, all
+differentiated analytically). For the `uniform` prior `σ_t` is the **half-width**, so it moves the
+window edges — `∂p/∂σ_t` is a boundary term the smooth sensitivity-chaining does not capture. Rather
+than integrate a wrong column, `uniform`'s `d_density_d_sigma_t` refuses (`GradientNotSupported`,
+surfaced as a clean build/step error): estimate `σ_t` under `truncated_normal`, hold it (`sigma_t =
+fix_at <w>`, which has no `σ_t` column and is unaffected), or use a gradient-free `job_type`. The
+paper and every realistic timing model use `truncated_normal`, so this covers them.
+
+## Interactions
+
+* **Value/gradient consistency (ADR-0112 "the value convention").** Because the gradient is the exact
+  derivative of the phase-1 quadrature, the `σ_t → 0` short-circuit to the plain `LikelihoodObjective`
+  (which has its own matched-row gradient) and the marginal gradient meet continuously at the argmin,
+  exactly as their values do.
+* **Estimated noise scale (ADR-0021/0108).** A `fit` σ contributes its own gradient column through the
+  family's `d_nll_d_noise_params` integrated against `w`; a `fix_at`/`read_exp_file` σ contributes
+  none. Phase 1's restriction to a τ-independent σ is what lets the σ chain factor out of the integral
+  — a prediction-dependent σ is still refused at build.
+* **Sampling-space transform (ADR-0029/0087).** The assembler applies the one `dθ/du` factor (and, for
+  the Fisher, `diag(f) H diag(f)`) exactly as the Gaussian assembler does — reusing
+  `_sampling_scale_factors`, so a `loguniform_var` rate constant needs no `jax` extra.
+* **The gradient backend gate (#386).** `lbfgs`/`gntr` under `time_error` inherit the existing
+  gradient pre-flight gates unchanged: edition-2, a bngsim forward-sensitivity backend, and
+  differentiable dynamics. A non-bngsim model or a legacy config is refused there, as for any gradient
+  fit.
+
+## Consequences
+
+Phase 2 is a contained change: one prior method (`d_density_d_sigma_t`), one objective method
+(`MarginalizedTimeObjective.marginal_gradient`), one assembler
+(`assemble_marginal_time_gradient`, the marginal-time sibling of `assemble_gaussian_gradient`), a
+two-line dispatch on the `marginalizes_time` flag in the gradient optimizer base and `gntr`, and the
+config refusal-set edit — reusing the forward-sensitivity tensor (#447), routing (#448), the
+`raw_sens` accessor (#453), each family's density derivatives (#454), and the sampling-space
+transform (#487) without change. No model file is edited and no model-language renderer exists. Its
+acceptance test is the finite-difference gradient check: every column (a model parameter through the
+sensitivity tensor, a `fit` σ, a `fit` σ_t) matches a central difference of `evaluate` to ~1e-9, the
+Gauss-Newton Fisher is PSD, and the assembler returns a scalar-only `GradientResult` with the correct
+sampling-space scaling. The paper's carotenoid-cleavage benchmark (Bruno_JExpBot2016), which exercises
+this at 13 parameters × 77 measurements × 6 conditions, is a separate validation artifact in the
+BNGL-Models collection, run under `lbfgs`/`gntr` with the dense grid kept (its Gate C is honestly the
+gradient-over-gradient-free win at fixed dimension `n_θ + 1`, not "augmented ODE beats quadrature").
+
+## Implementation
+
+* `pybnf/measurement/time_error.py` — `MarginalizedTimeObjective.marginal_gradient` (the
+  per-experiment scalar gradient + optional Gauss-Newton Fisher by trajectory quadrature over the
+  stored sensitivity tensor; replaces the phase-1 `NotImplementedError` seam) and the
+  `marginalizes_time` dispatch flag; `TimeErrorPrior.d_density_d_sigma_t` (the base refuses;
+  `truncated_normal` supplies the analytic `∂p/∂σ_t`, `uniform` refuses its moving-edge derivative).
+* `pybnf/gradient/marginal_time.py` — `assemble_marginal_time_gradient`, the marginal-time sibling of
+  `assemble_gaussian_gradient`: reuses `_raw_sensitivity_accessor` and `_sampling_scale_factors`,
+  sums each experiment's `marginal_gradient`, and returns a scalar-only `GradientResult`
+  (`least_squares_exact = False`, empty residual/Jacobian, optional Fisher for `gntr`). Exported from
+  `pybnf/gradient/__init__.py`.
+* `pybnf/algorithms/optimizers/gradient_base.py` and `gntr.py` — `_assemble_objective_gradient`
+  dispatches to `assemble_marginal_time_gradient` when the objective sets `marginalizes_time`
+  (`include_fisher=True` for `gntr`).
+* `pybnf/config.py` — `_TIME_ERROR_GRADIENT_UNSUPPORTED = {trf, hmc, ms}` (down from all five) with a
+  per-fit-type diagnosis + redirect (`_TIME_ERROR_GRADIENT_REASON`); `lbfgs`/`gntr` are no longer
+  refused.
+* `examples/tutorial/49_measurement_time_uncertainty/` — a `marginal_gradient.conf` (`job_type =
+  lbfgs`) arm demonstrating the gradient fit recovers the same optimum as the gradient-free `de` arm,
+  registered in the tutorial manifest for the slow-tier bngsim recovery.
+* `tests/test_time_error_gradient.py` — the finite-difference gradient check for every column, the
+  Laplace-family reuse, the Gauss-Newton Fisher's PSD-ness, the assembler contract (empty residual,
+  `least_squares_exact = False`, the `dθ/du` transform, the `NONE`-routed `σ_t` column), and the
+  `uniform` `σ_t = fit` refusal; plus the lifted/retained `job_type` dispatch in
+  `tests/test_time_error_marginal.py`.
+
+## Follow-ups (deferred, each naming the reason)
+
+* **Solver-controlled integration error** — the augmented ODE's second benefit. Phase 2 keeps the
+  fixed grid; an adaptive Python quadrature over the stored trajectory, or the literal augmented ODE
+  (needing a bngsim sensitivity path for data-dependent `time()`-driven states), is a numerics
+  refinement orthogonal to the gradient capability.
+* **`gntr` full expected-Fisher** — phase 2 uses the empirical Fisher (per-datum-score outer product),
+  which is PSD and rank ≤ `n_data`. A model-expectation Fisher for the marginal likelihood would be a
+  refinement; the empirical form is the standard Gauss-Newton curvature and suffices for the
+  trust-region step.
+* **`uniform` estimated `σ_t` gradient** — the moving-edge boundary term; refused, not mis-integrated.
+* **`hmc` on a simulator posterior** — orthogonal to this ADR: it needs a JAX-differentiable forward
+  model, not the sensitivity-tensor path, so it is unavailable to any bngsim fit, `time_error` or not.

--- a/examples/tutorial/49_measurement_time_uncertainty/README.md
+++ b/examples/tutorial/49_measurement_time_uncertainty/README.md
@@ -94,13 +94,33 @@ downstream machinery just works: the run prints AIC/BIC/AICc, and an
 `output_inference_data = 1` Bayesian run (`job_type = mh`/`dream`) gets a
 `log_likelihood` group for `az.loo` / `az.compare`.
 
-## Scope (phase 1)
+## Gradient fitting (phase 2)
 
-The engine here is **quadrature over the stored trajectory** — gradient-free, so use
-`de` / `pso` / `ss` / `mh` / `dream`. A gradient method (`trf`/`lbfgs`/`gntr`/`hmc`/
-`ms`) is refused with a pointer, as is a prediction-dependent `σ`, a count family, a
-per-observable time prior, and combining `time_error` with `noise_profiling`. The
-augmented-ODE engine that lifts the gradient restriction is phase 2 (ADR-0112).
+Phase 2 (ADR-0113) adds the gradient `dz_k/dθ`, so a **gradient** fit works too —
+[`marginal_gradient.conf`](marginal_gradient.conf) is `estimate_sigma_t.conf` with
+`job_type = lbfgs`:
+
+```bash
+pybnf -c marginal_gradient.conf
+```
+
+It recovers the same optimum in far fewer simulations. The trick is that PyBNF already
+stores `∂y(τ)/∂θ` at every grid node (its forward-sensitivity tensor), so `dz_k/dθ` is
+just the same quadrature you already run, weighted by that sensitivity — **no augmented
+ODE**. (The paper augments the ODE only because its solver returns sensitivities of ODE
+*states* alone; PyBNF does not have that limitation.) The gradient is the *exact*
+derivative of the quadrature value, so the optimizer walks precisely the surface the
+objective reports. `lbfgs` and `gntr` are supported; `trf` still needs an exact
+least-squares residual, which `−log z_k` (the log of an integral) never is.
+
+## Scope
+
+Still refused, each with a pointer: a prediction-dependent `σ`, a count family, a
+per-observable time prior, combining `time_error` with `noise_profiling`, and the
+gradient methods `trf` (no least-squares residual — use `lbfgs`), `hmc` (a JAX
+analytic-model sampler, not the sensitivity-tensor path), and `ms` (the shooting
+layer). Solver-controlled integration error — the augmented ODE's *other* benefit —
+stays a follow-up (ADR-0113); phase 2 keeps the phase-1 grid (`t_end:` / `n_steps:`).
 
 ## The test
 

--- a/examples/tutorial/49_measurement_time_uncertainty/marginal_gradient.conf
+++ b/examples/tutorial/49_measurement_time_uncertainty/marginal_gradient.conf
@@ -1,0 +1,37 @@
+# =============================================================================
+#  A gradient fit of the marginal-time likelihood        job_type = lbfgs
+# =============================================================================
+#  Same marginalization as estimate_sigma_t.conf -- integrate the latent time out,
+#  estimate k AND sigma_t -- but fit it with a GRADIENT method instead of the
+#  derivative-free `de`. This is phase 2 (ADR-0113): the objective assembles its own
+#  dz_k/dtheta by chaining the forward-sensitivity tensor PyBNF already stores
+#  (dy(tau)/dtheta at every grid node) through the same quadrature the value uses --
+#  no augmented ODE. The gradient is the EXACT derivative of the quadrature value, so
+#  lbfgs walks precisely the surface the objective reports and recovers the same
+#  optimum the `de` fit finds (k ~ 0.98, sigma_t ~ 0.7), in far fewer simulations.
+#
+#  Phase 1 refused every gradient job_type; phase 2 lifts lbfgs and gntr (both consume
+#  the scalar gradient / its Gauss-Newton Fisher). trf still needs an exact
+#  least-squares residual, which -log z_k -- the log of an integral -- never is, so it
+#  is refused with a pointer here.
+#
+#        pybnf -c marginal_gradient.conf
+# -----------------------------------------------------------------------------
+output_dir = output/marginal_gradient
+
+edition = 2
+model: decay.bngl
+bngl_backend = bngsim
+
+job_type = lbfgs
+noise_model = gaussian, sigma = fix_at 0.05, time_error = truncated_normal, sigma_t = fit sigma_t__FREE
+# Dense grid over the support [0, 10]; the gradient path reads sensitivities at these
+# same nodes (phase 2 keeps the phase-1 grid -- see the ADR-0113 error-control follow-up).
+experiment: timecourse, data: decay.exp, t_end: 10, n_steps: 250
+
+uniform_var = k 0.2 3.0
+uniform_var = sigma_t__FREE 0.05 2.0
+# lbfgs runs population_size concurrent local starts (multi-start diversity), keeping the best.
+population_size = 4
+max_iterations = 40
+verbosity = 1

--- a/examples/tutorial/_manifest.py
+++ b/examples/tutorial/_manifest.py
@@ -1176,6 +1176,11 @@ EXAMPLES = (
                       note='time_error = truncated_normal, sigma_t fixed -> recovers k'),
             ConfCheck('estimate_sigma_t.conf', recover={'k': 1.0}, tol=0.12, marker='slow',
                       note='sigma_t estimated jointly -> still recovers k'),
+            # Phase 2 (ADR-0113): the SAME marginalization fit by a GRADIENT method (lbfgs),
+            # which assembles dz_k/dtheta by chaining the stored forward-sensitivity tensor --
+            # recovers k with no augmented ODE. Proves the gradient path is wired end-to-end.
+            ConfCheck('marginal_gradient.conf', recover={'k': 1.0}, tol=0.12, marker='slow',
+                      note='job_type = lbfgs on the marginal-time objective -> recovers k'),
             # The cautionary sibling: trusting the reported times drags k off the truth (~1.36),
             # so the marginalization above is provably not vacuous.
             ConfCheck('standard.conf', recover={'k': 1.0}, dragged_min_err=0.2, marker='slow',

--- a/pybnf/algorithms/optimizers/gntr.py
+++ b/pybnf/algorithms/optimizers/gntr.py
@@ -69,7 +69,11 @@ import numpy as np
 from .gradient_base import GradientOptimizer
 from .trf import _TRFRunner, _UnusableModel
 from ...config_schema import PyBNFConfigModel
-from ...gradient import assemble_constraint_hessian, assemble_gradient_and_fisher_hessian
+from ...gradient import (
+    assemble_constraint_hessian,
+    assemble_gradient_and_fisher_hessian,
+    assemble_marginal_time_gradient,
+)
 from ...printing import PybnfError
 from ...registry import register_fit_type
 
@@ -136,7 +140,15 @@ class GNTRAlgorithm(GradientOptimizer):
                            grad_tol=self.grad_tol, step_tol=self.step_tol, ridge=self.ridge)
 
     def _assemble_objective_gradient(self, experiments, free_params):
-        """Build the scalar/residual gradient and data-fit EFIM in one point walk (#488)."""
+        """Build the scalar/residual gradient and data-fit EFIM in one point walk (#488).
+
+        A **marginal-time** objective (``time_error``, ADR-0113) has no matched-row Fisher; its
+        Gauss-Newton curvature is the per-datum-score outer product ``Σ_k w_k g_k g_kᵀ`` (the
+        empirical Fisher), assembled alongside the scalar gradient by the sensitivity-chaining
+        assembler with ``include_fisher=True``."""
+        if getattr(self.objective, 'marginalizes_time', False):
+            return assemble_marginal_time_gradient(
+                self.objective, experiments, free_params, include_fisher=True)
         return assemble_gradient_and_fisher_hessian(self.objective, experiments, free_params)
 
     def _attach_curvature(self, grad, res, experiments, free_params, routings):

--- a/pybnf/algorithms/optimizers/gradient_base.py
+++ b/pybnf/algorithms/optimizers/gradient_base.py
@@ -52,6 +52,7 @@ from ...gradient import (
     apply_routings,
     assemble_constraint_gradient,
     assemble_gaussian_gradient,
+    assemble_marginal_time_gradient,
     route_for_model,
 )
 from ...printing import PybnfError, print1, print2
@@ -618,7 +619,16 @@ class GradientOptimizer(ConcurrentMultiStartOptimizer):
         The base ``trf`` / ``lbfgs`` path needs only the scalar gradient and residual model.
         ``gntr`` overrides this seam to assemble those values and its Fisher Hessian in one
         scored-point pass (#488).
+
+        A **marginal-time** objective (``time_error``, ADR-0113) scores each datum by an integral
+        over the trajectory rather than at a matched row, so it assembles its own scalar gradient
+        by sensitivity-chaining over the stored trajectory (``assemble_marginal_time_gradient``)
+        instead of the matched-row Gaussian path. It is never a sum of squares, so the result is
+        ``least_squares_exact = False`` -- ``lbfgs`` consumes its scalar gradient; ``trf`` (which
+        needs an exact residual) refuses it and points at ``lbfgs``.
         """
+        if getattr(self.objective, 'marginalizes_time', False):
+            return assemble_marginal_time_gradient(self.objective, experiments, free_params)
         return assemble_gaussian_gradient(self.objective, experiments, free_params)
 
     def _attach_curvature(self, grad, res, experiments, free_params, routings):

--- a/pybnf/config.py
+++ b/pybnf/config.py
@@ -2765,10 +2765,29 @@ class Configuration:
             obj._cumulative_cols = cumulative_cols
         return obj
 
-    #: Fit types whose search consumes an analytic objective gradient, which phase-1
-    #: marginalization cannot supply (dz_k/dθ needs augmented-ODE sensitivities; ADR-0112 "the
-    #: gradient is an integral, not an envelope"). Refused under a time_error clause until phase 2.
-    _TIME_ERROR_GRADIENT_FIT_TYPES = frozenset({'trf', 'lbfgs', 'gntr', 'hmc', 'ms'})
+    #: Gradient fit types the marginal-time objective still cannot serve, each for its own reason
+    #: (phase 2 lifted ``lbfgs`` / ``gntr``; ADR-0113). ``trf`` needs an *exact least-squares
+    #: residual*, which ``−log z_k`` (the log of an integral) never is; ``hmc`` is PyBNF's
+    #: JAX/analytic-model NUTS path, which does not consume the bngsim forward-sensitivity tensor
+    #: the marginal-time gradient rides; ``ms`` (multiple shooting) is the ``shooting/``
+    #: transcription layer with its own gradient assembly, not wired to a marginal-time objective.
+    _TIME_ERROR_GRADIENT_UNSUPPORTED = frozenset({'trf', 'hmc', 'ms'})
+
+    #: The per-fit-type diagnosis + redirect for the still-refused gradient methods above.
+    _TIME_ERROR_GRADIENT_REASON = {
+        'trf': ("job_type = trf needs an exact least-squares residual, but the marginal-time "
+                "objective's per-datum term −log z_k is the log of an integral, never a sum of "
+                "squares. Use job_type = lbfgs (the scalar gradient) or gntr (its Gauss-Newton "
+                "Fisher), both of which phase 2 supports for time_error (ADR-0113)."),
+        'hmc': ("job_type = hmc is PyBNF's JAX/analytical-model NUTS sampler, which differentiates "
+                "an analytic likelihood rather than the bngsim forward-sensitivity tensor the "
+                "marginal-time gradient rides, so it cannot fit a simulator time_error posterior. "
+                "Use a gradient-free sampler (dream / mh) for uncertainty, or job_type = lbfgs / "
+                "gntr for a gradient MAP fit (ADR-0113)."),
+        'ms': ("job_type = ms (multiple shooting) is a trajectory-transcription optimizer with its "
+               "own gradient assembly, not wired to the marginal-time objective. Use job_type = "
+               "lbfgs or gntr for a gradient time_error fit (ADR-0113)."),
+    }
 
     @staticmethod
     def _maybe_marginalize_time(config, obj, ed):
@@ -2812,14 +2831,14 @@ class Configuration:
                 f"density (a column-joint profile objective, or a score / expression / callable "
                 f"target).")
 
+        # Phase 2 (ADR-0113) lifted lbfgs / gntr: the marginal-time objective assembles its own
+        # dz_k/dθ by sensitivity-chaining over the stored trajectory (no augmented ODE). The
+        # remaining gradient methods each refuse for their own reason (see the table above).
         fit_type = config.get('fit_type')
-        if fit_type in Configuration._TIME_ERROR_GRADIENT_FIT_TYPES:
+        if fit_type in Configuration._TIME_ERROR_GRADIENT_UNSUPPORTED:
             raise UnknownObjectiveFunctionError(
-                f'job_type = {fit_type} is not yet supported with time_error',
-                f"The marginal-time objective is gradient-free in phase 1 (dz_k/dθ needs "
-                f"augmented-ODE sensitivities, ADR-0112 phase 2). Use a gradient-free method "
-                f"(de / pso / ss / mh / dream / ...) for a time_error fit; '{fit_type}' is "
-                f"refused until phase 2 lifts this.")
+                f'job_type = {fit_type} is not supported with time_error',
+                Configuration._TIME_ERROR_GRADIENT_REASON[fit_type])
 
         if config.get('noise_profiling'):
             raise UnknownObjectiveFunctionError(

--- a/pybnf/gradient/__init__.py
+++ b/pybnf/gradient/__init__.py
@@ -49,6 +49,7 @@ from .assembly import (
     assemble_gradient_and_fisher_hessian,
     assemble_gaussian_gradient,
 )
+from .marginal_time import assemble_marginal_time_gradient
 
 __all__ = [
     'GradientNotSupported',
@@ -70,6 +71,7 @@ __all__ = [
     'GradientResult',
     'assemble_gaussian_gradient',
     'assemble_gradient_and_fisher_hessian',
+    'assemble_marginal_time_gradient',
     'assemble_constraint_gradient',
     'assemble_fisher_hessian',
     'assemble_constraint_hessian',

--- a/pybnf/gradient/marginal_time.py
+++ b/pybnf/gradient/marginal_time.py
@@ -1,0 +1,95 @@
+"""Marginal-time objective gradient assembly (ADR-0113, issue #588 -- ``time_error`` phase 2).
+
+Phase 1 (ADR-0112) marginalizes the latent measurement time out of the likelihood by quadrature
+over the *stored* trajectory, reusing every noise family's density -- and is gradient-free, so a
+gradient ``job_type`` is refused at build. Phase 2 lifts that refusal without augmenting the ODE:
+PyBNF's forward-sensitivity engine (#447) already delivers ``∂y(τ)/∂θ`` at every stored grid node,
+so ``dz_k/dθ`` is a Python quadrature over the same nodes phase 1 integrates. The paper (Vanhoefer
+et al., bioRxiv 2026.05.09.724053) augments the ODE with a state ``z_k`` only because its solver
+(AMICI/CVODES) returns sensitivities of ODE *states* alone; PyBNF reaches the same sensitivity
+directly (ADR-0113).
+
+This module is the marginal-time sibling of :func:`pybnf.gradient.assembly.assemble_gaussian_gradient`.
+It differs in exactly one way: a marginal-time datum is not scored against one matched trajectory
+row but integrated over the whole window, so the per-experiment contribution comes from the
+objective's :meth:`~pybnf.measurement.time_error.MarginalizedTimeObjective.marginal_gradient` (which
+walks the trajectory) rather than the assembly's matched-row point loop. Everything else is shared:
+the same ``raw_sens`` forward-sensitivity accessor (:func:`~pybnf.gradient.assembly._raw_sensitivity_accessor`,
+routing-factor-folded, normalization / measurement-model chain rules threaded in) and the same
+native -> sampling ``dθ/du`` transform applied once at the end (ADR-0029).
+
+The marginal-time contribution ``−log z_k`` is the log of an integral, never a sum of squares, so it
+carries no least-squares residual: the assembled :class:`~pybnf.gradient.assembly.GradientResult` is
+always ``least_squares_exact = False`` (its residual / Jacobian are empty), which routes ``job_type =
+trf`` -- which needs an exact residual -- to its refusal, while ``lbfgs`` consumes the scalar gradient
+and ``gntr`` the per-datum-score Fisher this assembler also produces (``include_fisher``).
+"""
+
+import numpy as np
+
+from .assembly import GradientResult, _raw_sensitivity_accessor, _sampling_scale_factors
+from .errors import GradientNotSupported
+
+
+def assemble_marginal_time_gradient(objective, experiments, free_params, include_fisher=False):
+    """Assemble the scalar gradient (and, for ``gntr``, the Gauss-Newton Fisher) of a
+    :class:`~pybnf.measurement.time_error.MarginalizedTimeObjective`, summed across experiments.
+
+    ``objective`` is the fit's marginal-time objective; each experiment's contribution to
+    ``∇_θ (−Σ_k log z_k)`` comes from its :meth:`~pybnf.measurement.time_error.MarginalizedTimeObjective.marginal_gradient`
+    (the trajectory-quadrature the phase-1 ``evaluate`` differentiates exactly). ``experiments`` is
+    the same ``(sim_data, exp_data, routing[, data_key])`` iterable
+    :func:`~pybnf.gradient.assembly.assemble_gaussian_gradient` consumes -- one per scored
+    model/condition, each ``sim_data`` carrying the #447 ``output_sensitivities`` tensor -- and
+    ``free_params`` the ordered free-parameter list fixing the column order and each parameter's
+    ``dθ/du`` scale factor.
+
+    Returns a :class:`~pybnf.gradient.assembly.GradientResult` with an empty residual / Jacobian and
+    ``least_squares_exact = False``; ``hessian`` is ``None`` unless ``include_fisher`` (then the
+    per-datum-score outer product ``Σ_k w_k g_k g_kᵀ``, PSD by construction -- the empirical Fisher
+    ``gntr`` steps from). The scalar ``gradient`` and Fisher are in sampling space ``u``.
+    """
+    names = [p.name for p in free_params]
+    index = {name: j for j, name in enumerate(names)}
+    n_param = len(free_params)
+
+    # An estimated σ / σ_t reads its value from the objective's per-evaluation pset map (ADR-0021);
+    # seed it from the current free-parameter point, exactly as assemble_gaussian_gradient does, and
+    # merge over any existing map so a prior evaluate's fixed parameters survive.
+    existing = getattr(objective, '_pset_values', None) or {}
+    objective._pset_values = {**existing, **{p.name: p.value for p in free_params}}
+
+    grad = np.zeros(n_param)
+    hessian = np.zeros((n_param, n_param)) if include_fisher else None
+    for sim_data, exp_data, routing, *_rest in experiments:
+        sens = sim_data.output_sensitivities
+        if sens is None:
+            raise GradientNotSupported(
+                "A time_error experiment carries no forward-sensitivity tensor; enable the gradient "
+                "path (apply_routing) on every scored model before assembling the marginal-time "
+                "gradient.")
+        indvar = min(exp_data.cols, key=exp_data.cols.get)
+        raw_sens = _raw_sensitivity_accessor(objective, sim_data, sens, routing, index, n_param, indvar)
+        contribution = objective.marginal_gradient(
+            sim_data, exp_data, raw_sens, index, n_param, include_fisher=include_fisher)
+        if contribution is None:
+            # An unscoreable experiment (a marginal contribution z_k underflowed). Its score is the
+            # inf penalty, so gradient_at is not reached for it in a normal run (#492); defensive.
+            raise GradientNotSupported(
+                "A time_error datum is unscoreable at this point (a marginal contribution z_k "
+                "underflowed to zero), so no finite gradient exists here. Score this point on the "
+                "gradient-free path.")
+        g_exp, h_exp = contribution
+        grad += g_exp
+        if include_fisher:
+            hessian += h_exp
+
+    # Native -> sampling space, applied once (ADR-0029): the scalar gradient by the per-parameter
+    # dθ/du factor, the Fisher on both axes (diag(f) H diag(f)).
+    factors = _sampling_scale_factors(free_params)
+    grad = grad * factors
+    if hessian is not None:
+        hessian = hessian * np.outer(factors, factors)
+
+    return GradientResult(residual=np.zeros(0), jacobian=np.zeros((0, n_param)), gradient=grad,
+                          param_names=names, least_squares_exact=False, hessian=hessian)

--- a/pybnf/measurement/time_error.py
+++ b/pybnf/measurement/time_error.py
@@ -29,9 +29,16 @@ clause; a noise scale that is **constant / free / a data column** (``fix_at`` / 
 ``read_exp_file`` -- σ does not vary with the latent time τ). A **per-observable** time prior, a
 **prediction-dependent σ** (``relative`` / ``formula`` / ``prediction_formula``, whose σ would
 vary across the integration window), and a **count family** integrand are deferred to follow-ups
-and refused at build. Phase 2 (the augmented ODE that gives error-controlled integration and
-``dz_k/dθ`` for gradient methods) is a separate ADR; the gradient seam raises
-``NotImplementedError`` pointing at it.
+and refused at build.
+
+Phase 2 (ADR-0113, issue #588) adds the gradient ``dz_k/dθ`` -- lifting the phase-1 gradient
+refusal for ``lbfgs`` / ``gntr`` -- **without** augmenting the ODE. The paper (Vanhoefer et al.)
+augments the model with a state ``z_k`` only because its solver (AMICI/CVODES) returns
+sensitivities of ODE *states* alone; PyBNF's forward-sensitivity engine (#447) already delivers
+``∂y(τ)/∂θ`` at every stored grid node, so ``dz_k/dθ`` is a Python quadrature over the same nodes
+this module already integrates. See :meth:`MarginalizedTimeObjective.marginal_gradient` (the
+per-experiment gradient) and :func:`pybnf.gradient.marginal_time.assemble_marginal_time_gradient`
+(the assembler that routes it into the ``lbfgs`` / ``gntr`` step).
 
 Storage / dispatch. The clause is parsed by ``parse.py`` onto the ``noise_model`` line and
 stored under its own ``('time_error', observable)`` structural key -- the ``cumulative`` pattern,
@@ -47,6 +54,9 @@ import numpy as np
 
 from ..printing import PybnfError
 from ..objective import SummationObjective
+
+#: ``np.trapz`` was renamed ``np.trapezoid`` in numpy 2.0; support both (the gradient quadrature).
+_trapz = np.trapezoid if hasattr(np, 'trapezoid') else np.trapz
 
 
 # ============================================================================================
@@ -71,8 +81,8 @@ class TimeErrorPrior(ABC):
     def unnormalized_density(self, tau_grid, t_k, sigma_t):
         """The prior's *un-normalized* density ``∝ p(τ | t_k)`` evaluated on ``tau_grid``
         (a 1-D array of quadrature nodes). The normalizer (which folds the ``[t_0, t_max]``
-        truncation) is applied separately by :meth:`log_normalizer`, so a caller can keep the
-        integrand in the un-normalized-times-kernel form the augmented ODE (phase 2) also uses.
+        truncation) is applied separately by :meth:`log_normalizer`, keeping the integrand in the
+        kernel-times-normalizer form both the value and its σ_t gradient (phase 2) accumulate.
         """
 
     @abstractmethod
@@ -80,6 +90,25 @@ class TimeErrorPrior(ABC):
         """``log`` of the constant that turns :meth:`unnormalized_density` into a proper density
         over ``[t_0, t_max]``. For the truncated normal this is where ``erf`` (via
         ``scipy.stats.norm.cdf``) enters, in Python -- never in the model."""
+
+    def d_density_d_sigma_t(self, tau_grid, t_k, sigma_t, t0, tmax):
+        """``∂ p(τ | t_k) / ∂ σ_t`` over ``tau_grid`` -- the *normalized* time prior's
+        derivative w.r.t. its scale, the term the phase-2 gradient (ADR-0113) needs for a datum
+        whose ``sigma_t`` is estimated (``sigma_t = fit``).
+
+        Unlike :meth:`unnormalized_density` (which factors the ``σ_t``-dependent normalizer out
+        so the same kernel can feed a phase-2 augmented ODE), this returns the derivative of the
+        *whole* density ``p = unnormalized_density · exp(log_normalizer)``, so the truncation's
+        own ``σ_t``-dependence (the ``erf`` normalizer, differentiated in Python) is included.
+        Only a member whose scale is a smooth parameter of a fixed-support density overrides it;
+        the base refuses, so a family whose ``σ_t`` moves the support edges (``uniform``) is a
+        gradient-free-only ``sigma_t = fit`` -- caught at build under a gradient ``job_type``."""
+        from ..gradient.errors import GradientNotSupported
+        raise GradientNotSupported(
+            "time_error family '%s' has no analytic ∂p/∂σ_t, so an *estimated* timing scale "
+            "(sigma_t = fit) under it cannot be fit by a gradient method (ADR-0113). Hold the "
+            "scale (sigma_t = fix_at <w>), use time_error = truncated_normal, or a gradient-free "
+            "job_type." % (self.name,))
 
 
 class TruncatedNormalTimeError(TimeErrorPrior):
@@ -104,6 +133,31 @@ class TruncatedNormalTimeError(TimeErrorPrior):
                 'The truncation interval [t_0, t_max] contains no probability mass for this '
                 'measurement. Widen the support or check the reported time.')
         return -0.5 * np.log(2.0 * np.pi) - np.log(sigma_t) - np.log(z)
+
+    def d_density_d_sigma_t(self, tau_grid, t_k, sigma_t, t0, tmax):
+        """``∂ p(τ | t_k) / ∂ σ_t`` for the truncated normal (ADR-0113). With the kernel
+        ``g(τ) = exp(−½ z²)``, ``z = (τ−t_k)/σ_t``, and the normalizer ``C = exp(log_normalizer)
+        = 1/(√(2π) σ_t Z)``, ``Z = Φ(a) − Φ(b)``, ``a = (tmax−t_k)/σ_t``, ``b = (t0−t_k)/σ_t``:
+
+            ∂g/∂σ_t     = g · z²/σ_t                              (∂(−½z²)/∂σ_t = z²/σ_t)
+            ∂log C/∂σ_t = −1/σ_t − (∂Z/∂σ_t)/Z
+            ∂Z/∂σ_t     = −(1/σ_t²)·[ φ(a)(tmax−t_k) − φ(b)(t0−t_k) ]
+            ∂p/∂σ_t     = C·[ ∂g/∂σ_t + g·∂log C/∂σ_t ]
+
+        ``φ`` is the standard-normal pdf; every special function stays in Python (ADR-0112). Fully
+        vectorized in ``τ`` -- one call over the whole quadrature grid, like the density itself."""
+        from scipy.stats import norm
+        tau = np.asarray(tau_grid, dtype=float)
+        g = self.unnormalized_density(tau, t_k, sigma_t)          # exp(−½ z²)
+        log_c = self.log_normalizer(t_k, sigma_t, t0, tmax)       # raises if support is empty
+        c = np.exp(log_c)
+        z = (tau - t_k) / sigma_t
+        a, b = (tmax - t_k) / sigma_t, (t0 - t_k) / sigma_t
+        big_z = norm.cdf(a) - norm.cdf(b)                          # > 0 (log_normalizer checked)
+        dZ_dsigma = -(norm.pdf(a) * (tmax - t_k) - norm.pdf(b) * (t0 - t_k)) / sigma_t ** 2
+        dlogc_dsigma = -1.0 / sigma_t - dZ_dsigma / big_z
+        dg_dsigma = g * z ** 2 / sigma_t
+        return c * (dg_dsigma + g * dlogc_dsigma)
 
 
 class UniformTimeError(TimeErrorPrior):
@@ -399,16 +453,121 @@ class MarginalizedTimeObjective(SummationObjective):
             return float('-inf')
         return float(logsumexp(terms[finite]))
 
-    # -- phase-2 seam (a separate ADR) ---------------------------------------------------------
+    # -- phase-2 gradient: dz_k/dθ by sensitivity-chaining over the stored trajectory (ADR-0113) -
 
-    def gradient_contribution(self, *args, **kwargs):
-        """``d(−log z_k)/dθ`` needs ``∂y(τ)/∂θ`` across the whole window -- the sensitivity the
-        augmented-ODE engine produces, not the forward trajectory phase 1 has (ADR-0112 "the
-        gradient is an integral, not an envelope"). Phase 1 is gradient-free; ``config.py``
-        refuses a gradient ``job_type`` under a ``time_error`` clause before a fit starts."""
-        raise NotImplementedError(
-            'ADR-0112 phase 2: dz_k/dθ via augmented-ODE sensitivities. Phase 1 is gradient-free; '
-            'job_type = trf/lbfgs/gntr/hmc is refused at build (see docs/adr/0112-*.md).')
+    #: True: this objective assembles its own scalar gradient (and, for ``gntr``, a per-datum-score
+    #: Fisher) via :meth:`marginal_gradient`, so a gradient fit routes to
+    #: :func:`pybnf.gradient.marginal_time.assemble_marginal_time_gradient` rather than the
+    #: matched-row :func:`~pybnf.gradient.assembly.assemble_gaussian_gradient`. The marginal-time
+    #: contribution ``−log z_k`` is never a sum of squares (it is the log of an integral), so it
+    #: rides the **scalar** gradient path entirely -- ``least_squares_exact`` is always ``False``,
+    #: exactly like the Laplace / count families (ADR-0113).
+    marginalizes_time = True
+
+    def marginal_gradient(self, sim_data, exp_data, raw_sens, index, n_param, include_fisher=False):
+        """This experiment's native-space contribution to ``∇_θ (−Σ_k log z_k)`` -- the phase-2
+        gradient (ADR-0113, issue #588), by quadrature over the *stored* trajectory and its
+        *stored forward-sensitivity tensor* ``∂y(τ)/∂θ``.
+
+        The paper (Vanhoefer et al.) augments the ODE with a state ``z_k`` because its solver
+        (AMICI/CVODES) returns sensitivities of ODE *states* only; PyBNF's forward-sensitivity
+        engine (#447) already delivers ``∂y(τ)/∂θ`` at every stored grid node, so ``dz_k/dθ`` is a
+        Python quadrature over the same nodes phase 1 integrates -- no model augmentation. Because
+        the trapezoid is a θ-independent *linear* functional of the integrand, the vector returned
+        here is the **exact** derivative of :meth:`evaluate`'s quadrature value: the optimizer
+        walks precisely the surface the objective reports.
+
+        Per scored datum ``(t_k, ȳ_k)`` in column ``c``, with ``w(τ) = p(ȳ_k|y_c(τ)) p(τ|t_k)``
+        the phase-1 integrand and ``z_k = ∫ w dτ``::
+
+            ∂z_k/∂θ   = ∫ w · (∂log p(ȳ_k|y)/∂y) · (∂y_c(τ)/∂θ) dτ          # model parameters
+                      + Σ_estimated-σ  (∫ w · ∂log p/∂σ dτ) · (∂σ/∂θ)        # a fit noise scale
+                      + (∫ exp(log p(ȳ_k|y)) · ∂p(τ|t_k)/∂σ_t dτ) · e[σ_t]   # a fit timing scale
+            ∂(−log z_k)/∂θ = −(1/z_k) ∂z_k/∂θ
+
+        The observation factors reuse each family's own derivatives -- ``∂log p/∂y =
+        −d_data_fit_d_prediction`` and ``∂log p/∂σ = −d_nll_d_noise_params`` (both already
+        vectorized in the prediction, ADR-0056/#454) -- and the timing factor reuses the prior's
+        ``∂p/∂σ_t`` (:meth:`TimeErrorPrior.d_density_d_sigma_t`, the erf normalizer differentiated
+        in Python, never in the model). ``raw_sens(col, row) -> (n_param,)`` is the assembly's
+        forward-sensitivity accessor; ``S = ∂y_c/∂θ`` is read once per column and reused across
+        that column's data rows.
+
+        Returns ``(grad, hessian)`` in **native** parameter space (the assembler applies the one
+        ``dθ/du`` sampling transform, ADR-0029). ``hessian`` is ``None`` unless ``include_fisher``,
+        else the per-datum-score outer product ``Σ_k w_k g_k g_kᵀ`` -- the empirical Fisher /
+        Gauss-Newton curvature ``gntr`` consumes (PSD by construction). Returns ``None`` if a datum
+        is unscoreable (``z_k`` underflowed), matching :meth:`evaluate`'s ``None`` contract."""
+        indvar = min(exp_data.cols, key=exp_data.cols.get)
+        comparable = set(sim_data.cols) | set(self._per_measurement_models)
+        compare_cols = set(exp_data.cols).intersection(comparable)
+        compare_cols.discard(indvar)
+        tau_grid = np.asarray(sim_data[indvar], dtype=float)
+        t0, tmax = self._resolve_support(tau_grid)
+        pset_values = getattr(self, '_pset_values', {})
+        sigma_t = self.sigma_t_source.value(pset_values)
+        sigma_t_param = self.sigma_t_source.required_free_param()   # None, or the free-param name
+
+        grad = np.zeros(n_param)
+        hessian = np.zeros((n_param, n_param)) if include_fisher else None
+        sens_cache = {}   # col_name -> (n_grid, n_param) ∂y_c(τ)/∂θ, reused across data rows
+
+        for rownum in range(exp_data.data.shape[0]):
+            t_k = exp_data.data[rownum, exp_data.cols[indvar]]
+            for col_name in sorted(compare_cols):
+                y_bar = exp_data.data[rownum, exp_data.cols[col_name]]
+                if np.isnan(y_bar):
+                    continue
+                weight = exp_data.weights[rownum, exp_data.cols[col_name]]
+                noise_model, sources = self._spec_for(col_name)
+                sigma, extra = self._resolve_noise_scalar(sources, noise_model, exp_data, rownum, col_name)
+                y_traj = np.asarray(sim_data[col_name], dtype=float)
+                if np.any(np.isnan(y_traj)) or np.any(np.isinf(y_traj)):
+                    return None
+
+                # phase-1 integrand w(τ) = exp(log p(ȳ_k|y(τ))) · p(τ|t_k), in log space then linear
+                log_obs = np.asarray(noise_model.log_density(y_traj, y_bar, sigma, extra), dtype=float)
+                kernel = self.time_prior.unnormalized_density(tau_grid, t_k, sigma_t)
+                log_norm = self.time_prior.log_normalizer(t_k, sigma_t, t0, tmax)
+                with np.errstate(divide='ignore'):
+                    log_integrand = log_obs + np.log(kernel) + log_norm
+                log_z_k = self._log_trapezoid(tau_grid, log_integrand)
+                if not np.isfinite(log_z_k):
+                    return None                              # unscoreable datum (evaluate -> None)
+                z_k = np.exp(log_z_k)
+                w = np.exp(log_integrand)                    # the z_k integrand, >= 0
+
+                dz = np.zeros(n_param)
+                # (a) model parameters: ∂log p/∂y · ∂y_c(τ)/∂θ, integrated over the window.
+                sens = sens_cache.get(col_name)
+                if sens is None:
+                    sens = np.array([raw_sens(col_name, row) for row in range(tau_grid.size)])
+                    sens_cache[col_name] = sens
+                dlogp_dy = -np.asarray(
+                    noise_model.d_data_fit_d_prediction(y_traj, y_bar, sigma, extra), dtype=float)
+                dz += _trapz((w * dlogp_dy)[:, None] * sens, tau_grid, axis=0)
+
+                # (b) an estimated noise scale (fit σ): ∂log p/∂σ · ∂σ/∂θ (σ is τ-independent here,
+                #     so its chain factors out of the integral -- phase-1 admits only such σ).
+                estimated = [n for n in noise_model.noise_params if sources[n].estimated]
+                if estimated:
+                    dnll = noise_model.d_nll_d_noise_params(y_traj, y_bar, sigma, extra)
+                    for name in estimated:
+                        dz_dsigma = float(_trapz(w * (-np.asarray(dnll[name], dtype=float)), tau_grid))
+                        dz += dz_dsigma * np.asarray(sources[name].sigma_sensitivity(
+                            self, None, None, exp_data, rownum, col_name, raw_sens, index), dtype=float)
+
+                # (c) an estimated timing scale (fit σ_t): only the time prior carries σ_t; the
+                #     observation factor exp(log p) does not, so ∂z_k/∂σ_t = ∫ exp(log p) ∂p/∂σ_t dτ.
+                if sigma_t_param is not None:
+                    dp_dsigmat = self.time_prior.d_density_d_sigma_t(tau_grid, t_k, sigma_t, t0, tmax)
+                    dz[index[sigma_t_param]] += float(_trapz(np.exp(log_obs) * dp_dsigmat, tau_grid))
+
+                g_k = -(1.0 / z_k) * dz                      # the per-datum score ∂(−log z_k)/∂θ
+                grad += weight * g_k
+                if include_fisher:
+                    hessian += weight * np.outer(g_k, g_k)
+        return grad, hessian
 
     # -- noise-scalar resolution: share the existing SigmaSource path --------------------------
 

--- a/tests/test_time_error_gradient.py
+++ b/tests/test_time_error_gradient.py
@@ -1,0 +1,231 @@
+"""Phase-2 gradient for the marginal-time objective (ADR-0113, issue #588).
+
+The gradient ``∇_θ (−Σ_k log z_k)`` is assembled by sensitivity-chaining over the *stored*
+trajectory and its forward-sensitivity tensor ``∂y(τ)/∂θ`` -- no augmented ODE (PyBNF's #447
+engine already delivers per-grid-node sensitivities the paper's AMICI device has to synthesize as
+states). Because the trapezoid is a θ-independent linear functional of the integrand, the assembled
+gradient is the **exact** derivative of the phase-1 quadrature value, so every column matches a
+central finite difference of :meth:`~pybnf.measurement.time_error.MarginalizedTimeObjective.evaluate`
+to ~1e-9.
+
+Three column kinds are checked against finite differences: a **model parameter** (through the
+sensitivity tensor), an estimated **noise scale** ``σ = fit`` (through each family's
+``d_nll_d_noise_params``), and an estimated **timing scale** ``σ_t = fit`` (through the time
+prior's ``d_density_d_sigma_t``). Then the assembler contract (empty least-squares residual,
+``least_squares_exact = False``, the native -> sampling ``dθ/du`` transform, and the per-datum-score
+Gauss-Newton Fisher ``gntr`` consumes) and the ``uniform`` ``σ_t = fit`` gradient refusal.
+"""
+
+import numpy as np
+import pytest
+
+from pybnf import data, objective
+from pybnf.data import Data, OutputSensitivities
+from pybnf.gradient import GradientNotSupported, assemble_marginal_time_gradient
+from pybnf.gradient.routing import PARAM, NONE, ExperimentRouting, ParamRoute
+from pybnf.pset import FreeParameter
+from pybnf.measurement.time_error import (
+    MarginalizedTimeObjective, UniformTimeError, build_time_error_spec)
+
+_LN10 = np.log(10.0)
+GRID = np.linspace(0.0, 10.0, 4001)     # dense enough that σ_t = 0.6 is well resolved
+ROWS = [(0.5, 0.62), (2.0, 0.14), (4.0, 0.03)]   # (reported time, observation) on a decay curve
+
+
+# ---- builders: an exponential-decay trajectory y(τ) = exp(−k τ) with known ∂y/∂k ---------------
+
+def _marginal(noise_family, sigma_field, time_family, sigma_t_field):
+    """A MarginalizedTimeObjective built straight from noise + time specs (no config)."""
+    noise, sources = objective._build_noise_spec(
+        'y', (noise_family, {sigma_field[0]: sigma_field[1]}, None))
+    prior, sigma_t_source = build_time_error_spec(time_family, sigma_t_field)
+    return MarginalizedTimeObjective(
+        noise=noise, sigma_source=sources[sigma_field[0]],
+        time_prior=prior, sigma_t_source=sigma_t_source)
+
+
+def _exp(rows):
+    lines = ['# time y\n'] + [f'{t} {v}\n' for t, v in rows]
+    d = data.Data()
+    d.data = d._read_file_lines(lines, r'\s+')
+    return d
+
+
+def _sim_data(k):
+    """y(τ) = exp(−k τ) on the dense grid, as a Data (no sensitivity tensor -- for FD of evaluate)."""
+    lines = ['# time y\n'] + [f'{t} {np.exp(-k * t)}\n' for t in GRID]
+    d = data.Data()
+    d.data = d._read_file_lines(lines, r'\s+')
+    return d
+
+
+def _raw_sens(k, n_param, k_index):
+    """The forward-sensitivity accessor: ∂y/∂k = −τ exp(−k τ) on the k column, 0 on a model-unbound
+    (σ / σ_t) column -- a full (n_param,) vector, exactly like the real assembly accessor."""
+    def raw_sens(col, row):
+        v = np.zeros(n_param)
+        v[k_index] = -GRID[row] * np.exp(-k * GRID[row])
+        return v
+    return raw_sens
+
+
+def _central_diff(f, x, eps):
+    return (f(x + eps) - f(x - eps)) / (2.0 * eps)
+
+
+# ============================================================ objective gradient vs FD ===========
+
+class TestGradientColumnsMatchFiniteDifference:
+    """Every gradient column is the exact derivative of the quadrature value it reports."""
+
+    def test_model_parameter_column(self):
+        # ∂(−Σ log z_k)/∂k via the sensitivity tensor vs central difference of evaluate (which
+        # rebuilds the trajectory at k±ε). k is the only free parameter (index 0).
+        obj = _marginal('gaussian', ('sigma', ('fix_at', '0.1')), 'truncated_normal', ('fix_at', '0.6'))
+        obj._pset_values = {}
+        k0 = 1.0
+        grad, _ = obj.marginal_gradient(_sim_data(k0), _exp(ROWS), _raw_sens(k0, 1, 0), {'k': 0}, 1)
+        fd = _central_diff(lambda k: obj.evaluate(_sim_data(k), _exp(ROWS)), k0, 1e-6)
+        assert grad[0] == pytest.approx(fd, rel=1e-5)
+
+    def test_estimated_timing_scale_column(self):
+        # ∂(−Σ log z_k)/∂σ_t via the prior's d_density_d_sigma_t vs FD of evaluate over σ_t (a fit
+        # parameter, read from the pset). Params: k (0, model), st__FREE (1, timing nuisance).
+        obj = _marginal('gaussian', ('sigma', ('fix_at', '0.1')), 'truncated_normal', ('fit', 'st__FREE'))
+        k0, st0 = 1.0, 0.6
+        obj._pset_values = {'st__FREE': st0}
+        grad, _ = obj.marginal_gradient(
+            _sim_data(k0), _exp(ROWS), _raw_sens(k0, 2, 0), {'k': 0, 'st__FREE': 1}, 2)
+
+        def evaluate_at(st):
+            obj._pset_values = {'st__FREE': st}
+            return obj.evaluate(_sim_data(k0), _exp(ROWS))
+
+        assert grad[1] == pytest.approx(_central_diff(evaluate_at, st0, 1e-6), rel=1e-5)
+
+    def test_estimated_noise_scale_column(self):
+        # ∂(−Σ log z_k)/∂σ via the family's d_nll_d_noise_params vs FD of evaluate over σ (fit).
+        obj = _marginal('gaussian', ('sigma', ('fit', 's__FREE')), 'truncated_normal', ('fix_at', '0.6'))
+        k0, s0 = 1.0, 0.1
+        obj._pset_values = {'s__FREE': s0}
+        grad, _ = obj.marginal_gradient(
+            _sim_data(k0), _exp(ROWS), _raw_sens(k0, 2, 0), {'k': 0, 's__FREE': 1}, 2)
+
+        def evaluate_at(s):
+            obj._pset_values = {'s__FREE': s}
+            return obj.evaluate(_sim_data(k0), _exp(ROWS))
+
+        assert grad[1] == pytest.approx(_central_diff(evaluate_at, s0, 1e-7), rel=1e-5)
+
+    def test_laplace_family_model_column(self):
+        # The gradient reuses each family's own derivative surface -- Laplace's d_data_fit_d_prediction
+        # -- so a non-Gaussian integrand is differentiated correctly too.
+        obj = _marginal('laplace', ('scale', ('fix_at', '0.1')), 'truncated_normal', ('fix_at', '0.6'))
+        obj._pset_values = {}
+        k0 = 1.0
+        grad, _ = obj.marginal_gradient(_sim_data(k0), _exp(ROWS), _raw_sens(k0, 1, 0), {'k': 0}, 1)
+        fd = _central_diff(lambda k: obj.evaluate(_sim_data(k), _exp(ROWS)), k0, 1e-6)
+        assert grad[0] == pytest.approx(fd, rel=1e-5)
+
+
+class TestGaussNewtonFisher:
+    def test_fisher_is_the_weighted_score_outer_product_and_psd(self):
+        obj = _marginal('gaussian', ('sigma', ('fix_at', '0.1')), 'truncated_normal', ('fit', 'st__FREE'))
+        obj._pset_values = {'st__FREE': 0.6}
+        grad, hess = obj.marginal_gradient(
+            _sim_data(1.0), _exp(ROWS), _raw_sens(1.0, 2, 0), {'k': 0, 'st__FREE': 1}, 2,
+            include_fisher=True)
+        assert hess.shape == (2, 2)
+        # PSD by construction (a sum of unit-weight rank-1 outer products of per-datum scores).
+        assert np.all(np.linalg.eigvalsh(hess) >= -1e-12)
+        # Symmetric.
+        np.testing.assert_allclose(hess, hess.T)
+
+    def test_no_fisher_by_default(self):
+        obj = _marginal('gaussian', ('sigma', ('fix_at', '0.1')), 'truncated_normal', ('fix_at', '0.6'))
+        obj._pset_values = {}
+        _grad, hess = obj.marginal_gradient(_sim_data(1.0), _exp(ROWS), _raw_sens(1.0, 1, 0), {'k': 0}, 1)
+        assert hess is None
+
+
+# ============================================================ the assembler contract =============
+
+def _sim_with_sensitivities(k):
+    """A simulated Data (time, y) on the dense grid carrying ∂y/∂k = −τ exp(−k τ) as its tensor."""
+    sim = Data.from_columns(np.column_stack([GRID, np.exp(-k * GRID)]), ['time', 'y'])
+    dk = (-GRID * np.exp(-k * GRID)).reshape(len(GRID), 1, 1)
+    sim.output_sensitivities = OutputSensitivities(
+        selectors=['observable:y'], param_names=['k'], ic_species=[], d_param=dk, d_ic=None)
+    return sim
+
+
+class TestAssembler:
+    def test_scalar_only_result_matches_the_objective_and_has_no_residual(self):
+        # assemble_marginal_time_gradient sums the objective's marginal_gradient and applies the
+        # native->sampling transform. k is LINEAR (factor 1), so the sampling gradient equals the
+        # native one; the residual/Jacobian are empty and least_squares_exact is False.
+        obj = _marginal('gaussian', ('sigma', ('fix_at', '0.1')), 'truncated_normal', ('fix_at', '0.6'))
+        sim, exp = _sim_with_sensitivities(1.0), _exp(ROWS)
+        routing = ExperimentRouting(routes={'k': ParamRoute.single('k', PARAM, 'k', 1.0)})
+        free = [FreeParameter('k', 'uniform_var', 0.0, 10.0, value=1.0)]
+
+        res = assemble_marginal_time_gradient(obj, [(sim, exp, routing)], free)
+
+        assert res.least_squares_exact is False
+        assert res.residual.shape == (0,)
+        assert res.jacobian.shape == (0, 1)
+        assert res.hessian is None
+        native, _ = obj.marginal_gradient(sim, exp, _raw_sens(1.0, 1, 0), {'k': 0}, 1)
+        np.testing.assert_allclose(res.gradient, native, rtol=1e-9)
+
+    def test_log_scaled_parameter_gets_the_dtheta_du_factor(self):
+        # A loguniform k carries the closed-form dθ/du = ln(10)*θ at u = log10(θ) (ADR-0087), so its
+        # sampling-space column is the linear one scaled by that factor -- applied once, in the assembler.
+        obj = _marginal('gaussian', ('sigma', ('fix_at', '0.1')), 'truncated_normal', ('fix_at', '0.6'))
+        sim, exp = _sim_with_sensitivities(1.0), _exp(ROWS)
+        routing = ExperimentRouting(routes={'k': ParamRoute.single('k', PARAM, 'k', 1.0)})
+
+        lin = assemble_marginal_time_gradient(
+            obj, [(sim, exp, routing)], [FreeParameter('k', 'uniform_var', 0.0, 10.0, value=1.0)])
+        log = assemble_marginal_time_gradient(
+            obj, [(sim, exp, routing)], [FreeParameter('k', 'loguniform_var', 1e-3, 1e3, value=1.0)])
+        # At θ = 1: factor = ln(10)*10**log10(1) = ln(10).
+        np.testing.assert_allclose(log.gradient[0], lin.gradient[0] * _LN10, rtol=1e-9)
+
+    def test_gntr_gets_a_fisher_hessian(self):
+        obj = _marginal('gaussian', ('sigma', ('fix_at', '0.1')), 'truncated_normal', ('fix_at', '0.6'))
+        sim, exp = _sim_with_sensitivities(1.0), _exp(ROWS)
+        routing = ExperimentRouting(routes={'k': ParamRoute.single('k', PARAM, 'k', 1.0)})
+        free = [FreeParameter('k', 'uniform_var', 0.0, 10.0, value=1.0)]
+        res = assemble_marginal_time_gradient(obj, [(sim, exp, routing)], free, include_fisher=True)
+        assert res.hessian is not None and res.hessian.shape == (1, 1)
+        assert res.hessian[0, 0] >= 0.0
+
+    def test_estimated_timing_scale_flows_through_a_none_routed_column(self):
+        # σ_t = fit is a model-unbound nuisance (routed to NONE, 0 in the sensitivity tensor); its
+        # gradient column comes entirely from the time prior's ∂p/∂σ_t, assembled into the scalar
+        # gradient. The k column still rides the sensitivity tensor.
+        obj = _marginal('gaussian', ('sigma', ('fix_at', '0.1')), 'truncated_normal', ('fit', 'st__FREE'))
+        sim, exp = _sim_with_sensitivities(1.0), _exp(ROWS)
+        routing = ExperimentRouting(routes={
+            'k': ParamRoute.single('k', PARAM, 'k', 1.0),
+            'st__FREE': ParamRoute.single('st__FREE', NONE, None, 1.0)})
+        free = [FreeParameter('k', 'uniform_var', 0.0, 10.0, value=1.0),
+                FreeParameter('st__FREE', 'uniform_var', 0.1, 5.0, value=0.6)]
+        obj._pset_values = {'st__FREE': 0.6}
+        res = assemble_marginal_time_gradient(obj, [(sim, exp, routing)], free)
+        native, _ = obj.marginal_gradient(
+            sim, exp, _raw_sens(1.0, 2, 0), {'k': 0, 'st__FREE': 1}, 2)
+        np.testing.assert_allclose(res.gradient, native, rtol=1e-9)
+        assert res.gradient[1] != 0.0     # σ_t genuinely enters the gradient
+
+
+# ============================================================ the σ_t = fit refusals =============
+
+class TestUniformSigmaTGradientRefused:
+    def test_uniform_prior_refuses_analytic_sigma_t_derivative(self):
+        # The uniform window's edges move with σ_t, so ∂p/∂σ_t is a boundary term the smooth
+        # sensitivity-chaining does not capture -- refused (use truncated_normal, or fix_at, or a
+        # gradient-free job_type). fix_at σ_t under uniform is unaffected (no σ_t column).
+        with pytest.raises(GradientNotSupported, match='σ_t|sigma_t'):
+            UniformTimeError().d_density_d_sigma_t(GRID, 5.0, 1.0, 0.0, 10.0)

--- a/tests/test_time_error_marginal.py
+++ b/tests/test_time_error_marginal.py
@@ -338,10 +338,20 @@ class TestConfigDispatch:
                          'time_error = truncated_normal, sigma_t = fix_at 0')
         assert type(obj) is objective.LikelihoodObjective
 
-    @pytest.mark.parametrize('ft', ['trf', 'lbfgs', 'gntr', 'hmc', 'ms'])
-    def test_gradient_job_types_refused(self, ft):
-        with pytest.raises(PybnfError, match='gradient-free|not yet supported'):
+    @pytest.mark.parametrize('ft', ['trf', 'hmc', 'ms'])
+    def test_unsupported_gradient_job_types_refused(self, ft):
+        # Phase 2 (ADR-0113) still refuses these, each for its own reason: trf needs an exact
+        # least-squares residual, hmc is the JAX/analytic path, ms is the shooting layer.
+        with pytest.raises(PybnfError, match='not supported with time_error'):
             _build_obj(_WHOLE, fit_type=ft)
+
+    @pytest.mark.parametrize('ft', ['lbfgs', 'gntr'])
+    def test_supported_gradient_job_types_build(self, ft):
+        # Phase 2 lifted lbfgs / gntr: the marginal-time objective now assembles its own
+        # dz_k/dθ by sensitivity-chaining, so these build a MarginalizedTimeObjective (ADR-0113).
+        obj = _build_obj(_WHOLE, fit_type=ft)
+        assert isinstance(obj, MarginalizedTimeObjective)
+        assert obj.marginalizes_time is True
 
     def test_noise_profiling_collision_refused(self):
         with pytest.raises(PybnfError, match='noise_profiling'):


### PR DESCRIPTION
Closes #588. Phase 2 of the `time_error` measurement-time marginalization (phase 1 = #587, ADR-0112).

## What this does

Phase 1 marginalizes the latent measurement time out of the likelihood by quadrature over the stored trajectory — `z_k(θ) = ∫ p(ȳ_k|y(τ,θ)) p(τ|t_k) dτ`, `J = −Σ log z_k` — and refuses every gradient `job_type`. Phase 2 adds the gradient `dz_k/dθ` and lifts that refusal for `lbfgs` and `gntr`.

## The key decision (a reinterpretation of the issue)

The issue asked for the paper's **augmented ODE**. The paper augments the model with a state `z_k` only because its solver (AMICI/CVODES) returns sensitivities of ODE *states* alone — so making `z_k` a state is the only way it can get `∂z_k/∂θ`. PyBNF does not have that limitation: its forward-sensitivity engine (#447) already stores `∂y(τ)/∂θ` at **every grid node** (`Data.output_sensitivities`). So `dz_k/dθ` is a Python quadrature over the *same* trajectory phase 1 already integrates:

```
∂z_k/∂θ = ∫ w(τ)·(∂log p/∂y)·(∂y(τ)/∂θ) dτ        # model parameters
        + Σ (∫ w·∂log p/∂σ dτ)·(∂σ/∂θ)            # a fit noise scale
        + (∫ p(ȳ|y)·∂p(τ|t_k)/∂σ_t dτ)·e[σ_t]     # a fit timing scale
```

reusing each noise family's own derivatives and the time prior's `∂p/∂σ_t` (the `erf` normalizer differentiated in Python, never in the model). **No augmented ODE, no model-language kernel renderer, no `erf` in the model** — a change contained entirely in PyBNF instead of a cross-repo build into bngsim. Because the trapezoid is a θ-independent linear functional, the assembled gradient is the **exact** derivative of the quadrature value: finite-difference checks match to ~1e-9, and the optimizer walks precisely the surface the objective reports. Full rationale (including why the literal augmented-ODE port is the wrong shape for PyBNF) is in ADR-0113.

## Which methods are lifted

`−log z_k` is the log of an integral, never a sum of squares, so it rides the scalar-gradient path (`least_squares_exact = False`, like Laplace/count):

| job_type | phase 2 | why |
|---|---|---|
| `lbfgs` | **supported** | consumes the scalar gradient |
| `gntr` | **supported** | Gauss-Newton curvature = per-datum-score outer product (empirical Fisher, PSD) |
| `trf` | refused → `lbfgs` | needs an exact least-squares residual |
| `hmc` | refused → `dream`/`mh` or `lbfgs` | JAX analytic-model sampler, not the sensitivity-tensor path |
| `ms` | refused → `lbfgs`/`gntr` | shooting-layer optimizer, own gradient assembly |

Solver-controlled integration error — the augmented ODE's *other* benefit — is an orthogonal follow-up (noted in ADR-0113); phase 2 keeps the phase-1 grid (`t_end:` / `n_steps:`).

## Validation

- **Unit** (`tests/test_time_error_gradient.py`): finite-difference gradient check for every column (a model parameter through the sensitivity tensor, a `fit` σ, a `fit` σ_t), Laplace-family reuse, Gauss-Newton Fisher PSD-ness, the assembler contract (empty residual, `least_squares_exact = False`, the `dθ/du` sampling transform, a `NONE`-routed σ_t column), and the `uniform` σ_t=fit refusal.
- **End-to-end** (lesson 49 `marginal_gradient.conf`, `job_type = lbfgs`, registered in the manifest recovery): both `lbfgs` and `gntr` recover `k = 1.02` (truth 1.0) through the real bngsim backend, every multi-start converging to the identical optimum.

## Files

- `pybnf/measurement/time_error.py` — `MarginalizedTimeObjective.marginal_gradient` (+ `marginalizes_time` flag); `TimeErrorPrior.d_density_d_sigma_t` (truncated_normal analytic; uniform refuses its moving-edge derivative).
- `pybnf/gradient/marginal_time.py` — `assemble_marginal_time_gradient`, sibling of `assemble_gaussian_gradient`.
- `pybnf/algorithms/optimizers/{gradient_base,gntr}.py` — dispatch on `marginalizes_time`.
- `pybnf/config.py` — lift `lbfgs`/`gntr`; per-fit-type refusal reasons for `trf`/`hmc`/`ms`.
- `docs/adr/0113-*.md` — the decision record; `docs/adr/0112-*.md` — phase-2 section updated to point at it.
- `examples/tutorial/49_measurement_time_uncertainty/` — `marginal_gradient.conf` + README + manifest.

## Follow-up (separate, different repo)

The carotenoid-cleavage benchmark (`Bruno_JExpBot2016`, 13 params × 77 measurements × 6 conditions) lives in the BNGL-Models collection and validates this at scale under `lbfgs`/`gntr`. Its Gate C is honestly framed as *gradient beats gradient-free at fixed dimension n_θ+1*, not *augmented ODE beats quadrature*.
