### PR TITLE
Renumber the #557 tolerance ADR to 0114 — 0112 was taken on main nine hours before it merged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to PyBNF are documented below. This project adheres to
 
 ### Added
 - **`sbml_atol` takes `auto` and `tracking`, so a model whose own scale asks for a *looser*
-  absolute tolerance can have one (#557, ADR-0112).** ADR-0103's derivation is allowed only to
+  absolute tolerance can have one (#557, ADR-0114).** ADR-0103's derivation is allowed only to
   tighten. That is a no-regression rule and it is why the derivation could be applied to every model
   without a flag — but a model whose species all sit far above one has a real, computable tolerance
   need, and the derivation computes it and then discards it. `Weber_BMC2015`'s seven species live at
@@ -51,7 +51,7 @@ All notable changes to PyBNF are documented below. This project adheres to
   is bit-identical on `Giordano_Nature2020` — the control, whose derivation tightens and so cannot
   see the ceiling — and moves `J_paper` at the PEtab nominal point in its sixth decimal. It is not
   free in the other direction either: error-test failures rise as steps fall, and `Laske` lost one
-  box point of twenty at one seed (both arms lose one at a second seed). ADR-0112 has every arm and
+  box point of twenty at one seed (both arms lose one at a second seed). ADR-0114 has every arm and
   says what it has not bisected.
 
 ### Fixed

--- a/docs/adr/0114-an-only-ever-tighten-clamp-is-a-no-regression-rule-rather-than-a-property-of-the-model-so-sbml-atol-gains-an-opt-in-that-lets-the-derivation-loosen-and-one-that-follows-the-trajectory.md
+++ b/docs/adr/0114-an-only-ever-tighten-clamp-is-a-no-regression-rule-rather-than-a-property-of-the-model-so-sbml-atol-gains-an-opt-in-that-lets-the-derivation-loosen-and-one-that-follows-the-trajectory.md
@@ -1,6 +1,10 @@
 # An only-ever-tighten clamp is a no-regression rule rather than a property of the model, so `sbml_atol` gains an opt-in that lets the derivation loosen — and one that follows the trajectory (issue #557)
 
 **Status: Accepted and implemented (2026-08-18). Extends ADR-0103 and ADR-0105; supersedes neither.**
+*(Numbered 0114 on 2026-08-19. It was written and merged as 0112, which #587's
+measurement-time ADR had already taken nine hours earlier on `main` — a collision neither branch
+could see, since each picked the next free number against the `main` it branched from. Renumbered
+rather than left duplicated because an ADR's number is how every other document cites it.)*
 Both stand exactly as written for the default path, which is byte-identical after this change. What
 this adds is a way for a job to say how far its own model's state may set its tolerance.
 

--- a/pybnf/bngsim_sbml_model.py
+++ b/pybnf/bngsim_sbml_model.py
@@ -160,7 +160,7 @@ def _derive_atol(scale, rtol, default_atol, *, loosen=False, model_name=None, wa
 
     The clamp binds on 10 of the 22 subset-I slugs with a readable nominal state, and nine
     of those ten integrate their box samples at the clamped value today -- they are merely
-    charged 1.5x-2.6x the integrator steps for it (ADR-0112). That is the whole argument
+    charged 1.5x-2.6x the integrator steps for it (ADR-0114). That is the whole argument
     for the opt-in: the ten are the *scope* of the problem, not a mandate to move nine
     working results.
 

--- a/tests/test_sbml_solver_tolerances.py
+++ b/tests/test_sbml_solver_tolerances.py
@@ -1138,7 +1138,7 @@ def test_the_looser_tolerance_costs_the_integrator_less_work(tmp_path):
     supposed to govern it, and pays in steps for resolution nobody asked for.
 
     Steps, rather than pass/fail, is the right instrument and the corpus is what says so
-    (ADR-0112): over 20 sensitivity-applied box points per slug, the six subset-I models
+    (ADR-0114): over 20 sensitivity-applied box points per slug, the six subset-I models
     the clamp binds hardest cost 0.38x-0.67x the CVODE steps under ``auto`` -- and all of
     them integrate either way. This is the fixture-scale version of that number, asserted
     with a wide margin rather than at a bare inequality so a second platform's CVODE


### PR DESCRIPTION
Follow-up to #592. Docs only — no code behaviour changes.

## The collision

Two ADRs on `main` both answer to **0112**:

| file | landed |
|---|---|
| `0112-a-measurement-time-uncertainty-…` (#587) | 2026-08-18 **11:19** |
| `0112-an-only-ever-tighten-clamp-…` (#557, #592) | 2026-08-18 **20:15** |

Neither branch could see it. Each picked the next free number against the `main` it branched from,
#587 landed while #592 was in review, and nothing checks the number at merge.

## The fix

**The later one moves.** 0113 is also taken (#587's phase-2 gradient ADR), so the #557 tolerance ADR
becomes **0114**.

Renumbered rather than left duplicated because an ADR's number is how every other document cites it:
two files answering to "ADR-0112" makes every existing citation ambiguous — including the ones inside
#587's own ADRs, which are the ones most likely to be read together.

- File renamed (`git mv`, so the history follows).
- The **three** references that meant *this* ADR updated: `CHANGELOG.md` (the #557 entry's two), the
  `_derive_atol` docstring, and the corpus-numbers docstring in `test_sbml_solver_tolerances.py`.
- #587's references are untouched — they already meant the ADR-0112 that stays.
- A status note in the renumbered ADR records the old number, so a link or a note written against
  0112 in the nine hours it existed still lands somewhere that explains itself.

## Checks

- `ls docs/adr | sed 's/-.*//' | sort | uniq -d` — **empty** (was `0112`).
- No `ADR-0112` citation remains anywhere near a tolerance:
  `grep -rn "ADR-0112" --include=*.py --include=*.md --include=*.rst . | grep -iE "atol|toleran|clamp"`
  returns nothing.
- `tests/test_sbml_solver_tolerances.py`: 100 passed.
- `uvx ruff@0.15.14 check .`: clean.

## Worth knowing

This is structural, not a one-off: any two PRs adding an ADR concurrently collide, and the loser is
whichever merges second. Not proposing a guard here — a pre-commit check that the highest ADR number
is unique would catch it at authoring time but still not at merge time, which is where this one
happened. Flagging it in case it is worth its own issue.
