### PR TITLE
sbml_atol takes auto and tracking, so a model whose own scale asks for a looser absolute tolerance can have one (#557, ADR-0112)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,55 @@ All notable changes to PyBNF are documented below. This project adheres to
 
 ## [Unreleased]
 
+### Added
+- **`sbml_atol` takes `auto` and `tracking`, so a model whose own scale asks for a *looser*
+  absolute tolerance can have one (#557, ADR-0112).** ADR-0103's derivation is allowed only to
+  tighten. That is a no-regression rule and it is why the derivation could be applied to every model
+  without a flag — but a model whose species all sit far above one has a real, computable tolerance
+  need, and the derivation computes it and then discards it. `Weber_BMC2015`'s seven species live at
+  `1.24e+02 .. 4.21e+07`, so it asks for `4.665e-03` and is handed `1e-08`, 5.7 decades tighter.
+  ADR-0105's per-species vector cannot rescue that either, and the way it fails is the point: each
+  entry clamps into `[scalar_atol, default_atol]`, the scalar has itself been clamped to
+  `default_atol`, that interval collapses to a point, and the vector correctly declines — so the
+  per-species mechanism silently declines exactly the models that span the most decades. Measured
+  over the subset-I corpus, the clamp binds on **10 of the 22 slugs with a readable nominal state**.
+
+  - **`sbml_atol = auto`** lifts the ceiling on both derivations and nothing else. ADR-0105's
+    *floor* — no species resolved below the model's own scalar — stays exactly where its measurement
+    put it (releasing it killed 91 of 100 `Brannmark_JBC2010` box points against 39), and the
+    `1e-16` floor stays too. What is left, `rtol * max(y_i, median)`, is bngsim's own `derive_atol`
+    with the model's median as its `floor`, and is asserted against the library rather than against
+    a second copy of the arithmetic.
+  - **`sbml_atol = tracking [decades]`** wires lanl/bngsim#213's `CVodeWFtolerances` — an absolute
+    tolerance re-evaluated against the state being integrated, so a species that starts at order one
+    and decays to nothing keeps a tolerance that means something for it. This is the half ADR-0105
+    named as out of reach. The ceiling is `auto`'s vector, held from the **nominal** state, so
+    `tracking 0` is `auto` exactly and a fit that moves initial conditions does not move its own
+    tolerance; bngsim's bare `"auto"` ceiling, which re-derives from the live state at every run,
+    is deliberately not used. An unstated depth is left to bngsim rather than copied.
+
+  **Nothing changes without one of those two words.** Unset is byte-identical — same clamps, same
+  vector, same steady-state pairing — and a number remains the documented off-switch that pins
+  `CVodeSStolerances` ulp for ulp. `tracking` on a bngsim without the capability is *refused*, at
+  config load and again in the model constructor, rather than silently integrating at something
+  else.
+
+  **One thing #557 claims does not reproduce, and it is recorded rather than repeated.** The issue's
+  headline is that Weber integrates 6 of 30 sensitivity-applied box points at the clamped tolerance,
+  against 22 at `1e-04`. On the current stack all six arms — unset, `1e-08`, `1e-04`, `auto`,
+  `tracking`, `tracking 6` — integrate **30 of 30**, within 7.2 s of each other. bngsim moved from
+  0.12.2 to 0.13.0 in between, and the documented Weber-specific change is lanl/bngsim#305, whose
+  own entry measures that slug's `t = 24` crossing and reports the step count roughly halving. So
+  this ships as a capability with a measured cost rather than as a rescue, and the instrument that
+  discriminates is **integrator steps** rather than pass/fail. Over 20 box points per slug with the
+  gradient sensitivity request applied, `auto` costs 0.38x–0.67x the CVODE steps on the six slugs the
+  clamp binds hardest (`Perelson` 8 440 → 3 216; `Weber` 78 641 → 36 154; `Laske` 236 629 → 158 543),
+  is bit-identical on `Giordano_Nature2020` — the control, whose derivation tightens and so cannot
+  see the ceiling — and moves `J_paper` at the PEtab nominal point in its sixth decimal. It is not
+  free in the other direction either: error-test failures rise as steps fall, and `Laske` lost one
+  box point of twenty at one seed (both arms lose one at a second seed). ADR-0112 has every arm and
+  says what it has not bisected.
+
 ### Fixed
 - **`job_type = ms` no longer dies on a fit with a measurement-model formula observable (#578).**
   Multiple shooting was unusable on essentially the whole PEtab-imported corpus — including its

--- a/docs/adr/0112-an-only-ever-tighten-clamp-is-a-no-regression-rule-rather-than-a-property-of-the-model-so-sbml-atol-gains-an-opt-in-that-lets-the-derivation-loosen-and-one-that-follows-the-trajectory.md
+++ b/docs/adr/0112-an-only-ever-tighten-clamp-is-a-no-regression-rule-rather-than-a-property-of-the-model-so-sbml-atol-gains-an-opt-in-that-lets-the-derivation-loosen-and-one-that-follows-the-trajectory.md
@@ -1,0 +1,313 @@
+# An only-ever-tighten clamp is a no-regression rule rather than a property of the model, so `sbml_atol` gains an opt-in that lets the derivation loosen — and one that follows the trajectory (issue #557)
+
+**Status: Accepted and implemented (2026-08-18). Extends ADR-0103 and ADR-0105; supersedes neither.**
+Both stand exactly as written for the default path, which is byte-identical after this change. What
+this adds is a way for a job to say how far its own model's state may set its tolerance.
+
+## The clamp, and what it is for
+
+ADR-0103 derives a scalar `atol` from the model's median nominal species value and clamps it into
+`[1e-16, backend default]`; ADR-0105 derives a per-species vector and clamps each entry into
+`[that scalar, backend default]`. The upper clamp in both is the same rule — *the derivation may
+only ever tighten* — and ADR-0103's own text says why:
+
+> the derivation can only *tighten*, never loosen, so a model whose species are of order one (or
+> larger) keeps the backend default bit-for-bit and every existing trajectory is unchanged.
+
+As a no-regression rule that is sound, and it is why the derivation could be applied to every model
+without a flag. The problem is the parenthesis. **"Or larger" is doing a great deal of work.** A
+model whose species all sit far above one has a real, computable tolerance need, and the derivation
+computes it and then discards it.
+
+`Weber_BMC2015` is the case #557 is filed from: seven species at `1.24e+02 .. 4.21e+07`, median
+`4.665e+05`, so `rtol * median` is `4.665e-03` and the clamp hands it `1e-08` — **5.7 decades
+tighter than its own scale asks for**. ADR-0105's vector cannot rescue it either, and the way it
+fails is worth stating precisely: entries clamp into `[scalar_atol, default_atol]`, the scalar has
+itself been clamped to `default_atol`, so that interval collapses to a point, the vector is
+elementwise the scalar, and `_derive_per_species_atol` correctly returns `None`. **The per-species
+mechanism silently declines exactly the models whose own scale asks for something the ceiling will
+not give.**
+
+Over the 22 subset-I slugs with a readable nominal state, the clamp binds on **10** — measured
+today, not carried forward:
+
+| slug | median y₀ | wants | gets |
+|---|---:|---:|---:|
+| `Smith_BMCSystBiol2013` | 7.879e+14 | **7.88e+06** | 1e-08 |
+| `Perelson_Science1996` | 1.86e+06 | 1.86e-02 | 1e-08 |
+| `Weber_BMC2015` | 4.665e+05 | 4.67e-03 | 1e-08 |
+| `Rahman_MBS2016` | 1.365e+04 | 1.37e-04 | 1e-08 |
+| `Crauste_CellSystems2017` | 4.046e+03 | 4.05e-05 | 1e-08 |
+| `Zhao_QuantBiol2020` | 387 | 3.87e-06 | 1e-08 |
+| `Okuonghae_ChaosSolitonsFractals2020` | 212 | 2.12e-06 | 1e-08 |
+| `Laske_PLOSComputBiol2019` | 150 | 1.50e-06 | 1e-08 |
+| `Oliveira_NatCommun2021` | 24.11 | 2.41e-07 | 1e-08 |
+| `Raia_CancerResearch2011` | 1.30 | 1.30e-08 | 1e-08 |
+
+The other 12 either tighten (`Giordano_Nature2020`, `Brannmark_JBC2010`, `Bertozzi_PNAS2020`,
+`Armistead_CellDeathDis2024`) or sit at median exactly 1, where the clamp is a no-op.
+
+**Nine of those ten integrate their box samples at the clamped value today** — every one probed
+below; `Smith_BMCSystBiol2013` was not, because a single 10-point sensitivity probe on it had not
+finished in twenty minutes, which is its own remark about a model whose recorded fit took 13 h. That
+is the whole argument for an opt-in rather than a default change: the table is the *scope* of the
+problem, not a mandate to move nine working results.
+
+## The decision
+
+**`sbml_atol` takes two settings besides a number, and both are statements about how far the
+model's own state may set its tolerance rather than replacements for the derivation.**
+
+```
+sbml_atol = auto                  # trust the derivation in both directions
+sbml_atol = tracking [<decades>]  # auto's vector as a ceiling, followed down the trajectory
+```
+
+A **number** is unchanged and remains the documented off-switch: it pins the scalar and switches
+every derivation off, `CVodeSStolerances`, ulp for ulp. **Unset** is unchanged in every respect —
+same clamps, same vector, same steady-state pairing.
+
+### `auto` lifts one clamp, and only one
+
+```python
+scalar_i = max(rtol * median(y), 1e-16)        # was min(that, default_atol)
+atol_i   = max(rtol * y_i, scalar)             # was min(that, default_atol)
+```
+
+- **The ceiling goes.** That is the whole of what #557 asks for, and it is safe to make optional
+  precisely because it is not safe to make default.
+- **The floor stays exactly where ADR-0105's measurement put it.** Read literally, "resolve each
+  species to `rtol` of its own magnitude" puts `Brannmark_JBC2010`'s `IRp` at `1.76e-17`, and over
+  100 points of that model's own fit box that rule killed **91 of 100** simulations against the
+  scalar's 39. Nothing about a model living *above* one revisits that measurement, so #557 moves
+  one clamp and leaves the other alone.
+- **`_DERIVED_ATOL_FLOOR` stays too.** "Both directions" is a natural reading that would take the
+  `1e-16` floor with it. It answers a different question — how much resolution the derivation will
+  reach for *on its own*, which past `1e-16` is already under double precision's resolution of a
+  state of order one — and a model that genuinely lives down there still says so with a number.
+
+What is left is `max(rtol*y_i, rtol*median)` = `rtol * max(y_i, median)`, which is **bngsim's own
+`derive_atol` with the model's median supplied as its `floor`**. So the opt-in is not a fourth
+PyBNF-specific rule; it is the backend's rule with PyBNF's answer to the one question the backend
+leaves open (bngsim's default floor is the smallest strictly positive species, the reading ADR-0105
+measured and rejected). `test_the_loosened_vector_is_bngsims_own_derivation` asserts that against
+the library, as `test_only_ever_tighten_is_pybnfs_to_apply_not_the_backends` already does for the
+clamped default.
+
+### `tracking` is the half ADR-0105 named as out of reach
+
+ADR-0105 closes by naming what it could not do:
+
+> resolving a species *below* the model's own scale, and a tolerance that follows the trajectory —
+> the same thing from two directions […] That is lanl/bngsim#213's `CVodeWFtolerances`.
+
+That is now shipped in bngsim, and `sbml_atol = tracking` reaches it. The rule bngsim installs is
+`atol_i(y) = clamp(rtol*|y_i|, ceiling_i * 10**-decades, ceiling_i)`, evaluated at the state being
+integrated. **The ceiling is `auto`'s vector**, so:
+
+- tracking is never *looser* than `auto`, only deeper, and `tracking 0` is `auto` exactly (to ~1
+  ulp — the same error weights through `CVodeWFtolerances` rather than `CVodeSVtolerances`). That
+  is a strict-extension property, not a coincidence, and it is why one internal flag governs both
+  settings rather than two modes sharing a derivation by accident;
+- the ceiling is stated explicitly from the **nominal** state. bngsim's own default ceiling is
+  `"auto"`, which re-derives from the model's **live** state at every `run()` — the shape ADR-0105
+  ruled out for the vector, because on a fit that moves initial conditions the tolerance becomes a
+  function of the search position, putting a step in the objective wherever the derivation crosses
+  a rounding boundary. Invisible in the usual way: the objective still looks correct and only the
+  search behaves oddly.
+
+`decades` is optional and an unstated depth is left to bngsim rather than copied here — 12 is a
+measured property of that mechanism (where its own accuracy stops improving; past it the limit is
+roundoff) and belongs to the library that measured it.
+
+### The rest of the decision
+
+- **The steady-state cutoff is stated under tracking too, for ADR-0105's reason.** bngsim resolves
+  a `TrackingAtol` to the *Simulator's own* scalar for every scalar-shaped consumer, and
+  `steady_state_tol` is one, so left alone a tracking run would converge `time = inf` measurements
+  and pre-equilibration phases against `1e-8` rather than against anything the model said.
+
+- **Tracking applies even when the vector declines.** A model whose species share one scale takes
+  the scalar call (19 of 23 slugs), and under tracking that scalar becomes a broadcast ceiling
+  rather than a refusal. What tracking adds is *within*-species and over time, which is orthogonal
+  to whether the species differ from each other — a model that starts uniform and decays is
+  precisely where a vector of initial values has nothing to say.
+
+- **`auto` is meaningful without lanl/bngsim#196.** The scalar is the whole of what ADR-0103 had
+  and it is what the clamp acted on, so an older bngsim opting in still gets the looser number.
+  The capability probe refines this change rather than gating it.
+
+- **`tracking` is refused, not degraded, without lanl/bngsim#213.** Both at config load
+  (`PybnfError`, so the run never starts) and in the model constructor (`ModelError`, for a model
+  built directly). A tolerance mode that silently did not apply produces a plausible trajectory and
+  a wrong conclusion about the model, which is the failure this whole line of work exists to stop
+  making.
+
+- **`sbml_atol` still does not take a hand-written vector**, which is #557's second ask. Its second
+  clause — relax `_derive_atol_vector`'s upper clamp — is delivered here, and with it
+  `CVodeSVtolerances` becomes reachable from a conf on models that could not reach it before, with
+  entries the model's own state supplies. The first clause is left open as **#586**: `sbml_atol` is
+  one global key applying to every SBML/Antimony model in a fit, so a positional vector has no
+  ordering a conf author can see and a species-keyed one has no unambiguous reading across models
+  that do not share species. That needs a per-model tolerance record and its own design.
+
+## Verification
+
+### The premise measurement no longer reproduces, and that is worth saying plainly
+
+#557's headline is that at the clamped tolerance `Weber_BMC2015` is unfittable — 6 of 30
+sensitivity-applied box points integrating, in 239 s, against 22 at `sbml_atol = 1e-4`. **On
+today's stack that is no longer true.** The same probe, same slug, same seed, same 30 points, same
+sensitivity request:
+
+| `sbml_atol` | integrated / 30 | wall |
+|---|---:|---:|
+| unset (the clamped derivation, `1e-08`) | **30** | 7.2 s |
+| `1e-08` explicit | 30 | 7.2 s |
+| `1e-04` (what the slug ships) | 30 | 6.6 s |
+| `auto` (`4.665e-03` + vector) | 30 | 6.2 s |
+| `tracking 6` | 30 | 6.8 s |
+| `tracking` (depth 12) | 30 | 7.1 s |
+
+The stack moved between #557's measurement (bngsim 0.12.2 at `114d3b3`) and this one (bngsim
+0.13.0), and the documented Weber-specific change in between is **lanl/bngsim#305** — a registered
+time-discontinuity root that could never be reached, so the run wedged one ulp below `t = 24`.
+bngsim's own entry measures that fix on this very slug and reports error-test failures at the
+crossing falling from 33–58 to 0–4 with the step count roughly halving. That is consistent with the
+`mxstep` exhaustion #557 attributes to the tolerance, but **this ADR has not bisected it** and does
+not claim more than the two observations: the failure was real when measured, and it is not present
+now.
+
+Two consequences, and they point in different directions:
+
+- **#557's strongest argument for the change is gone.** "This alone would have made Weber fittable
+  with no hand-set number" is no longer a statement about the current code, because Weber is
+  fittable at the clamped tolerance now.
+- **The defect #557 describes is untouched by that.** The derivation still computes `4.665e-03` for
+  Weber and still discards it; the vector still declines on exactly the models that span the most
+  decades; `sbml_atol` still could not reach either of bngsim's two newer mechanisms. Those are
+  properties of PyBNF's code, and none of them was fixed upstream.
+
+So this ships as what it is — a capability with a measured *cost* rather than a rescue — and the
+honest summary of the corpus evidence is below rather than in the issue's original numbers.
+
+### What the loosening is worth on the corpus now
+
+Integrator **steps**, not pass/fail, is the instrument that discriminates: `auto` is a claim about
+how much work the tolerance is asking for, and on models that all integrate anyway the wall clock on
+a small model cannot see it. 20 points from each slug's own fit box (seed 11), with the gradient
+sensitivity request applied, counting every CVODE step and error-test failure across every `run()`
+the probe drives:
+
+| slug | clamp | clamped steps | `auto` steps | vs | `tracking` steps |
+|---|:--:|---:|---:|---:|---:|
+| `Perelson_Science1996` | binds | 8 440 | **3 216** | 0.38x | 9 512 |
+| `Weber_BMC2015` | binds | 78 641 | **36 154** | 0.46x | 75 650 |
+| `Crauste_CellSystems2017` | binds | 8 617 | **4 162** | 0.48x | 13 751 |
+| `Rahman_MBS2016` | binds | 6 298 | **3 709** | 0.59x | 5 783 |
+| `Okuonghae_ChaosSolitonsFractals2020` | binds | 19 480 | **11 996** | 0.62x | 25 946 |
+| `Laske_PLOSComputBiol2019` | binds | 236 629 | **158 543** | 0.67x | 292 014 |
+| `Oliveira_NatCommun2021` | binds | 13 639 | 11 164 | 0.82x | 17 037 |
+| `Raia_CancerResearch2011` | binds | 116 506 | 115 127 | 0.99x | 272 650 |
+| `Giordano_Nature2020` | tightens | 157 728 | **157 728** | **1.00x** | 197 082 |
+| `Brannmark_JBC2010` | tightens | 164 564 | 167 700 | 1.02x | 255 575 |
+
+Four things this says, and one of them is uncomfortable.
+
+- **The loosening is worth 1.5x–2.6x of the integrator's work** on the models the clamp binds
+  hardest, at no cost in points integrated. That is the value of the change on the current stack:
+  not "this model now runs", but "this model was being charged for resolution nobody asked for". The
+  two rows near 1.00x are the ones whose median barely clears the ceiling (`Raia` at 1.30,
+  `Oliveira` at 24.1), which is the expected gradient.
+- **`Giordano_Nature2020` is bit-identical, 157 728 = 157 728, 126 = 126 error-test failures.** It is
+  the control the whole design rests on: a model whose derivation *tightens* cannot see the ceiling,
+  so lifting it must change nothing. It changes nothing. (`Brannmark` moves 2% because `auto` also
+  releases its vector's top end — `X` from `1e-8` to bngsim's `1.0e-07` — which is the one place the
+  two ADR-0105 slugs are touched at all, and it costs steps rather than saving them.)
+- **Error-test failures often go *up* while steps go down** (`Perelson` 10 → 52, `Zhao` 147 → 1121).
+  That is what a looser tolerance looks like from inside: bigger steps, more of them rejected, fewer
+  overall. It is also the mechanism behind the smoothness cost below, so it is worth having in view
+  rather than reporting the step count alone.
+- **`Laske_PLOSComputBiol2019` lost a box point**, 20/20 to 19/20. Re-run at a second seed both arms
+  give 19/20 (and the clamped arm is the one that spends 349 717 steps against `auto`'s 242 173), so
+  this is not a systematic regression — but it is the direction the opt-in's risk lies in, and it is
+  exactly why this is opt-in. `Zhao_QuantBiol2020` is the same shape one step milder: 97 675 steps to
+  68 929, with error-test failures up 7.6x and no point lost.
+
+### It is not an accuracy trade
+
+`J_paper` at the PEtab nominal point — the quantity `nominal_check.json` pins, computed through
+`likelihood_information_criteria` exactly as an end-of-fit does:
+
+| slug | arm | `J_paper` | `OG_nominal` |
+|---|---|---:|---:|
+| `Weber_BMC2015` | clamped (`1e-08`) | 296.2018011 | −0.000201 |
+| | `1e-04` (what it ships) | 296.2018264 | −0.000176 |
+| | `auto` (`4.665e-03`) | 296.2018660 | −0.000136 |
+| | `tracking` | 296.2018022 | −0.000200 |
+| `Giordano_Nature2020` | clamped | 287.62776135703666 | 3775.9692594667868 |
+| | `auto` | **287.62776135703666** | **3775.9692594667868** |
+
+Weber's whole 5.7-decade sweep moves the objective in its **sixth decimal**, and `nominal_check.json`
+holds under every arm. Giordano's is identical to all 17 digits, which is the control again.
+
+What a looser tolerance costs is **smoothness**, and the distinction is the reason `Weber_BMC2015`
+ships `sbml_atol = 1e-4` rather than the derivation's own `4.665e-03`: #557 measured the *assembled*
+gradient as invariant across that whole sweep while the finite-difference reference degraded 28x
+between `1e-4` and `4.665e-3`. A trust-region line search consumes the objective surface, not the
+gradient. So `auto` is the setting that tells a job what its model's own scale asks for; a job whose
+line search turns out to need something tighter still states a number, and this ADR does not claim
+otherwise.
+
+### The default path is untouched
+
+- `_derive_atol` and `_derive_atol_vector` take a `loosen` keyword defaulting to `False`, and with
+  it false every expression is character-for-character what it was.
+- `test_the_derivation_loosens_only_when_asked` covers both sides of the ceiling: three scales at
+  or below it return the identical number either way, so every model ADR-0103 moved and every model
+  it deliberately left alone is unmoved by the existence of the flag.
+- The 23-slug derivation table above was produced by loading each slug twice in one process, unset
+  and `auto`, and reading the tolerance each would run at.
+
+### The mechanism, in fixtures
+
+`tests/test_sbml_solver_tolerances.py` gains `_LARGE_SPREAD_SBML` — the ADR-0105 spread lifted six
+decades, so `X` starts at 1e+07, `Mid` at 1e+04 and `Tiny` at 1e-03. It is `Weber_BMC2015`'s shape
+reduced to something a unit test can hold, and it exhibits the whole defect:
+
+- `test_a_model_above_the_backend_default_gets_no_vector_until_it_opts_in` — the ten-decade model
+  takes the *scalar* path under the clamped derivation, which is the "declines exactly where it is
+  needed" claim as an assertion. Opting in re-opens the interval and `X` resolves three decades
+  apart from `Tiny`.
+- `test_the_looser_tolerance_is_what_lets_the_large_model_integrate` — integrator steps, the
+  fixture-scale version of the cost claim.
+- `test_the_opted_in_model_still_integrates_to_its_closed_form` — the accuracy half, against the
+  exact solution: `X` decaying through three time-gated stages from 1e+07 matches `exp` to a
+  relative 1.0e-06, which is `rtol` doing what `rtol` is for. That is the shape of the trade — the
+  absolute term stops governing and the relative one governs, which is the condition ADR-0103 says
+  the derivation is trying to reach.
+- `test_tracking_resolves_the_species_a_vector_of_initial_values_cannot` — the tracking oracle, on
+  the ADR-0105 fixture where `X` starts at 10 and ends near 7e-17. Its tail under the derived
+  vector is pure noise (the vector gives it `1e-8`, eight decades above where it has got to);
+  tracking follows it down. This is a *different* claim from the loosening, and is asserted
+  separately.
+- `test_tracking_at_depth_zero_is_the_loosened_vector` — the strict-extension property, asserted as
+  a trajectory rather than as a ceiling, at the ~1 ulp bngsim documents for the three routes.
+
+### Scope
+
+**In:** `_bngsim_caps.py` (`BNGSIM_HAS_TRACKING_ATOL`); `bngsim_sbml_model.py`
+(`parse_atol_setting`, the `loosen` keyword on both derivations, `_atol_loosens`, the tracking
+branch of `_run_tolerance_kwargs`, and the constructor's shape/capability checks); `parse.py` (the
+mode grammar, tried ahead of `numgram`, which error-stops after its `=` and so cannot backtrack);
+`config_schema.py`; `config.py`; `docs/config_keys.rst`.
+
+**Out (unchanged):** every BNGL/net model. Every stochastic run. The RoadRunner backend. Every job
+that does not state `sbml_atol`, and every job that states a number.
+
+Relevant ADRs: **0103** (the scalar and the clamp this makes liftable), **0105** (the vector, its
+floor, and the steady-state pairing), **0086** / **0052** / **0104** (the steady-state and
+pre-equilibration paths the explicit `steady_state_tol` protects). Relevant issues: lanl/bngsim
+**#196** (the vector), **#212** (its public export), **#213** (the trajectory-following successor),
+**#305** (the crossing-stop fix that changed Weber's measurement). Closes issue **#557**; opens
+**#586**.

--- a/docs/config_keys.rst
+++ b/docs/config_keys.rst
@@ -1318,20 +1318,74 @@ Algorithm Options
   for the whole fit. A tolerance that moved with a fitted initial condition would put a
   step in the objective wherever the derivation crossed a rounding boundary.
 
-  Set ``sbml_atol`` explicitly if your model lives below the ``1e-16`` floor, or if you
-  want a different tolerance from the one the derivation picks. It is a **single number**
-  and it replaces the whole derivation: stating it integrates every species at that value,
-  which is also the way to pin the pre-per-species behaviour exactly.
+  **Both clamps above only ever tighten, and that is a no-regression rule rather than a
+  statement about your model.** A model whose species all sit far *above* one has a real,
+  computable tolerance need, and the derivation computes it and then discards it:
+  ``Weber_BMC2015``'s seven species live at ``1.24e+02 .. 4.21e+07``, so it asks for
+  ``4.7e-03`` and is handed ``1e-08``, 5.7 decades tighter. What that costs is CVODE's
+  error test read forwards: an ``atol`` far under the state's own magnitude is one the
+  absolute term can never reach, so the integrator is held to a *relative* accuracy far
+  tighter than the ``sbml_rtol`` that is supposed to govern it, and pays in steps for
+  resolution nobody asked for. A forward-sensitivity solve pays most, since CVODES derives
+  its sensitivity tolerances from the state ones. Say ``sbml_atol = auto`` to lift the
+  ceiling:
+
+  ``sbml_atol = auto``
+    Trust the derivation in **both** directions. The two steps above are unchanged except
+    that neither is capped at ``1e-08`` any more, so a species is integrated at
+    ``sbml_rtol`` times its own initial value however large that is, and the model-wide
+    number is ``sbml_rtol`` times the median however large *that* is. The lower clamp
+    stays: no species is resolved below the model-wide number, which is the part that was
+    measured (releasing it roughly doubled the failed simulations on the model it was
+    meant to help). Nothing changes for a model whose species sit at or below one — those
+    never reached the ceiling — so this only moves models the clamp was serving badly.
+
+  ``sbml_atol = tracking``, ``sbml_atol = tracking <decades>``
+    ``auto``, plus an absolute tolerance that follows the **trajectory** rather than
+    staying where the initial values put it. A vector read off initial values fixes the
+    cross-species compromise and stops there: whatever number a species gets, it keeps for
+    the whole run, so a species that starts at order one and decays to something tiny
+    outgrows its own tolerance partway through and stops being error-controlled. This
+    installs bngsim's ``CVodeWFtolerances`` rule
+    ``atol_i(y) = clamp(sbml_rtol*|y_i|, ceiling_i * 10**-decades, ceiling_i)``, with the
+    ``auto`` vector as the ceiling — so it is never *looser* than ``auto``, only deeper,
+    and ``tracking 0`` is ``auto`` exactly.
+
+    ``<decades>`` is how far below its own ceiling a species keeps being resolved
+    relatively; omit it for bngsim's measured default (12). It is not free — roughly 1.6x
+    the integrator steps at the default depth on a real-model sweep, ~4x on a pure decay —
+    and it cannot conjure digits that are not there: a species formed as a *difference* of
+    large fluxes carries roundoff of order ``eps * flux``, and asking for accuracy below
+    that collapses the step size rather than sharpening the answer. Lower the depth if a
+    model that integrated before stops. Needs a bngsim with lanl/bngsim#213; PyBNF refuses
+    the key rather than integrating at something else if yours does not have it.
+
+  Set ``sbml_atol`` to a **number** if your model lives below the ``1e-16`` floor, or if
+  you want a different tolerance from the one the derivation picks. A number replaces the
+  whole derivation: it integrates every species at that value, which is also the way to
+  pin the pre-per-species behaviour exactly. ``auto`` and ``tracking`` are not that — they
+  say how far the model's own state may set its tolerance, so the derivation stays on.
+
+  What a looser tolerance costs is **smoothness**, not accuracy, and the distinction
+  matters when choosing between ``auto`` and a hand-set number. On ``Weber_BMC2015`` four
+  decades of tolerance move the objective at the reference point in its *sixth* decimal,
+  and the assembled gradient does not move at all; what degrades is the finite-difference
+  reference — i.e. the objective surface a trust-region line search consumes. So a
+  gradient fit on a model with a wide species spread may do better at a number somewhere
+  under the derivation's own answer, and ``auto`` is the setting that tells you what that
+  answer is.
 
   A bngsim build without per-species tolerance support stops after the first step and
   integrates every species at the model-wide number, so an older bngsim runs every fit it
-  ran before.
+  ran before — and still honours ``auto``, which loosens that number.
 
   Default: unset (see above)
 
-  Example:
+  Examples:
 
     * ``sbml_atol = 1e-20``
+    * ``sbml_atol = auto``
+    * ``sbml_atol = tracking 6``
 
 **smoothing**
   Number of replicate runs to average together for each parameter set (useful for stochastic simulations). This option can be used with

--- a/pybnf/_bngsim_caps.py
+++ b/pybnf/_bngsim_caps.py
@@ -218,6 +218,24 @@ BNGSIM_HAS_PER_SPECIES_ATOL = bool(
 )
 
 
+# An absolute tolerance that follows the **trajectory** rather than the initial state:
+# ``Simulator.run(atol=TrackingAtol(...))`` installs a ``CVodeWFtolerances`` error-weight
+# function computing ``clamp(rtol*|y_i|, ceiling_i * 10**-decades, ceiling_i)`` at the
+# state actually being integrated (lanl/bngsim#213). A vector read off initial values
+# cannot see a species that starts at order one and decays to nothing; this can, and it
+# is what ADR-0105 named as the half it could not reach.
+#
+# A name probe again, and for the same reason as ``BNGSIM_HAS_PER_SPECIES_ATOL``: the
+# capability arrived without a version bump that identifies it, and the cost of guessing
+# wrong is a ``TrackingAtol`` handed to a ``run`` that does not know the type. ``#557``
+# refuses ``sbml_atol = tracking`` outright when this is False rather than quietly
+# integrating at something else -- a tolerance mode that silently did not apply is the
+# failure that looks like a modelling result.
+BNGSIM_HAS_TRACKING_ATOL = bool(
+    BNGSIM_AVAILABLE and hasattr(bngsim, 'TrackingAtol')
+)
+
+
 def event_sens_min_version():
     """The bngsim version whose forward sensitivities survive a discrete event (#536)."""
     return '%d.%d.%d' % _BNGSIM_EVENT_SENS_VERSION

--- a/pybnf/bngsim_sbml_model.py
+++ b/pybnf/bngsim_sbml_model.py
@@ -52,13 +52,117 @@ _BNGSIM_DEFAULT_ATOL = 1e-8
 _DERIVED_ATOL_FLOOR = 1e-16
 
 
-def _derive_atol(scale, rtol, default_atol, *, model_name=None, warned=None):
+# The two non-numeric settings ``sbml_atol`` accepts (#557). Both are opt-ins to the
+# derivation rather than replacements for it, which is what separates them from a pinned
+# number: a number states the tolerance, these state how far the model's own state is
+# allowed to state it.
+#
+# ``auto``     -- trust the derivation in **both** directions, i.e. lift the upper clamp
+#                 that lets it only ever tighten (:func:`_derive_atol`).
+# ``tracking`` -- ``auto``'s vector as a *ceiling*, re-evaluated against the state being
+#                 integrated rather than against t = 0 (lanl/bngsim#213's
+#                 ``CVodeWFtolerances``). Takes an optional depth in decades; bngsim's
+#                 own default (12) applies when it is not stated.
+_ATOL_AUTO = 'auto'
+_ATOL_TRACKING = 'tracking'
+
+
+def parse_atol_setting(atol):
+    """Split an ``sbml_atol`` value into ``(pinned, mode, decades)`` (#557).
+
+    One shape authority for a key that now carries three different kinds of statement,
+    so ``config.py`` (which rejects a bad one with a pointed message at config load) and
+    the model constructor (which is reachable directly, and must not defer a malformed
+    setting to the first ``run``) cannot disagree about what a value means.
+
+    * a **number** -- ``(float, None, None)``. The documented off-switch: it pins the
+      scalar and switches every derivation, vector and tracking alike, off.
+    * ``auto`` -- ``(None, 'auto', None)``.
+    * ``tracking`` / ``tracking <decades>`` -- ``(None, 'tracking', None | float)``.
+      ``None`` decades means "bngsim's default depth", which is deliberately not copied
+      here: it is a measured property of that mechanism (12, where its own accuracy stops
+      improving) and belongs to the library that measured it.
+    * ``None`` -- ``(None, None, None)``, the unset default: derive, and only tighten.
+
+    A numeric *string* reads as the number, because a value can reach a model from
+    somewhere other than the conf grammar (a hand-built dict, an importer). Raises
+    ``ValueError`` with a message naming the value; callers translate it into their own
+    error type rather than each re-deciding what the legal shapes are.
+    """
+    if atol is None:
+        return None, None, None
+    if isinstance(atol, bool):
+        raise ValueError(f'expected a positive number, "auto", or "tracking [decades]"; got {atol!r}')
+    if isinstance(atol, (int, float)):
+        return _positive_atol(atol), None, None
+    tokens = str(atol).strip().split()
+    if not tokens:
+        raise ValueError('expected a positive number, "auto", or "tracking [decades]"; got an empty value')
+    mode = tokens[0].lower()
+    # The modes are tried before the number, not because the order could go either way --
+    # neither spelling parses as a float -- but so a malformed `tracking <junk>` reports
+    # what is wrong with its depth rather than falling through to "not a number".
+    if mode == _ATOL_AUTO and len(tokens) == 1:
+        return None, _ATOL_AUTO, None
+    if mode == _ATOL_TRACKING and len(tokens) <= 2:
+        if len(tokens) == 1:
+            return None, _ATOL_TRACKING, None
+        try:
+            decades = float(tokens[1])
+        except ValueError:
+            raise ValueError(
+                f'"tracking" takes an optional depth in decades; got {tokens[1]!r}') from None
+        if not np.isfinite(decades) or decades < 0.0:
+            raise ValueError(
+                f'"tracking" decades must be finite and >= 0; got {decades!r}. A tracking '
+                'tolerance with no floor is pure relative error control, which has no '
+                'weight to give a species sitting at exactly zero.')
+        return None, _ATOL_TRACKING, decades
+    if len(tokens) == 1:
+        try:
+            number = float(tokens[0])
+        except ValueError:
+            pass
+        else:
+            return _positive_atol(number), None, None
+    raise ValueError(
+        f'expected a positive number, "auto", or "tracking [decades]"; got {str(atol)!r}')
+
+
+def _positive_atol(value):
+    """``float(value)``, refusing what CVODE cannot take as an absolute tolerance."""
+    value = float(value)
+    if not np.isfinite(value) or value <= 0.0:
+        raise ValueError(f'an absolute tolerance must be a finite positive number; got {value!r}')
+    return value
+
+
+def _derive_atol(scale, rtol, default_atol, *, loosen=False, model_name=None, warned=None):
     """The absolute tolerance a model whose state lives at ``scale`` needs (#546).
 
     ``rtol * scale``, clamped into ``[_DERIVED_ATOL_FLOOR, default_atol]``. The upper
     clamp is what makes this safe to apply unconditionally: the derivation can only
     *tighten*, never loosen, so a model whose species are of order one (or larger) keeps
     the backend default bit-for-bit and every existing trajectory is unchanged.
+
+    **``loosen`` lifts that upper clamp, and lifts nothing else** (#557,
+    ``sbml_atol = auto``). Only-ever-tighten is a no-regression rule, not a statement
+    about the model, and the phrase carrying it -- "of order one *or larger*" -- is doing
+    a great deal of work: a model whose species all sit far above one has a real,
+    computable tolerance need, and the derivation computes it and then discards it.
+    ``Weber_BMC2015``'s seven species live at 1.24e+02 .. 4.21e+07, median 4.67e+05, so it
+    asks for ``4.665e-03`` and is handed ``1e-8``, 5.7 decades tighter. What that costs is
+    the error test read forwards: an ``atol`` far under the state's own magnitude is one
+    the absolute term can never reach, so the integrator is held to a *relative* accuracy
+    far tighter than the ``rtol`` that is supposed to govern it, and pays in steps for
+    resolution nobody asked for. The forward-*sensitivity* solve pays most, since CVODES
+    derives its sensitivity tolerances from the state ones.
+
+    The clamp binds on 10 of the 22 subset-I slugs with a readable nominal state, and nine
+    of those ten integrate their box samples at the clamped value today -- they are merely
+    charged 1.5x-2.6x the integrator steps for it (ADR-0112). That is the whole argument
+    for the opt-in: the ten are the *scope* of the problem, not a mandate to move nine
+    working results.
 
     The rule is CVODE's own error test read backwards. It weights each state by
     ``rtol*|y_i| + atol``, so ``atol`` is a declaration that values below it are noise --
@@ -76,9 +180,12 @@ def _derive_atol(scale, rtol, default_atol, *, model_name=None, warned=None):
     the floor binds -- the model asks for more resolution than the derivation will reach
     for on its own -- it is logged once per model via the ``warned`` set, because that is
     the case where the tolerance is still not small enough and nothing else would say so.
+    The floor is unconditional: ``loosen`` is about the ceiling, and a model asking for
+    ``1e-20`` is asking for something ``1e-16`` already declines to reach for.
     """
     if scale is None:
         return default_atol
+    ceiling = np.inf if loosen else default_atol
     wanted = rtol * scale
     if wanted < _DERIVED_ATOL_FLOOR and warned is not None and model_name not in warned:
         warned.add(model_name)
@@ -89,10 +196,10 @@ def _derive_atol(scale, rtol, default_atol, *, model_name=None, warned=None):
             'under-resolved, set sbml_atol explicitly.',
             model_name, scale, wanted, _DERIVED_ATOL_FLOOR, _DERIVED_ATOL_FLOOR,
         )
-    return min(max(wanted, _DERIVED_ATOL_FLOOR), default_atol)
+    return min(max(wanted, _DERIVED_ATOL_FLOOR), ceiling)
 
 
-def _derive_atol_vector(nominal, scalar_atol, rtol, default_atol):
+def _derive_atol_vector(nominal, scalar_atol, rtol, default_atol, *, loosen=False):
     """One absolute tolerance per species, from the model's nominal state (ADR-0105).
 
     ``atol_i = clamp(rtol * y_i, scalar_atol, default_atol)``, with ``y_i`` the species'
@@ -104,6 +211,14 @@ def _derive_atol_vector(nominal, scalar_atol, rtol, default_atol):
       are all of order one integrates exactly as before. bngsim's own ``derive_atol`` has
       no upper clamp -- it returns ``1.0e-07`` for ``Brannmark_JBC2010``'s ``X``, looser
       than the default -- so only-ever-tighten is PyBNF's to apply, and is applied here.
+
+      ``loosen`` (#557, ``sbml_atol = auto``) lifts this clamp and only this one; the
+      lower one stays exactly where the measurement below put it. What is left is
+      ``max(rtol*y_i, scalar_atol)``, i.e. ``rtol * max(y_i, median)`` -- which is
+      *bngsim's own* ``derive_atol`` with the model's median supplied as its ``floor``,
+      rather than the smallest strictly positive species bngsim would pick by default.
+      That equivalence is asserted against the library rather than against a copy of this
+      arithmetic, the same way the unclamped default is.
 
     * **The lower clamp is the model's own scalar, and it is there because the
       alternative was measured and lost.** Read literally, "resolve each species to
@@ -139,7 +254,8 @@ def _derive_atol_vector(nominal, scalar_atol, rtol, default_atol):
     ``nominal`` is ordered; the caller owns the ordering contract against
     ``Model.species_names``.
     """
-    return np.clip(rtol * np.asarray(nominal, dtype=float), scalar_atol, default_atol)
+    ceiling = np.inf if loosen else default_atol
+    return np.clip(rtol * np.asarray(nominal, dtype=float), scalar_atol, ceiling)
 
 
 # Process-level cache of loaded bngsim engine models, keyed by a hash of the
@@ -204,6 +320,7 @@ from ._bngsim_caps import (
     BNGSIM_HAS_OUTPUT_SENS,
     BNGSIM_HAS_PER_SPECIES_ATOL,
     BNGSIM_HAS_SBML,
+    BNGSIM_HAS_TRACKING_ATOL,
     BNGSIM_SBML_ERROR,
     bngsim,
     feature_missing_reason,
@@ -344,8 +461,18 @@ class BngsimSbmlModelNoTimeout(Model):
     # model's own state scale (:meth:`_effective_tolerances`). Class attributes so an
     # instance built via object.__new__ -- the ``_make_simulator`` test fakes, unpickling
     # -- answers "not stated" rather than raising.
+    #
+    # ``sbml_atol`` splits three ways (#557, :func:`parse_atol_setting`), and only the
+    # first of the three is a tolerance: ``_config_atol`` is a *pinned number*, which
+    # switches every derivation off, while ``_atol_mode`` is an opt-in to the derivation
+    # -- ``auto`` lifts its only-ever-tighten ceiling, ``tracking`` adds
+    # lanl/bngsim#213's trajectory-following weights on top of that. The two are mutually
+    # exclusive by construction, so ``_config_atol is not None`` remains exactly what it
+    # was: "the user stated the number, take it".
     _config_rtol = None
     _config_atol = None
+    _atol_mode = None
+    _atol_tracking_decades = None
 
     # The model's per-species nominal values in bngsim's units, and their typical (median
     # strictly-positive) magnitude, both set from the parsed document by
@@ -406,7 +533,19 @@ class BngsimSbmlModelNoTimeout(Model):
         self.integrator = integrator
         self.strict_ssa = bool(strict_ssa)
         self._config_rtol = None if rtol is None else float(rtol)
-        self._config_atol = None if atol is None else float(atol)
+        try:
+            (self._config_atol, self._atol_mode,
+             self._atol_tracking_decades) = parse_atol_setting(atol)
+        except ValueError as exc:
+            raise ModelError(f'Invalid sbml_atol for model {self.name}: {exc}') from exc
+        if self._atol_mode == _ATOL_TRACKING and not BNGSIM_HAS_TRACKING_ATOL:
+            # Refused rather than degraded. A tolerance mode that silently did not apply
+            # produces a plausible trajectory and a wrong conclusion about the model,
+            # which is the failure this whole line of work exists to stop making.
+            raise ModelError(
+                'sbml_atol = tracking needs a bngsim whose Simulator.run takes a '
+                'trajectory-following absolute tolerance (lanl/bngsim#213, '
+                'bngsim.TrackingAtol); this build does not have one.')
         self._tolerance_cache = None
         self._atol_vector_cache = None
         self._atol_floor_warned = set()
@@ -1703,14 +1842,26 @@ class BngsimSbmlModelNoTimeout(Model):
         except bngsim.SsaValidationError as exc:
             raise ModelError(str(exc)) from exc
 
+    def _atol_loosens(self):
+        """Whether this model's ``sbml_atol`` opted into loosening (#557).
+
+        True for both non-numeric settings: ``tracking`` builds its ceiling from the same
+        derivation ``auto`` produces, so at depth 0 it *is* ``auto`` -- a strict
+        extension, which is the property that makes one flag correct for both rather than
+        an accident that two modes happen to share.
+        """
+        return getattr(self, '_atol_mode', None) in (_ATOL_AUTO, _ATOL_TRACKING)
+
     def _effective_tolerances(self, sim):
         """The ``(rtol, scalar atol)`` pair this model is measured in (#546).
 
-        ``sbml_rtol`` / ``sbml_atol`` win outright when stated. Otherwise rtol is the
-        backend's own default (read off the constructed ``Simulator`` so this tracks
-        bngsim rather than a copy of its constant) and atol is derived from the model's
-        typical species magnitude by :func:`_derive_atol` -- which can only tighten, so a
-        model of order-one scale keeps the default pair exactly.
+        ``sbml_rtol`` / a **pinned** ``sbml_atol`` win outright when stated. Otherwise
+        rtol is the backend's own default (read off the constructed ``Simulator`` so this
+        tracks bngsim rather than a copy of its constant) and atol is derived from the
+        model's typical species magnitude by :func:`_derive_atol` -- which can only
+        tighten, so a model of order-one scale keeps the default pair exactly, unless
+        ``sbml_atol = auto`` / ``tracking`` (#557) has lifted that ceiling, in which case
+        a model living *above* one gets the looser tolerance its own scale asks for.
 
         Under ADR-0105 this scalar is no longer always the *integration* tolerance: when
         the per-species vector is in force it becomes the steady-state convergence cutoff
@@ -1742,13 +1893,16 @@ class BngsimSbmlModelNoTimeout(Model):
             default_atol = float(getattr(sim, '_atol', _BNGSIM_DEFAULT_ATOL))
             scale = getattr(self, '_nominal_state_scale', None)
             name = getattr(self, 'name', None)
-            atol = _derive_atol(scale, rtol, default_atol, model_name=name,
+            atol = _derive_atol(scale, rtol, default_atol, loosen=self._atol_loosens(),
+                                model_name=name,
                                 warned=getattr(self, '_atol_floor_warned', None))
             if atol != default_atol:
                 logger.debug(
                     'bngsim SBML model %s: typical species magnitude %g, so the ODE '
-                    'absolute tolerance is %g rather than the backend default %g.',
-                    name, scale, atol, default_atol)
+                    'absolute tolerance is %g rather than the backend default %g (%s).',
+                    name, scale, atol, default_atol,
+                    'looser -- sbml_atol opted into the derivation in both directions'
+                    if atol > default_atol else 'tighter')
         self._tolerance_cache = (float(rtol), float(atol))
         return self._tolerance_cache
 
@@ -1762,16 +1916,19 @@ class BngsimSbmlModelNoTimeout(Model):
           probe rather than a version floor, because the build that first carried
           lanl/bngsim#196 declares the same version string as the wheel 25 commits behind
           it;
-        * **``sbml_atol`` is stated** -- an explicit scalar is the documented off-switch
-          for this whole change, and it pins the pre-#196 ``CVodeSStolerances`` path
-          bit-for-bit, ulp included;
+        * **``sbml_atol`` pins a number** -- an explicit scalar is the documented
+          off-switch for this whole change, and it pins the pre-#196 ``CVodeSStolerances``
+          path bit-for-bit, ulp included. ``auto`` / ``tracking`` (#557) are *not* that:
+          they state how far the derivation may go, so the vector stays on and gains its
+          released upper end;
         * **there is no nominal state to read** (a non-constant compartment volume makes
           the unit factors parameter-dependent), so there is nothing to derive from;
         * **the engine model's species do not line up** with the document's, so the
           vector could not be ordered without guessing -- a mis-ordered vector assigns
           one species' tolerance to another and nothing downstream would say so;
         * **the vector is elementwise the scalar** -- true of 19 of the 23 subset-I
-          slugs, which is what "ADR-0103 had nothing to give back here" looks like: a
+          slugs under the clamped derivation, which is what "ADR-0103 had nothing to give
+          back here" looks like: a
           model the scalar derivation left at the backend default has no over-tightening
           to undo. Handing CVODE a constant vector instead of the constant it already has
           buys nothing and costs the ~1 ulp ``cvEwtSetSS``/``cvEwtSetSV`` difference #196
@@ -1812,7 +1969,8 @@ class BngsimSbmlModelNoTimeout(Model):
         rtol, scalar_atol = self._effective_tolerances(sim)
         default_atol = float(getattr(sim, '_atol', _BNGSIM_DEFAULT_ATOL))
         by_species = dict(zip(nominal, _derive_atol_vector(
-            list(nominal.values()), scalar_atol, rtol, default_atol)))
+            list(nominal.values()), scalar_atol, rtol, default_atol,
+            loosen=self._atol_loosens())))
         if all(atol == scalar_atol for atol in by_species.values()):
             return None
         missing = set(names) - set(by_species)
@@ -1860,9 +2018,34 @@ class BngsimSbmlModelNoTimeout(Model):
         integration tolerance and becomes the convergence criterion, which keeps one
         statement about the model's magnitude governing both and reproduces today's
         steady-state behaviour exactly.
+
+        ``sbml_atol = tracking`` (#557) takes the same pairing for the same reason, one
+        step further along: bngsim resolves a ``TrackingAtol`` to *its own* scalar for
+        every scalar-shaped consumer, so the cutoff has to be stated there too. What
+        travels is the derived vector as the tracking **ceiling** -- a constant of the
+        model, read off its nominal state -- with the trajectory-following happening
+        strictly *beneath* it. bngsim also ships a bare ``"tracking"`` whose ceiling is
+        derived from the **live** state at every ``run``; that is the shape ADR-0105 ruled
+        out for the vector and it is ruled out here for the same reason, since a fit that
+        moves initial conditions would then put a step in the objective wherever the
+        derivation crossed a rounding boundary.
+
+        When the vector declines -- a model whose species share one scale, an ordering it
+        cannot take, a bngsim without lanl/bngsim#196 -- tracking still applies, with the
+        scalar as a broadcast ceiling. That case is not a degradation: what tracking adds
+        is *within*-species and over time, so it is orthogonal to whether the species
+        differ from each other, and a model whose species all start at one is exactly
+        where a decay into nothing is invisible to any vector read off initial values.
         """
         rtol, scalar_atol = self._effective_tolerances(sim)
         vector = self._per_species_atol(sim, engine_model)
+        if getattr(self, '_atol_mode', None) == _ATOL_TRACKING:
+            decades = getattr(self, '_atol_tracking_decades', None)
+            spec = dict(ceiling=scalar_atol if vector is None else vector)
+            if decades is not None:
+                spec['decades'] = float(decades)
+            return {'rtol': rtol, 'atol': bngsim.TrackingAtol(**spec),
+                    'steady_state_tol': scalar_atol}
         if vector is None:
             return {'rtol': rtol, 'atol': scalar_atol}
         return {'rtol': rtol, 'atol': vector, 'steady_state_tol': scalar_atol}

--- a/pybnf/config.py
+++ b/pybnf/config.py
@@ -15,8 +15,10 @@ from .pset import BNGLModel, ModelError, SbmlModel, SbmlModelNoTimeout, FreePara
     Mutation, MutationSet
 from .bngsim_sbml_model import (
     BNGSIM_HAS_SBML,
+    BNGSIM_HAS_TRACKING_ATOL,
     BNGSIM_SBML_ERROR,
     BngsimSbmlModelNoTimeout,
+    parse_atol_setting,
 )
 from .bngsim_antimony_model import (
     BNGSIM_HAS_ANTIMONY,
@@ -2462,6 +2464,24 @@ class Configuration:
                     'Config option "{}" is only supported when sbml_backend = bngsim. '
                     'Current sbml_backend is "{}".'.format(tol_key, self.config['sbml_backend'])
                 )
+            if tol_key == 'sbml_atol':
+                # sbml_atol also carries the two derivation opt-ins (#557), so its shape
+                # check is parse_atol_setting's -- the same function the model constructor
+                # uses, so the two cannot disagree about what a value means. Rejected
+                # here, at config load, because the alternative is a ModelError raised
+                # once per model after the run has already started.
+                try:
+                    _, atol_mode, _ = parse_atol_setting(tol)
+                except ValueError as exc:
+                    raise PybnfError(f'Config option "sbml_atol": {exc}') from exc
+                if atol_mode == 'tracking' and not BNGSIM_HAS_TRACKING_ATOL:
+                    raise PybnfError(
+                        'Config option "sbml_atol = tracking" needs a bngsim whose '
+                        'Simulator.run takes a trajectory-following absolute tolerance '
+                        '(lanl/bngsim#213, bngsim.TrackingAtol); this build does not have '
+                        'one.',
+                        'Upgrade bngsim, or state a number (or "auto") instead.')
+                continue
             if tol <= 0.:
                 raise PybnfError(f'Config option "{tol_key}" must be a positive number; got {tol}.')
         # Check that the integrator is valid

--- a/pybnf/config_schema.py
+++ b/pybnf/config_schema.py
@@ -233,8 +233,16 @@ class GlobalConfig(PyBNFConfigModel):
     # keeps 1e-8 exactly. Stating either pins it for every deterministic run of every
     # SBML/Antimony model in the fit. bngsim backend only; the BNGL path takes its
     # tolerances from the actions block, which is BioNetGen's own surface for them.
+    #
+    # sbml_atol also takes two non-numeric settings (#557), which is why it is typed
+    # loosely here rather than as a float: `auto` lifts the derivation's only-ever-tighten
+    # ceiling, so a model living far ABOVE one gets the looser tolerance its own scale
+    # asks for; `tracking [decades]` adds lanl/bngsim#213's trajectory-following weights
+    # on top. Their shape is owned by bngsim_sbml_model.parse_atol_setting and checked in
+    # config.py, so a bad one is a pointed error at config load rather than a Pydantic
+    # union report.
     sbml_rtol: Optional[float] = None
-    sbml_atol: Optional[float] = None
+    sbml_atol: Any = None
     stochastic_seed: str = 'auto'
     parallel_count: Optional[int] = None
     save_best_data: int = 0

--- a/pybnf/parse.py
+++ b/pybnf/parse.py
@@ -14,6 +14,10 @@ import re
 
 logger = logging.getLogger(__name__)
 
+# What ``sbml_atol``'s numeric form looks like, so ploop can tell it from a MODE token
+# (#557) without a try/except around ``float`` that would also swallow ``inf``/``nan``.
+_NUMERIC_VALUE = re.compile(r'[+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?')
+
 
 _one_of = pp.one_of if hasattr(pp, 'one_of') else pp.oneOf
 _DelimitedList = pp.DelimitedList if hasattr(pp, 'DelimitedList') else pp.delimitedList
@@ -208,6 +212,20 @@ def parse(s):
     # multiple num value
     multnumkey = _one_of(' '.join(multnumkeys), caseless=True)
     multnumgram = multnumkey - equals - pp.OneOrMore(num) - comment
+
+    # the bngsim SBML absolute tolerance's non-numeric settings (#557):
+    #   sbml_atol = auto                 -- trust the derivation in BOTH directions
+    #   sbml_atol = tracking [<decades>] -- auto's vector as a ceiling, followed down the
+    #                                       trajectory (lanl/bngsim#213)
+    # ``sbml_atol`` stays in ``numkeys_float`` for the pinned-number form, so this has to be
+    # tried BEFORE ``numgram`` -- which error-stops (``-``) right after its ``=`` and so
+    # cannot backtrack out of a non-numeric value. Built with ``+`` up to the mode token for
+    # the mirror-image reason: a numeric value fails here and must fall through to
+    # ``numgram``. Once a mode has matched, the rest error-stops, so ``tracking 1 2`` reports
+    # a bad depth rather than reading as an unknown key.
+    sbml_atol_key = pp.CaselessLiteral('sbml_atol')
+    sbml_atol_mode = _one_of('auto tracking', caseless=True)
+    sbml_atol_gram = sbml_atol_key + equals + sbml_atol_mode - pp.Optional(num) - comment
 
     # model-data mapping grammar
     mdmkey = pp.CaselessLiteral("model")
@@ -595,7 +613,7 @@ def parse(s):
     parameter_gram = parameter_key + colon - param_id - pp.ZeroOrMore(parameter_field) - comment
 
     # check each grammar and output somewhat legible error message
-    parser = model_decl_gram | mdmgram | noise_model_gram | objective_target_gram | mode_gram | expression_gram | callable_gram | data_gram | gennet_gram | condition_gram | experiment_gram | observable_gram | parameter_gram | strgram | numgram | strnumgram | multnumgram | multstrgram | vargram | norm_modern_gram | normgram | dictgram | mutgram
+    parser = model_decl_gram | mdmgram | noise_model_gram | objective_target_gram | mode_gram | expression_gram | callable_gram | data_gram | gennet_gram | condition_gram | experiment_gram | observable_gram | parameter_gram | sbml_atol_gram | strgram | numgram | strnumgram | multnumgram | multstrgram | vargram | norm_modern_gram | normgram | dictgram | mutgram
     line = _parse_all(parser, s).asList()
 
     return line
@@ -640,6 +658,12 @@ def ploop(ls):  # parse loop
             elif l[0] in numkeys_int:
                 key = l[0]
                 values = int(l[1])
+            elif l[0] == 'sbml_atol' and not _NUMERIC_VALUE.fullmatch(l[1]):
+                # A tolerance MODE rather than a number (#557): 'auto' / 'tracking [d]'.
+                # Carried through as one lower-cased string so config.py and the model
+                # constructor read the same value; parse_atol_setting owns its shape.
+                key = l[0]
+                values = ' '.join(l[1:]).lower()
             elif l[0] in numkeys_float:
                 key = l[0]
                 values = float(l[1])
@@ -953,6 +977,11 @@ def ploop(ls):  # parse loop
             fmt = ''
             if key in numkeys_int:
                 fmt = f"'{key}=x' where x is an integer"
+            elif key == 'sbml_atol':
+                fmt = ("'sbml_atol=x' where x is a positive decimal number, or "
+                       "'sbml_atol=auto' (derive it from the model's own species scale, in "
+                       "both directions), or 'sbml_atol=tracking [decades]' (auto, plus an "
+                       "absolute tolerance that follows the trajectory)")
             elif key in numkeys_float:
                 fmt = f"'{key}=x' where x is a decimal number"
             elif key in multnumkeys:

--- a/tests/test_sbml_solver_tolerances.py
+++ b/tests/test_sbml_solver_tolerances.py
@@ -94,6 +94,7 @@ from pybnf.bngsim_sbml_model import (
     _derive_atol_vector,
 )
 from pybnf.printing import PybnfError
+from pybnf.pset import ModelError
 from pybnf.pset import FreeParameter, PSet, TimeCourse
 
 from .context import config
@@ -241,6 +242,17 @@ _ZERO_SEEDED_SBML = _TWO_SCALE_SBML.replace(
     'hasOnlySubstanceUnits="false" boundaryCondition="true" constant="false"/>\n'
     '      <species id="Big" compartment="c" initialConcentration="1.0" ')
 
+# The same three-species spread lifted six decades, so every species starts far ABOVE
+# one: ``X`` at 1e+07, ``Mid`` at 1e+04, ``Tiny`` at 1e-03, median 1e+04. This is
+# ``Weber_BMC2015``'s shape and the case ADR-0103's ceiling discards (#557) -- the
+# derivation computes 1e-04 for it and hands it 1e-08 instead. It is also the case
+# ADR-0105's vector cannot rescue, since the vector clamps into ``[scalar, default]``,
+# which here collapses to the single point 1e-08.
+_LARGE_SPREAD_SBML = (_WIDE_SPREAD_SBML
+                      .replace('initialConcentration="1e-2"', 'initialConcentration="1e4"')
+                      .replace('initialConcentration="1e-9"', 'initialConcentration="1e-3"')
+                      .replace('initialConcentration="10"', 'initialConcentration="1e7"'))
+
 K0, K1, K2, T1, T2, X0 = 0.7, 0.2, 0.5, 2.0, 5.0, 1e-8
 KB, BIG0 = 1e-3, 1.0
 T_END, N_STEPS = 8.0, 32
@@ -251,6 +263,11 @@ T_END, N_STEPS = 8.0, 32
 _TWO_SCALE_SCALAR = 5e-9
 _WIDE_SPREAD_SCALAR = 1e-10
 _WIDE_T_END = 80.0
+
+# ``_LARGE_SPREAD_SBML``'s two answers: what ADR-0103's ceiling hands it, and what its own
+# median asks for (``rtol * 1e4``). The gap between them is the whole of #557.
+_LARGE_SPREAD_CLAMPED = _BNGSIM_DEFAULT_ATOL
+_LARGE_SPREAD_LOOSENED = 1e-4
 
 
 def _stage_widths(t):
@@ -967,3 +984,444 @@ def test_config_rejects_a_nonpositive_tolerance(key):
 
     with pytest.raises(PybnfError, match='positive'):
         cfg._load_simulators()
+
+
+# --- #557: the ceiling is a no-regression rule, so it is liftable on request ----- #
+@pytest.mark.parametrize('scale, clamped, loosened', [
+    # Below the backend default's own scale: the ceiling never bound, so lifting it
+    # changes nothing and every model ADR-0103 was written for is untouched.
+    (3.667e-7, 3.667e-15, 3.667e-15),
+    (0.033, 3.3e-10, 3.3e-10),
+    # Exactly at the ceiling -- an order-one model, the no-op case either way.
+    (1.0, _BNGSIM_DEFAULT_ATOL, _BNGSIM_DEFAULT_ATOL),
+    # Above it: the derivation has an answer and the ceiling is what discards it.
+    # 4.665e+05 is Weber_BMC2015's own median, and 4.665e-03 its own answer.
+    (4.665e5, _BNGSIM_DEFAULT_ATOL, 4.665e-3),
+    (7.879e14, _BNGSIM_DEFAULT_ATOL, 7.879e6),
+])
+def test_the_derivation_loosens_only_when_asked(scale, clamped, loosened):
+    """``loosen`` lifts the upper clamp and nothing else (#557).
+
+    The two rows above the ceiling are the ones the issue is about, and the three below
+    it are why this is safe to add: a model whose state lives at or under one gets the
+    identical number either way, so every trajectory ADR-0103 changed and every
+    trajectory it deliberately left alone is unmoved by the existence of this flag. Only
+    a model asking for something *looser* than the backend default can tell the
+    difference, which is exactly the population the clamp was silently serving badly --
+    10 of the 22 subset-I slugs with a readable nominal state.
+    """
+    common = (_BNGSIM_DEFAULT_RTOL, _BNGSIM_DEFAULT_ATOL)
+
+    assert _derive_atol(scale, *common) == pytest.approx(clamped)
+    assert _derive_atol(scale, *common, loosen=True) == pytest.approx(loosened)
+
+
+def test_lifting_the_ceiling_does_not_lift_the_floor():
+    """``loosen`` is about the ceiling; ``_DERIVED_ATOL_FLOOR`` is untouched by it.
+
+    Worth an assertion rather than a comment because "trust the derivation in both
+    directions" is a natural reading of the opt-in that would take the floor with it. It
+    does not: the floor answers a different question -- how much resolution the derivation
+    will *reach for on its own*, which past ~1e-16 is already under double precision's
+    resolution of a state of order one -- and a model that genuinely lives down there
+    still says so by pinning a number.
+    """
+    tiny = 1e-20 / _BNGSIM_DEFAULT_RTOL
+
+    assert _derive_atol(tiny, _BNGSIM_DEFAULT_RTOL, _BNGSIM_DEFAULT_ATOL,
+                        loosen=True) == _DERIVED_ATOL_FLOOR
+
+
+@pytest.mark.parametrize('nominal', [
+    [1e7, 1e4, 1e-3], [4.208e7, 4.665e5, 1.239e2], [10.0, 1e-2, 1.8e-9], [1.0, 1e6],
+])
+def test_the_loosened_vector_still_never_resolves_below_the_models_scale(nominal):
+    """Lifting the ceiling leaves ADR-0105's *floor* exactly where its measurement put it.
+
+    The lower clamp is the one that was paid for: read literally, "resolve each species to
+    ``rtol`` of its own magnitude" put ``Brannmark_JBC2010``'s ``IRp`` at 1.76e-17 and
+    killed 91 of 100 box points against the scalar's 39. Nothing about a model whose
+    species live *above* one revisits that, so #557 moves one clamp and leaves the other
+    alone -- and this is the property that says so, on the large-scale rows and the
+    ADR-0105 rows alike.
+    """
+    scale = float(np.median([v for v in nominal if v > 0.0]))
+    scalar_atol = _derive_atol(scale, _BNGSIM_DEFAULT_RTOL, _BNGSIM_DEFAULT_ATOL,
+                               loosen=True)
+    got = _derive_atol_vector(nominal, scalar_atol, _BNGSIM_DEFAULT_RTOL,
+                              _BNGSIM_DEFAULT_ATOL, loosen=True)
+
+    assert np.all(got >= scalar_atol)
+
+
+@_needs_per_species_atol
+def test_the_loosened_vector_is_bngsims_own_derivation():
+    """With the ceiling lifted, the rule *is* ``bngsim.derive_atol`` at the model's median.
+
+    ``max(rtol*y_i, rtol*median)`` is ``rtol * max(y_i, median)``, which is the library's
+    own function with the median supplied as its ``floor`` -- so the opt-in is not a
+    fourth PyBNF-specific rule, it is the backend's rule with PyBNF's answer to the one
+    question the backend leaves open. (bngsim's default floor is the smallest strictly
+    positive species instead, which is the reading ADR-0105 measured and rejected; the
+    ``floor=`` argument exists for exactly this.)
+
+    The companion assertion is ``test_only_ever_tighten_is_pybnfs_to_apply_not_the
+    _backends``: pinned against the same library, it says the *clamped* default is
+    PyBNF's own. Both are asserted against bngsim rather than against a second copy of
+    this arithmetic.
+    """
+    import bngsim
+
+    nominal = [4.208e7, 4.665e5, 1.239e2]
+    median = float(np.median(nominal))
+    scalar_atol = _derive_atol(median, _BNGSIM_DEFAULT_RTOL, _BNGSIM_DEFAULT_ATOL,
+                               loosen=True)
+
+    ours = _derive_atol_vector(nominal, scalar_atol, _BNGSIM_DEFAULT_RTOL,
+                               _BNGSIM_DEFAULT_ATOL, loosen=True)
+    theirs = bngsim.derive_atol(nominal, _BNGSIM_DEFAULT_RTOL, floor=median)
+
+    np.testing.assert_allclose(ours, theirs, rtol=1e-12)
+
+
+@_needs_per_species_atol
+def test_a_model_above_the_backend_default_gets_no_vector_until_it_opts_in(tmp_path):
+    """The issue's central observation, as a test: the vector declines where it is needed.
+
+    ``_LARGE_SPREAD_SBML`` spans ten decades, which is precisely the shape ADR-0105's
+    vector exists for -- and it takes the scalar path, because the vector clamps into
+    ``[scalar_atol, default_atol]`` and the scalar has itself been clamped to
+    ``default_atol``, collapsing that interval to a point. So the per-species mechanism
+    silently declines exactly the models whose own scale asks for something the ceiling
+    will not give. Opting in re-opens the interval and the same model resolves ``X``
+    (1e+07) three decades apart from ``Tiny`` (1e-03).
+    """
+    clamped = _piecewise_model(tmp_path, text=_LARGE_SPREAD_SBML, name='large_off.xml')
+    opted_in = _piecewise_model(tmp_path, text=_LARGE_SPREAD_SBML, name='large_on.xml',
+                                atol='auto')
+
+    assert _tolerance_kwargs(clamped)[1] == {'rtol': _BNGSIM_DEFAULT_RTOL,
+                                             'atol': _LARGE_SPREAD_CLAMPED}
+
+    engine, kwargs = _tolerance_kwargs(opted_in)
+    assert dict(zip(engine.species_names, kwargs['atol'])) == pytest.approx(
+        {'X': 0.1, 'Mid': _LARGE_SPREAD_LOOSENED, 'Tiny': _LARGE_SPREAD_LOOSENED})
+    # ADR-0105's pairing holds under the opt-in too: the model-wide scalar is still what
+    # a `time = inf` measurement and a pre-equilibration phase converge against, and it
+    # is still stated rather than left to bngsim's own 1e-8 fallback.
+    assert kwargs['steady_state_tol'] == pytest.approx(_LARGE_SPREAD_LOOSENED)
+
+
+def test_the_opt_in_reaches_a_model_with_no_vector_to_give(tmp_path, monkeypatch):
+    """``auto`` loosens the *scalar* too, so it serves an install without lanl/bngsim#196.
+
+    The scalar is the whole of what ADR-0103 had and it is what the clamp acted on, so
+    the loosening is meaningful on its own -- an older bngsim opting in gets 1e-04 rather
+    than 1e-08 on this model, without a vector anywhere in sight. That also makes the
+    capability probe a refinement of this change rather than a precondition for it.
+    """
+    monkeypatch.setattr(bngsim_sbml_model, 'BNGSIM_HAS_PER_SPECIES_ATOL', False)
+    model = _piecewise_model(tmp_path, text=_LARGE_SPREAD_SBML, name='large_old.xml',
+                             atol='auto')
+
+    assert _tolerance_kwargs(model)[1] == {
+        'rtol': _BNGSIM_DEFAULT_RTOL, 'atol': pytest.approx(_LARGE_SPREAD_LOOSENED)}
+
+
+@_needs_per_species_atol
+def test_the_looser_tolerance_costs_the_integrator_less_work(tmp_path):
+    """The mechanism, in steps: the same model, at a tolerance its own state asks for.
+
+    CVODE weights each state by ``rtol*|y_i| + atol``, so on a model living at
+    1e+04..1e+07 an ``atol`` of 1e-08 is one the absolute term can never reach: the
+    integrator is held to a *relative* accuracy far tighter than the ``rtol`` that is
+    supposed to govern it, and pays in steps for resolution nobody asked for.
+
+    Steps, rather than pass/fail, is the right instrument and the corpus is what says so
+    (ADR-0112): over 20 sensitivity-applied box points per slug, the six subset-I models
+    the clamp binds hardest cost 0.38x-0.67x the CVODE steps under ``auto`` -- and all of
+    them integrate either way. This is the fixture-scale version of that number, asserted
+    with a wide margin rather than at a bare inequality so a second platform's CVODE
+    cannot flip it on a step or two.
+    """
+    clamped = _piecewise_model(tmp_path, text=_LARGE_SPREAD_SBML, name='large_steps_off.xml')
+    opted_in = _piecewise_model(tmp_path, text=_LARGE_SPREAD_SBML, name='large_steps_on.xml',
+                                atol='auto')
+
+    def steps(model):
+        # A fresh engine model per run: a second run() on the same Simulator continues
+        # from where the first left off (ADR-0104), which would make these incomparable.
+        engine = model._engine_model_for_action()
+        sim = model._make_simulator(engine, 'ode')
+        result = sim.run(t_span=(0.0, _WIDE_T_END), n_points=81,
+                         **model._run_tolerance_kwargs(sim, engine))
+        return int(result.solver_stats['n_steps'])
+
+    assert steps(opted_in) < 0.75 * steps(clamped)
+
+
+@_needs_per_species_atol
+def test_the_opted_in_model_still_integrates_to_its_closed_form(tmp_path):
+    """A looser tolerance is not a wrong answer -- it is a coarser one, and here it is not.
+
+    The trade #557 is actually making is against *smoothness*, not accuracy: on Weber four
+    decades of tolerance move ``J_paper`` in the sixth decimal while the finite-difference
+    reference degrades 28x. This asserts the accuracy half on the fixture, where the
+    closed form is exact -- ``X`` decaying through three time-gated stages from 1e+07,
+    integrated at the 0.1 its own magnitude asks for, still matches ``exp`` to a relative
+    1.0e-06, which is ``rtol`` doing exactly what ``rtol`` is for. That is the shape of
+    the trade: the absolute tolerance stops governing and the relative one governs, which
+    is the condition ADR-0103 states the derivation is trying to reach.
+    """
+    model = _piecewise_model(tmp_path, text=_LARGE_SPREAD_SBML, name='large_exact.xml',
+                             atol='auto')
+    engine = model._engine_model_for_action()
+    sim = model._make_simulator(engine, 'ode')
+    result = sim.run(t_span=(0.0, T_END), n_points=N_STEPS + 1,
+                     **model._run_tolerance_kwargs(sim, engine))
+
+    got = np.asarray(result.species)[:, list(result.species_names).index('X')]
+    np.testing.assert_allclose(got, _exact_x(np.asarray(result.time), x0=1e7), rtol=3e-6)
+
+
+# --- #557: a tolerance that follows the trajectory (lanl/bngsim#213) ------------- #
+_needs_tracking_atol = pytest.mark.skipif(
+    not bngsim_sbml_model.BNGSIM_HAS_TRACKING_ATOL,
+    reason='needs a bngsim whose Simulator.run takes a TrackingAtol (lanl/bngsim#213)')
+
+
+@_needs_tracking_atol
+def test_tracking_carries_the_derived_vector_as_its_ceiling(tmp_path):
+    """``sbml_atol = tracking`` is ``auto``'s vector, plus a rule for going below it.
+
+    The ceiling is the thing to check. bngsim's own ``TrackingAtol()`` defaults it to
+    ``"auto"``, which re-derives from the model's **live** state at every ``run`` -- the
+    shape ADR-0105 ruled out for the vector, because a fit that moves initial conditions
+    would then integrate each evaluation at a tolerance that is a function of the search
+    position. So PyBNF states the ceiling explicitly, from the nominal state, exactly as
+    it states the vector.
+    """
+    model = _piecewise_model(tmp_path, text=_LARGE_SPREAD_SBML, name='large_track.xml',
+                             atol='tracking 6')
+    reference = _piecewise_model(tmp_path, text=_LARGE_SPREAD_SBML, name='large_track_ref.xml',
+                                 atol='auto')
+    engine, kwargs = _tolerance_kwargs(model)
+
+    assert isinstance(kwargs['atol'], bngsim_sbml_model.bngsim.TrackingAtol)
+    assert kwargs['atol'].decades == 6.0
+    np.testing.assert_allclose(kwargs['atol'].ceiling, _tolerance_kwargs(reference)[1]['atol'])
+    # bngsim resolves a TrackingAtol to the *Simulator's* own scalar for every
+    # scalar-shaped consumer, so ADR-0105's steady-state cutoff has to be stated here for
+    # the same reason it is stated with a vector.
+    assert kwargs['steady_state_tol'] == pytest.approx(_LARGE_SPREAD_LOOSENED)
+
+
+@_needs_tracking_atol
+def test_tracking_without_a_depth_leaves_it_to_the_backend(tmp_path):
+    """An unstated depth is bngsim's default, not a copy of bngsim's default.
+
+    12 is a *measured* property of that mechanism -- the depth at which its own accuracy
+    stops improving on the model it was measured against, past which the limit is roundoff
+    -- so it belongs to the library that measured it. Copying the number here would let
+    the two drift apart silently.
+    """
+    model = _piecewise_model(tmp_path, text=_LARGE_SPREAD_SBML, name='large_track_def.xml',
+                             atol='tracking')
+    _, kwargs = _tolerance_kwargs(model)
+
+    assert kwargs['atol'].decades == bngsim_sbml_model.bngsim.TrackingAtol().decades
+
+
+@_needs_tracking_atol
+def test_tracking_at_depth_zero_is_the_loosened_vector(tmp_path):
+    """Depth 0 reduces to ``auto`` exactly, which is what makes tracking an *extension*.
+
+    bngsim's rule is ``clamp(rtol*|y_i|, ceiling_i * 10**-decades, ceiling_i)``, so at
+    depth 0 the clamp collapses onto the ceiling and the same tolerance reaches CVODE
+    through ``CVodeWFtolerances`` rather than ``CVodeSVtolerances``. The two agree to
+    about one ulp rather than exactly -- the same error weights by differently
+    contractable expressions -- which is why this asserts the trajectory closely rather
+    than bit-for-bit.
+
+    That property is why one ``_atol_loosens()`` flag is correct for both settings: they
+    are not two modes that happen to share a derivation, they are one derivation and a
+    depth.
+    """
+    def trajectory(atol, name):
+        model = _piecewise_model(tmp_path, text=_LARGE_SPREAD_SBML, name=name, atol=atol)
+        engine = model._engine_model_for_action()
+        sim = model._make_simulator(engine, 'ode')
+        result = sim.run(t_span=(0.0, T_END), n_points=N_STEPS + 1,
+                         **model._run_tolerance_kwargs(sim, engine))
+        return np.asarray(result.species)[:, list(result.species_names).index('X')]
+
+    np.testing.assert_allclose(trajectory('tracking 0', 'depth0.xml'),
+                               trajectory('auto', 'depth0_ref.xml'), rtol=1e-9)
+
+
+@_needs_tracking_atol
+def test_tracking_resolves_the_species_a_vector_of_initial_values_cannot(tmp_path):
+    """The half ADR-0105 named as out of reach, now in reach and measured.
+
+    A vector read off initial values fixes the *cross-species* compromise and stops there:
+    whatever number species ``i`` gets, it keeps for the whole run, so a species that
+    starts at order one and decays outgrows its own tolerance partway through and stops
+    being error-controlled. ``X`` here starts at 10 and ends near 7e-17 -- eighteen decades
+    down -- which is the case in the flesh.
+
+    So this is not the same claim as the loosening: the loosening is about which models
+    integrate at all, and this is about whether a decayed species' value means anything.
+    Both are ``sbml_atol``'s to state because they are the same statement about how far
+    the model's own state may set its tolerance.
+    """
+    def tail(atol, name):
+        model = _piecewise_model(tmp_path, text=_WIDE_SPREAD_SBML, name=name, atol=atol)
+        engine = model._engine_model_for_action()
+        sim = model._make_simulator(engine, 'ode')
+        result = sim.run(t_span=(0.0, _WIDE_T_END), n_points=81,
+                         **model._run_tolerance_kwargs(sim, engine))
+        time = np.asarray(result.time)
+        got = np.asarray(result.species)[:, list(result.species_names).index('X')]
+        exact = _exact_x(time, x0=10.0)
+        return float(np.max(np.abs(got[-8:] - exact[-8:]) / exact[-8:]))
+
+    # The derived vector gives X the backend default 1e-8, which is 8 decades ABOVE where
+    # X has got to, so its tail is pure noise. Tracking follows it down.
+    assert tail('tracking', 'wide_track.xml') < 1e-3 * tail(None, 'wide_novector.xml')
+
+
+@_needs_tracking_atol
+def test_tracking_applies_to_a_model_whose_species_share_one_scale(tmp_path):
+    """No vector to state is not a reason to decline tracking -- it is the case for it.
+
+    A model whose species all start at one gets an elementwise-constant vector and so
+    takes the scalar call (19 of the 23 subset-I slugs). What tracking adds is
+    *within*-species and over time, which is orthogonal to whether the species differ
+    from each other; a model that starts uniform and decays is precisely where a vector
+    of initial values has nothing to say. So the scalar becomes a broadcast ceiling
+    rather than a refusal.
+    """
+    model = _piecewise_model(tmp_path, text=_ORDER_ONE_SBML, name='one_track.xml',
+                             atol='tracking 4')
+    _, kwargs = _tolerance_kwargs(model)
+
+    assert isinstance(kwargs['atol'], bngsim_sbml_model.bngsim.TrackingAtol)
+    assert kwargs['atol'].ceiling == pytest.approx(_BNGSIM_DEFAULT_ATOL)
+    assert kwargs['atol'].decades == 4.0
+
+
+def test_tracking_is_refused_rather_than_dropped_without_the_backend(tmp_path):
+    """A mode that cannot apply must not silently not apply.
+
+    The failure that would otherwise happen is the one this whole line of work exists to
+    stop making: a run that integrated at something other than what was asked for, whose
+    trajectory is plausible and whose conclusion is about the model.
+    """
+    monkey = pytest.MonkeyPatch()
+    monkey.setattr(bngsim_sbml_model, 'BNGSIM_HAS_TRACKING_ATOL', False)
+    try:
+        with pytest.raises(ModelError, match='lanl/bngsim#213'):
+            _piecewise_model(tmp_path, text=_ORDER_ONE_SBML, name='no_track.xml',
+                             atol='tracking')
+    finally:
+        monkey.undo()
+
+
+# --- #557: what the settings are, at the boundaries ----------------------------- #
+@pytest.mark.parametrize('value, expected', [
+    (None, (None, None, None)),
+    (1e-4, (1e-4, None, None)),
+    ('1e-4', (1e-4, None, None)),
+    ('auto', (None, 'auto', None)),
+    ('AUTO', (None, 'auto', None)),
+    ('tracking', (None, 'tracking', None)),
+    ('tracking 6', (None, 'tracking', 6.0)),
+    ('tracking 0', (None, 'tracking', 0.0)),
+])
+def test_parse_atol_setting_reads_every_legal_shape(value, expected):
+    """One shape authority, so config.py and the model constructor cannot disagree.
+
+    A numeric *string* reads as the number because a value can reach a model from
+    somewhere other than the conf grammar -- a hand-built dict, an importer -- and the
+    two spellings must mean the same tolerance.
+    """
+    assert bngsim_sbml_model.parse_atol_setting(value) == expected
+
+
+@pytest.mark.parametrize('value', [
+    0, -1e-8, float('inf'), float('nan'), True, '', 'nonsense', 'auto 3',
+    'tracking x', 'tracking -1', 'tracking 1 2',
+])
+def test_parse_atol_setting_refuses_what_is_not_a_tolerance(value):
+    """Including the three that look plausible: a zero/negative/infinite one.
+
+    ``tracking -1`` is refused for bngsim's own reason -- a tracking tolerance with no
+    floor is pure relative error control, which has no weight to give a species sitting
+    at exactly zero.
+    """
+    with pytest.raises(ValueError):
+        bngsim_sbml_model.parse_atol_setting(value)
+
+
+@pytest.mark.parametrize('text, expected', [
+    ('sbml_atol = 1e-4', 1e-4),
+    ('sbml_atol = auto', 'auto'),
+    ('sbml_atol = AUTO', 'auto'),
+    ('sbml_atol = tracking', 'tracking'),
+    ('sbml_atol = tracking 6', 'tracking 6'),
+    ('sbml_atol = tracking 6  # the depth', 'tracking 6'),
+])
+def test_the_conf_grammar_takes_a_number_or_a_mode(text, expected):
+    """A key that used to be a float now carries three kinds of statement (#557).
+
+    The grammar order is the fragile part and is what this pins: ``numgram`` error-stops
+    immediately after its ``=``, so a mode reaching it would be a hard parse failure
+    rather than a backtrack -- the mode grammar has to be tried first, and has to fail
+    *recoverably* on a number so the float form still lands on ``numgram``.
+    """
+    from pybnf import parse
+
+    assert parse.ploop([text])['sbml_atol'] == expected
+
+
+@pytest.mark.parametrize('text', ['sbml_atol = nonsense', 'sbml_atol = tracking 1 2'])
+def test_the_conf_grammar_names_all_three_forms_when_it_refuses(text):
+    """The error a typo gets lists what the key actually accepts, not just "a number"."""
+    from pybnf import parse
+
+    with pytest.raises(PybnfError) as exc:
+        parse.ploop([text])
+    assert 'auto' in str(exc.value) and 'tracking' in str(exc.value)
+
+
+def _tolerance_config(value, backend='bngsim'):
+    """A bare :class:`Configuration` carrying just enough to reach the tolerance checks."""
+    cfg = object.__new__(config.Configuration)
+    cfg.models = {}
+    cfg.config = {'bng_command': '', 'sbml_backend': backend, 'sbml_integrator': 'cvode',
+                  'sbml_ssa_strict': 1, 'sbml_atol': value}
+    return cfg
+
+
+@pytest.mark.parametrize('value', ['auto', 'tracking', 'tracking 6'])
+def test_config_accepts_the_modes_under_the_bngsim_backend(value):
+    """...and still refuses them under RoadRunner, which has its own integrator settings."""
+    _tolerance_config(value)._load_simulators()
+
+    with pytest.raises(PybnfError, match='sbml_atol.*bngsim'):
+        _tolerance_config(value, backend='roadrunner')._load_simulators()
+
+
+@pytest.mark.parametrize('value', ['nonsense', 'tracking -1', 0, -1])
+def test_config_refuses_a_setting_that_is_not_a_tolerance(value):
+    """Refused at config load rather than as a ModelError once the run has started."""
+    with pytest.raises(PybnfError, match='sbml_atol'):
+        _tolerance_config(value)._load_simulators()
+
+
+def test_config_refuses_tracking_without_the_backend_capability(monkeypatch):
+    """The capability check runs at config load too, so the refusal is not per-model."""
+    monkeypatch.setattr(config, 'BNGSIM_HAS_TRACKING_ATOL', False)
+
+    with pytest.raises(PybnfError, match='lanl/bngsim#213'):
+        _tolerance_config('tracking')._load_simulators()


### PR DESCRIPTION
Closes #557. ADR-0112. Opens #586.

## What this adds

`sbml_atol` takes two settings besides a number. Both say **how far the model's own state may set
its tolerance**; neither replaces the derivation, which is what separates them from a pinned number.

```
sbml_atol = auto                  # trust the derivation in both directions
sbml_atol = tracking [<decades>]  # auto's vector as a ceiling, followed down the trajectory
```

**Nothing changes without one of those two words.** Unset is byte-identical — same clamps, same
vector, same steady-state pairing — and a number remains the documented off-switch that pins
`CVodeSStolerances` ulp for ulp.

### `auto` lifts one clamp, and only one

ADR-0103's derivation may only ever *tighten*. That is a no-regression rule and it is why the
derivation could be applied to every model without a flag — but the phrase carrying it, "of order
one *or larger*", is doing a great deal of work. A model whose species all sit far above one has a
real, computable tolerance need, and the derivation computes it and then discards it.
`Weber_BMC2015` asks for `4.665e-03` and is handed `1e-08`.

ADR-0105's per-species vector cannot rescue that either, and the way it fails is the point: each
entry clamps into `[scalar_atol, default_atol]`, the scalar has itself been clamped to
`default_atol`, that interval collapses to a point, and the vector correctly declines — so **the
per-species mechanism silently declines exactly the models that span the most decades**. The clamp
binds on **10 of the 22** subset-I slugs with a readable nominal state.

`auto` lifts the ceiling on both derivations and nothing else. ADR-0105's *floor* stays exactly
where its measurement put it (releasing it killed 91 of 100 `Brannmark_JBC2010` box points against
39), and the `1e-16` floor stays too. What is left, `rtol * max(y_i, median)`, is **bngsim's own
`derive_atol` with the model's median as its `floor`** — asserted against the library rather than
against a second copy of the arithmetic.

### `tracking` is the half ADR-0105 named as out of reach

lanl/bngsim#213's `CVodeWFtolerances`: an absolute tolerance re-evaluated against the state being
integrated, so a species that starts at order one and decays to nothing keeps a tolerance that means
something for it. The ceiling is `auto`'s vector held from the **nominal** state, so `tracking 0` is
`auto` exactly and a fit that moves initial conditions does not move its own tolerance — bngsim's
bare `"auto"` ceiling, which re-derives from the live state at every run, is deliberately not used.
An unstated depth is left to bngsim rather than copied. Refused, not degraded, on a bngsim without
the capability — at config load and again in the model constructor.

## Please read this part before the diff

**#557's headline measurement no longer reproduces.** The issue reports `Weber_BMC2015` integrating
6 of 30 sensitivity-applied box points at the clamped tolerance against 22 at `1e-04`. On the current
stack all six arms — unset, `1e-08`, `1e-04`, `auto`, `tracking`, `tracking 6` — integrate **30 of
30**, within 7.2 s of each other. bngsim moved 0.12.2 → 0.13.0 in between and the documented
Weber-specific change is **lanl/bngsim#305**, whose own entry measures that slug's `t = 24` crossing
and reports the step count roughly halving. I have not bisected it and the ADR says so.

So this ships as a capability with a measured cost rather than as a rescue, and the instrument that
discriminates is **integrator steps**, not pass/fail. 20 box points per slug, gradient sensitivity
request applied, counting every CVODE step:

| slug | clamp | clamped | `auto` | vs | `tracking` |
|---|:--:|---:|---:|---:|---:|
| `Perelson_Science1996` | binds | 8 440 | **3 216** | 0.38x | 9 512 |
| `Weber_BMC2015` | binds | 78 641 | **36 154** | 0.46x | 75 650 |
| `Crauste_CellSystems2017` | binds | 8 617 | **4 162** | 0.48x | 13 751 |
| `Rahman_MBS2016` | binds | 6 298 | **3 709** | 0.59x | 5 783 |
| `Okuonghae_ChaosSolitonsFractals2020` | binds | 19 480 | **11 996** | 0.62x | 25 946 |
| `Laske_PLOSComputBiol2019` | binds | 236 629 | **158 543** | 0.67x | 292 014 |
| `Oliveira_NatCommun2021` | binds | 13 639 | 11 164 | 0.82x | 17 037 |
| `Raia_CancerResearch2011` | binds | 116 506 | 115 127 | 0.99x | 272 650 |
| `Giordano_Nature2020` | tightens | 157 728 | **157 728** | **1.00x** | 197 082 |
| `Brannmark_JBC2010` | tightens | 164 564 | 167 700 | 1.02x | 255 575 |

- `Giordano_Nature2020` is **bit-identical**, steps and error-test failures both — the control the
  design rests on: a model whose derivation tightens cannot see the ceiling, so lifting it must
  change nothing.
- Not free in the other direction: **error-test failures rise as steps fall** (`Perelson` 10 → 52,
  `Zhao` 147 → 1121), and **`Laske` lost one box point of twenty** at seed 11. At a second seed both
  arms lose one, so it is not systematic — but it is where the opt-in's risk lies, and it is why
  this is opt-in.
- **Not an accuracy trade.** `J_paper` at the PEtab nominal point across Weber's whole 5.7-decade
  sweep moves in the *sixth decimal* (296.2018011 → 296.2018660) and `nominal_check.json` holds under
  every arm; Giordano's is identical to all 17 digits. What a looser tolerance costs is *smoothness*,
  which is why `Weber_BMC2015` ships `1e-4` rather than its own `4.665e-03` and why this PR does not
  touch that conf.

## Scope

`_bngsim_caps.py` (`BNGSIM_HAS_TRACKING_ATOL`, a name probe for the same reason as its neighbour);
`bngsim_sbml_model.py` (`parse_atol_setting` as the one shape authority, a `loosen` keyword on both
derivations, the tracking branch of `_run_tolerance_kwargs`); `parse.py` (the mode grammar, tried
ahead of `numgram`, which error-stops after its `=` and so cannot backtrack); `config_schema.py`;
`config.py`; `docs/config_keys.rst`; CHANGELOG; ADR-0112.

Out, unchanged: every BNGL/net model, every stochastic run, the RoadRunner backend, and every job
that does not state `sbml_atol` or states a number.

**#557's second ask is half delivered on purpose.** Relaxing `_derive_atol_vector`'s upper clamp is
here, and with it `CVodeSVtolerances` is reachable from a conf on models that could not reach it
before, with entries the model's own state supplies. A *hand-written* vector is #586: `sbml_atol` is
one global key applying to every SBML/Antimony model in a fit, so a positional vector has no ordering
a conf author can see and a species-keyed one has no unambiguous reading across models that do not
share species. That needs a per-model tolerance record and its own design.

## Tests

`tests/test_sbml_solver_tolerances.py` gains 21 test functions — 56 cases with parametrization, taking the file from 44 to 100 —
and `_LARGE_SPREAD_SBML` — the ADR-0105 spread
lifted six decades, which is `Weber_BMC2015`'s shape reduced to something a unit test can hold and
which exhibits the whole defect. Notably:

- `test_a_model_above_the_backend_default_gets_no_vector_until_it_opts_in` — the "declines exactly
  where it is needed" claim, as an assertion.
- `test_the_derivation_loosens_only_when_asked` — both sides of the ceiling, so the no-op case is
  pinned as hard as the moving one.
- `test_the_loosened_vector_is_bngsims_own_derivation` — pinned against the library, the mirror of
  the existing `test_only_ever_tighten_is_pybnfs_to_apply_not_the_backends`.
- `test_tracking_resolves_the_species_a_vector_of_initial_values_cannot` — the tracking oracle,
  against a closed form, on a species that decays eighteen decades.
- `test_tracking_at_depth_zero_is_the_loosened_vector` — the strict-extension property, as a
  trajectory, at the ~1 ulp bngsim documents for its three routes.
