### PR TITLE
ci(petab): dogfood upstream libpetab-python main for native BNGL (merged #508)

### DIFF
--- a/.github/actions/setup-pybnf/action.yml
+++ b/.github/actions/setup-pybnf/action.yml
@@ -39,10 +39,11 @@ inputs:
   petab-spec:
     description: >-
       The petab requirement to install. Defaults to stock PyPI petab. A CI leg
-      overrides it with the #420 Step B fork
-      (git+…/libpetab-python@bngl_model_support) so the exporter oracle
-      validates `language: bngl` problems through petab's OWN native BnglModel
-      loader rather than the register_bngl() monkeypatch (ADR-0026).
+      overrides it with upstream libpetab-python main
+      (git+…/PEtab-dev/libpetab-python@main), where the native BnglModel loader
+      landed (PEtab-dev/libpetab-python#508), so the exporter oracle validates
+      `language: bngl` problems through petab's OWN native loader rather than the
+      register_bngl() monkeypatch (ADR-0026).
     required: false
     default: 'petab>=0.8,<1'
   cache-suffix:
@@ -135,7 +136,8 @@ runs:
         # path (pybnf[petab], ADR-0035, petab.v2.math); stock PyPI petab carries
         # the math grammar, so one install covers both. The exact petab
         # requirement is the `petab-spec` input (default stock PyPI; a CI leg
-        # overrides it with the Step B fork to run the NATIVE BNGL loader).
+        # overrides it with upstream libpetab-python main to run the NATIVE BNGL
+        # loader, PEtab-dev/libpetab-python#508).
         # arviz/h5netcdf/h5py unskip the ArviZ InferenceData bridge oracle
         # (ADR-0055; tests/test_inference_data.py + the tutorial diagnostics beat)
         # and matplotlib unskips the profile-likelihood plot oracle (#467). These

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,11 +86,13 @@ jobs:
 
   # The PEtab v2 export oracle (ADR-0025/0026) validates emitted `language: bngl`
   # problems at MODEL level. On the pytest job above (stock PyPI petab) that runs
-  # through the register_bngl() monkeypatch. This job installs the #420 Step B
-  # fork instead, so Problem.from_yaml loads BNGL through petab's OWN native
-  # BnglModel loader -- exercising the collapse-to-no-op path that otherwise only
-  # ever SKIPS, and keeping the upstream contribution (PEtab-dev/PEtab#436)
-  # continuously green. One Python version is enough; the loader is pure Python.
+  # through the register_bngl() monkeypatch. This job installs upstream
+  # libpetab-python main instead -- where the native BnglModel loader landed
+  # (PEtab-dev/libpetab-python#508) -- so Problem.from_yaml loads BNGL through
+  # petab's OWN native loader, exercising the collapse-to-no-op path that
+  # otherwise only ever SKIPS and keeping us green against the merged upstream
+  # contribution ahead of its first PyPI release (0.8.2 does not yet carry it).
+  # One Python version is enough; the loader is pure Python.
   pytest-native-bngl:
     runs-on: ubuntu-latest
     name: pytest (native BNGL loader)
@@ -105,18 +107,19 @@ jobs:
           # under PYBNF_NO_BNGSIM=1 below) rather than pay for a wheel nothing
           # here exercises. The matrix legs above cover bngsim.
           bngsim: 'false'
-          petab-spec: 'petab @ git+https://github.com/wshlavacek/libpetab-python.git@bngl_model_support'
+          petab-spec: 'petab @ git+https://github.com/PEtab-dev/libpetab-python.git@main'
           # This job also runs 3.12 through setup-pybnf, so without its own
           # suffix it shares the matrix py3.12 job's cache key and one save loses
           # the reservation (the "another job may be creating this cache"
           # warning). Give it a distinct namespace.
           cache-suffix: pybnf-native
 
-      # Fail loudly if the fork did not actually install (e.g. a resolution
-      # fallback to stock petab): the native path would silently skip otherwise.
+      # Fail loudly if the upstream build did not actually install (e.g. a
+      # resolution fallback to stock petab): the native path would silently skip
+      # otherwise.
       - name: Assert petab has native BNGL support
         run: |
-          uv run --no-sync python -c "import petab.v1.models as m; assert 'bngl' in m.known_model_types, 'the Step B fork is not installed: bngl is not a known petab model type'; print('native BNGL loader present')"
+          uv run --no-sync python -c "import petab.v1.models as m; assert 'bngl' in m.known_model_types, 'upstream libpetab-python main is not installed: bngl is not a known petab model type'; print('native BNGL loader present')"
 
       - name: Run the PEtab oracle through the native loader
         env:

--- a/pybnf/petab/_bngl.py
+++ b/pybnf/petab/_bngl.py
@@ -22,12 +22,11 @@ repo, ``docs/bngl-grammar.md``): line continuations (a trailing ``\\``), the
 species ``$`` clamp marker, and the observable/function/compartment line shapes.
 
 **Drift note (#420 Step B):** this reader has an upstream twin — the standalone,
-pybnf-free port in the ``bngl_model_support`` branch of ``libpetab-python``
-(``petab/v1/models/bngl_model.py``), the candidate ``BnglModel`` contribution for
-PEtab-dev/PEtab#436. The two carry the *same* entity-enumeration semantics and
-grammar hardening; any change here (e.g. a block alias or pattern-modifier rule)
-must be ported there, guarded by the mirrored grammar-hardening tests on both
-sides.
+pybnf-free port now merged into ``libpetab-python`` main
+(``petab/v1/models/bngl_model.py``, PEtab-dev/libpetab-python#508). The two carry
+the *same* entity-enumeration semantics and grammar hardening; any change here
+(e.g. a block alias or pattern-modifier rule) must be ported upstream, guarded by
+the mirrored grammar-hardening tests on both sides.
 """
 
 import re

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ antimony = [
 # imports petab; the bare-name observableFormula path and core stay dependency-free
 # (ADR-0019). Stock PyPI petab carries the math grammar, so this is a normal extra a
 # user installs with `pip install pybnf[petab]` (the test extra below overrides the
-# pin with the dogfooded fork for the BnglModel validation oracle).
+# pin with upstream libpetab-python main for the BnglModel validation oracle).
 petab = [
     "petab>=0.8,<1",
 ]
@@ -114,14 +114,16 @@ tests = [
     # formula tests use petab.v2.math. Test-only -- core stays dependency-free.
     # Stock PyPI petab, so this extra (and therefore the published wheel's
     # Requires-Dist) carries NO direct URL reference -- PyPI rejects any distribution
-    # whose metadata names a `git+` ref. The #420 Step B fork that teaches
-    # libpetab-python to load `language: bngl` problems natively (validating the
-    # exporter oracle at MODEL level rather than via the register_bngl() monkeypatch)
-    # is NOT pinned here: it is injected only on the dedicated CI leg through the
-    # setup-pybnf action's `petab-spec` input (see .github/workflows/tests.yml). Once
-    # upstream ships native BNGL (PEtab-dev/PEtab#436) even that override goes away.
-    # register_bngl() stays a working fallback for stock petab, and the oracle/formula
-    # tests `pytest.importorskip('petab')`, so this is not a hard test requirement.
+    # whose metadata names a `git+` ref. Upstream libpetab-python main, where the
+    # native `language: bngl` loader merged (PEtab-dev/libpetab-python#508 -- it
+    # validates the exporter oracle at MODEL level rather than via the register_bngl()
+    # monkeypatch), is NOT pinned here: it is injected only on the dedicated CI leg
+    # through the setup-pybnf action's `petab-spec` input (see
+    # .github/workflows/tests.yml). The latest PyPI petab (0.8.2) does not yet carry
+    # BNGL, so register_bngl() stays a working fallback for stock petab; once a
+    # release ships it, that override -- and the monkeypatch -- go away. The
+    # oracle/formula tests `pytest.importorskip('petab')`, so this is not a hard test
+    # requirement.
     "petab>=0.8,<1",
     # ArviZ InferenceData bridge oracle (ADR-0055): tests/test_inference_data.py
     # builds real containers and round-trips them through netCDF, so the bridge is


### PR DESCRIPTION
## What & why

The native `BnglModel` loader PyBNF has been validating through a personal fork branch is now **merged upstream**: [PEtab-dev/libpetab-python#508](https://github.com/PEtab-dev/libpetab-python/pull/508). This repoints the `pytest-native-bngl` CI leg from that fork branch to `PEtab-dev/libpetab-python@main`, so the leg dogfoods the **actual merged code** (and survives the fork branch being deleted), and refreshes the now-stale "Step B fork" wording.

## Changes

- **`.github/workflows/tests.yml`** — `petab-spec` for the `pytest-native-bngl` leg: `wshlavacek/libpetab-python@bngl_model_support` → `PEtab-dev/libpetab-python@main`; updated the assertion message and surrounding comments.
- **`.github/actions/setup-pybnf/action.yml`** — refreshed the `petab-spec` input description and the install comment.
- **`pybnf/petab/_bngl.py`** — drift note now points at the merged upstream twin instead of the fork branch.
- **`pyproject.toml`** — comments in the `petab`/`tests` extras updated to reflect the merge.

## Runtime is unchanged

`register_bngl()` already collapses to a no-op against native support. Verified locally against upstream `main`:

- `bngl` is in `petab.v1.models.known_model_types`
- `petab.v2.core` imports cleanly (the no-op path doesn't raise)
- the no-op detection triggers
- the native `BnglModel` parses parameters/observables

The latest PyPI `petab` (**0.8.2**) does **not** yet carry BNGL, so the `petab>=0.8,<1` pin and the `register_bngl()` monkeypatch fallback both stay in place.

## Follow-up (not in this PR)

When a PyPI `petab` release **after 0.8.2** ships native BNGL, bump the pin and retire `register_bngl()`.