### PR TITLE
fix(de): DE/ade convergence is an absolute objective range, not a ratio, so a likelihood fit no longer stops after generation 0 (#561)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ All notable changes to PyBNF are documented below. This project adheres to
 ## [Unreleased]
 
 ### Fixed
+- **`job_type = de` and `job_type = ade` no longer stop after generation 0 on a negative
+  objective (#561, ADR-0114).** The Differential Evolution family tested convergence with a
+  *ratio* of objectives — `max(fit) / min(fit) < 1 + stop_tolerance` — which reads as
+  convergence only on a positive objective bounded below by 0 (a χ², an SSE). On a likelihood
+  objective (a negative log-likelihood, unbounded below) it fired at generation 0: an
+  all-negative population lands the ratio in `(0, 1]`, and a single `inf`-scored failed
+  simulation makes it `-inf`, below *every* threshold — so no value of `stop_tolerance`
+  disabled it, and both members of the family were unrunnable on any estimated-σ likelihood
+  fit (the whole Grein et al. 2026 benchmark subset-I corpus, 23/23 slugs). On
+  `Borghans_BiophysChem1997` (`islands = 4`, `population_size = 400`, `max_iterations = 600`)
+  the run terminated inside the first generation, spending a 240,000-evaluation budget on 0
+  generations of search — and `stop_tolerance = -1e9` still fired, because the failed-sim
+  `-inf` is below that too.
+  The convergence test is now an **absolute range in objective units**,
+  `max - min <= de_tolfun`, assessed over the **finite** fitnesses only — sign-agnostic, and
+  with failed simulations (`inf`) ignored so one dead candidate can neither trigger nor block
+  the stop. It gets its own key, `de_tolfun` (a range in objective units, where
+  `stop_tolerance` was a dimensionless ratio), which falls back to `stop_tolerance` when unset
+  so an existing config keeps its threshold magnitude — mirroring how `cmaes_tolfun` splits
+  off `cmaes_stop_tol` (ADR-0106, the CMA-ES sibling of exactly this defect). The shared check
+  lives in one `DifferentialEvolutionBase` helper, so `de` and `ade` cannot drift apart again
+  (the missing `!= 0` guard that let `ade` divide `0/0` on an all-zero population was such a
+  drift; the range form has no division). In an island run, convergence is assessed only once
+  every island has completed an iteration, so ignoring `inf` cannot let one finished island
+  stop the whole search before the others have run.
+  Regression tests pin each failure mode at its decision point (an all-negative spread and an
+  `inf`-defeated threshold are *not* converged; a collapsed finite population *is*; `de_tolfun`
+  is its own knob; the all-zero `ade` population no longer divides) plus an end-to-end guard
+  that both optimizers advance past generation 0 on an objective that is negative everywhere
+  the population lands.
 - **`job_type = ms` no longer dies on a fit with a measurement-model formula observable (#578).**
   Multiple shooting was unusable on essentially the whole PEtab-imported corpus — including its
   own motivating problem, `Borghans_BiophysChem1997` — failing on the first outer iteration with

--- a/docs/adr/0114-the-de-family-convergence-test-is-an-absolute-objective-range-over-the-finite-population-carried-by-its-own-key-so-a-likelihood-fit-no-longer-stops-after-generation-0.md
+++ b/docs/adr/0114-the-de-family-convergence-test-is-an-absolute-objective-range-over-the-finite-population-carried-by-its-own-key-so-a-likelihood-fit-no-longer-stops-after-generation-0.md
@@ -1,0 +1,175 @@
+# The Differential Evolution family's convergence test is an absolute objective range over the finite population, carried by its own key, so a likelihood fit's negative objective no longer stops the run after generation 0 (issue #561)
+
+**Status: Accepted and implemented (2026-08-19). The DE sibling of ADR-0106.** ADR-0106
+(issue #550) fixed exactly this reasoning for CMA-ES: "PyBNF minimizes a negative
+log-likelihood, which is unbounded below, so `|f|` GROWS as the fit improves." `de` and
+`ade` are the unfixed siblings, and their form is worse — a **ratio** of objectives
+rather than a relative additive threshold. This ADR makes the DE-family convergence
+criterion an **absolute range in objective units**, assessed over the **finite**
+fitnesses only, and gives it **its own key**, `de_tolfun`, because a ratio and a range
+have no common scale.
+
+## The defect
+
+Both members of the family test convergence with a ratio of the population's objective
+values.
+
+`pybnf/algorithms/optimizers/differential_evolution.py`, `de` (per island):
+
+```python
+if (np.min(self.fitnesses) != 0) and (np.max(self.fitnesses) / np.min(self.fitnesses) < 1. + self.stop_tolerance):
+    return 'STOP'
+```
+
+`ade`, without even the `!= 0` guard:
+
+```python
+if np.max(self.fitnesses) / np.min(self.fitnesses) < 1. + self.stop_tolerance:
+    return 'STOP'
+```
+
+The test means "the spread is small **relative to the values**", which is a convergence
+statement only when the objective is positive and bounded below by 0 (a χ², an SSE). It
+fails two ways otherwise, and both are the **sign** of the objective, not any real
+convergence:
+
+1. **All fitnesses negative.** `max/min` lands in `(0, 1]` — for `max = -59.5`,
+   `min = -166.0` it is `0.358`, below `1 + stop_tolerance` for any non-negative
+   tolerance. So the run stops at the first check regardless of how spread out the
+   population is: `0.358` is a population spanning 107 NLL units being called converged.
+2. **Any failed simulation, with any negative fitness present.** A failed point scores
+   `inf` (`base.py`, `add_to_trajectory`), so `max/min = inf / (negative) = -inf`, below
+   *every* threshold. This defeats the obvious workaround: setting `stop_tolerance` very
+   negative does not disable the test, because `-inf` is below that too.
+
+That is every estimated-σ likelihood problem — the whole Grein et al. 2026 benchmark
+subset-I corpus (23/23 slugs, all with `noise_model` estimating σ and all with a negative
+objective at their nominal point) — so **both members of the Differential Evolution
+family were unrunnable there**.
+
+### Observed
+
+`Borghans_BiophysChem1997` from the subset-I corpus (23 free parameters,
+`noise_model = lognormal, sigma = fit sigma`, so the objective is a negative NLL),
+`job_type = de`, `population_size = 400`, `max_iterations = 600`, `islands = 4`, PyBNF
+`095a5a14`, bngsim 0.13.0:
+
+| `stop_tolerance` | outcome | generation-0 jobs | generation-1 jobs |
+|---|---|---:|---:|
+| `1e-6` | `Stop criterion satisfied with objective function value of -59.48` | 125 | **0** |
+| `-1e9` | `Stop criterion satisfied with objective function value of -0.78` | 32 | **0** |
+
+Both runs terminate inside the first generation, having spent a 240,000-evaluation
+budget on 0 generations of search. The second row is the workaround point:
+`stop_tolerance = -1e9` puts the threshold at −1e9 and *still* fires, because failed
+points make the ratio `-inf`. There is no configuration that disables this test. Note the
+reported "best objective" is *worse* in the second run (−0.78 vs −59.48): with the test
+firing mid-generation, what gets reported is whatever the partial population happened to
+hold.
+
+## The decision
+
+### 1. The criterion is an absolute range in objective units, over the finite fitnesses
+
+```python
+finite = np.asarray(self.fitnesses, dtype=float)
+finite = finite[np.isfinite(finite)]
+return bool(finite.size and (finite.max() - finite.min()) <= self.de_tolfun)
+```
+
+The range `max - min` is **sign-agnostic**: an all-negative population spanning 107 NLL
+units has a range of 107, nowhere near any convergence tolerance, so it does not fire.
+Ignoring the non-finite entries is what makes a failed simulation unable to either
+**satisfy** or **defeat** the test — the same robustness ADR-0106 chose *not* to adopt
+for CMA-ES's current-generation conjunct, here adopted because it is the whole point of
+the fix. An empty finite set (every member still `inf`, e.g. before the first result) is
+never "converged". This also subsumes the original `!= 0` guard against dividing by an
+all-zero population, which `ade` never had — a whole population at exactly 0 now reports
+converged (range 0) with no division at all, rather than computing `0/0 = nan`.
+
+The check lives in one shared helper, `DifferentialEvolutionBase._population_converged`,
+so `de` and `ade` cannot drift apart again (the missing `ade` guard was exactly such a
+drift).
+
+### 2. It gets its own key, `de_tolfun`, falling back to `stop_tolerance`
+
+The old `stop_tolerance` was a **dimensionless ratio**; the new threshold is a **range in
+objective units**, whose natural magnitude is set by the data, the noise model, and the
+number of scored points. These cannot share one well-set value, so — exactly as ADR-0106
+split `cmaes_tolfun` off `cmaes_stop_tol` — `de_tolfun` is the range tolerance, and
+**unset it falls back to `stop_tolerance`**, so an existing config keeps the threshold
+*magnitude* it had. The reinterpretation from ratio to range is unavoidable (it is the
+defect), but no config silently acquires a *different number*.
+
+### 3. Island DE assesses convergence only once every island has run
+
+The convergence check reads the global `self.fitnesses` but fires per island, when that
+island completes an iteration. Ignoring `inf` removes a coupling the old ratio relied on:
+an unevaluated island (all members at the initial `inf` sentinel) used to make the global
+`max` infinite and thereby block convergence. Without that, a single island finishing its
+first iteration with a collapsed finite subpopulation could stop the whole multi-island
+run before the other islands had searched at all.
+
+So the `de` call site gates the check on `min(self.iter_num) >= 1` — every island has
+completed at least one iteration, hence no member is still at its initial `inf` (only
+failed sims are `inf`, and those are correctly filtered). This restores the "wait for the
+whole population" half of the old behavior without the sign / failed-sim half. For a
+single island (`islands = 1`, the default) it holds from the first iteration on, so
+single-island DE and `ade` — whose per-iteration check point already guarantees a full
+population pass — are unaffected.
+
+## What is deliberately not changed
+
+* **The reported reason string.** `de`/`ade` return `'STOP'` and the run loop prints the
+  generic "Stop criterion satisfied with objective function value of …"; this is
+  unchanged. ADR-0106 added a threshold-reporting reason for the CMA-ES *restart battery*
+  because a restart's arithmetic (range vs window vs tolerance) was otherwise
+  unrecoverable from the log; a DE convergence stop has no such hidden arithmetic.
+* **The default magnitude.** `de_tolfun` unset is `stop_tolerance` (default `0.002`).
+  A fit that wants the old *relative* semantics has no equivalent — but that semantics was
+  only ever meaningful for a positive objective, where an absolute range at the same
+  magnitude is a stricter, well-defined stop.
+
+## Consequences
+
+* **The DE family runs on a likelihood objective.** On the reported fit the run no longer
+  stops at generation 0; it searches to `max_iterations` (or a genuine range collapse).
+  The whole subset-I corpus becomes reachable by `de`/`ade`, which mattered because on its
+  last unsolved slug (wshlavacek/BNGL-Models#38) `de` was reached for precisely because
+  `gntr`, `cmaes` and `pso` all converge to the same shallow attractor.
+* **A failed simulation neither stops nor blocks the search.** The `inf` is filtered, so
+  one dead candidate can no longer end a run (defeat by `-inf`) nor, in island DE, hold a
+  finished island open forever.
+* **Existing configs keep their threshold magnitude.** `de_tolfun` unset is
+  `stop_tolerance`; only the ratio→range reinterpretation changes, and only in the
+  direction of a better-defined stop.
+* **One new config key.** `de_tolfun` joins the DE-family schema
+  (`Optional[float]`, `ge=0`), the `parse.py` float-token list, and the golden
+  effective-config corpus, which moves by that one key across the nine DE-family fits.
+* **What a user should set.** On a likelihood fit, set `de_tolfun` to the smallest
+  population objective spread you still consider unconverged (a range in your objective's
+  units); leave it unset on a classic SSE/χ² fit to keep the `0.002`-magnitude stop.
+
+## Alternatives considered
+
+* **Reuse `stop_tolerance` and just drop the ratio.** Rejected for the same reason
+  ADR-0106 rejected reusing `cmaes_stop_tol`: a dimensionless ratio and an
+  objective-units range have no common scale, so one key cannot be well-set for both, and
+  silently redefining the existing key's units is worse than adding one.
+* **Require ≥ 2 finite members for a "spread".** Considered. A single finite member
+  (range 0) reports converged, which on a population where all-but-one sim failed is a
+  degenerate but defensible "one viable point" stop. Not adopted: it is an extra rule for
+  a pathological state (a persistently 9/10-failing population is not going to search
+  productively either way), and the issue's proposed form uses `finite.size >= 1`.
+* **Distinguish an unevaluated `inf` from a failed-sim `inf` by tracking evaluation
+  state.** Rejected as heavier than needed: `min(self.iter_num) >= 1` is an exact proxy
+  in island DE (every island having run once ⟺ no initial-`inf` members remain) and needs
+  no new state.
+
+## References
+
+* Issue #561 (this defect) and the reproduction write-up wshlavacek/BNGL-Models#38
+  (`Borghans_BiophysChem1997`, Grein subset-I).
+* ADR-0106 (the CMA-ES sibling, #550): the same "unbounded-below likelihood defeats a
+  relative/ratio convergence threshold" reasoning, and the `cmaes_tolfun`-off-`cmaes_stop_tol`
+  own-key precedent this mirrors.

--- a/docs/algorithms.rst
+++ b/docs/algorithms.rst
@@ -125,7 +125,24 @@ The asynchronous version of the algorithm is identical to the sychronous algorit
 Island-based version
 """"""""""""""""""""
 
-In the island-based version of the algorithm [Penas2015]_, the population is divided into ``num_islands`` islands, which each follow the above update procedure independently. Every ``migrate_every`` iterations, a migration step occurs in which ``num_to_migrate`` individuals from each island are transferred randomly to others (according to a random permutation of the islands, keeping the number of individuals on each island constant). The migration step does not require synchronization of the islands; it is performed when the last island reaches the appropriate iteration number, regardless of whether other islands are already further along. 
+In the island-based version of the algorithm [Penas2015]_, the population is divided into ``num_islands`` islands, which each follow the above update procedure independently. Every ``migrate_every`` iterations, a migration step occurs in which ``num_to_migrate`` individuals from each island are transferred randomly to others (according to a random permutation of the islands, keeping the number of individuals on each island constant). The migration step does not require synchronization of the islands; it is performed when the last island reaches the appropriate iteration number, regardless of whether other islands are already further along.
+
+Convergence
+"""""""""""
+
+A run finishes either at ``max_iterations`` or when the population has converged to
+roughly the same objective value. Convergence is measured as an **absolute range** of the
+objective over the population: the run stops once the spread between the best and worst
+*finite* member falls to ``de_tolfun`` or below. Failed simulations (scored as infinity)
+are ignored, so one dead candidate can neither trigger nor block the stop. The range is in
+the units of your objective function, which is what makes it well-defined on a likelihood
+objective — a negative log-likelihood is unbounded below, so a *ratio* of objectives
+(the pre-#561 test) reads an all-negative population as converged and stops after
+generation 0. ``de_tolfun`` is unset by default and then follows ``stop_tolerance``, so an
+existing config keeps the threshold magnitude it had; set ``de_tolfun`` to control the
+objective range independently of that key. In an island run, convergence is assessed only
+once every island has completed at least one iteration, so a single finished island cannot
+stop the whole search before the others have run.
 
 Applications
 ^^^^^^^^^^^^

--- a/docs/config_keys.rst
+++ b/docs/config_keys.rst
@@ -1672,15 +1672,25 @@ PyBNF offers two versions of :ref:`differential evoltution <alg-de>`: synchronou
     * ``mutation_factor = 0.7``
 
 **stop_tolerance**
-  Stop the run if within the current popluation, :math:`max\_objective / min\_objective < 1 + e`, where *e* is the value of this key. This criterion triggers when the entire population has converged to roughly the same objective function value. 
-  
+  Stop the run when the current population has converged to roughly the same objective function value, measured as an **absolute range** of the objective across the finite members of the population: the run ends once :math:`max\_objective - min\_objective \le e`, where *e* is the value of this key. Failed simulations (which score infinity) are ignored, so one dead candidate can neither trigger nor block the stop. This is a range in the units of your objective function; on a likelihood objective (a negative log-likelihood, which is unbounded below) set it to the smallest population spread you still consider unconverged. Prior to #561 this was a *ratio* test (:math:`max/min < 1 + e`), which stopped the run at generation 0 on any objective that can go negative; see ``de_tolfun`` to set the range independently of this key's magnitude.
+
   Default: 0.002
-  
+
   Example:
-  
+
     * ``stop_tolerance = 0.001``
-  
-  
+
+
+**de_tolfun**
+  The convergence tolerance the run actually uses: the absolute objective range (see ``stop_tolerance``) below which the population counts as converged. It is a range in the units of your objective function, whereas ``stop_tolerance`` was historically a dimensionless ratio; the two are separated so a fit can set a meaningful objective-range stop without reinterpreting the legacy key. Unset, it follows ``stop_tolerance``, so an existing config keeps the threshold magnitude it had.
+
+  Default: unset (follows ``stop_tolerance``)
+
+  Example:
+
+    * ``de_tolfun = 1e-3``
+
+
 **de_strategy**
   Specifies how new parameter sets are chosen. The following options are available:
   

--- a/pybnf/algorithms/optimizers/differential_evolution.py
+++ b/pybnf/algorithms/optimizers/differential_evolution.py
@@ -15,7 +15,10 @@ from ...printing import print1, print2, PybnfError
 from ...registry import register_fit_type
 
 import logging
+from typing import Optional
+
 import numpy as np
+from pydantic import Field
 import re
 import copy
 
@@ -40,6 +43,16 @@ class DEFamilyConfig(PyBNFConfigModel):
     mutation_rate: float = 0.5
     mutation_factor: float = 0.5
     stop_tolerance: float = 0.002
+    # The DE-family convergence tolerance as an absolute range in OBJECTIVE units
+    # (#561, ADR-0114): the population is converged when the spread of its finite
+    # fitnesses, ``max - min``, has collapsed to within this value. ``stop_tolerance``
+    # was a *ratio* (``max/min``), which only reads as convergence on a positive
+    # objective bounded below by 0; ``de_tolfun`` measures the range directly, so it
+    # is well-defined for a likelihood objective too. It is a range in objective units
+    # where ``stop_tolerance`` was dimensionless, so it gets its own key -- and falls
+    # back to ``stop_tolerance`` when unset (mirroring ``cmaes_tolfun`` -> ``cmaes_stop_tol``,
+    # ADR-0106), so an existing config keeps the threshold magnitude it had.
+    de_tolfun: Optional[float] = Field(default=None, ge=0.0)
     de_strategy: str = 'rand1'
 
 
@@ -77,6 +90,13 @@ class DifferentialEvolutionBase(Algorithm):
         self.mutation_factor = config.config['mutation_factor']
         self.max_iterations = config.config['max_iterations']
         self.stop_tolerance = config.config['stop_tolerance']
+        # The convergence tolerance the run actually uses (#561, ADR-0114): an
+        # absolute range in objective units. Unset ``de_tolfun`` falls back to
+        # ``stop_tolerance`` -- the single knob the test used before -- so an existing
+        # config keeps its threshold magnitude, now read as a range rather than a ratio.
+        configured_tolfun = config.config['de_tolfun']
+        self.de_tolfun = (self.stop_tolerance if configured_tolfun is None
+                          else float(configured_tolfun))
 
         self.strategy = config.config['de_strategy']
         options = ('rand1', 'rand2', 'best1', 'best2', 'all1', 'all2')
@@ -127,6 +147,33 @@ class DifferentialEvolutionBase(Algorithm):
                 new_pset_vars.append(p)
 
         return PSet(new_pset_vars)
+
+    def _population_converged(self):
+        """The DE-family convergence test (#561, ADR-0114), shared by ``de`` and ``ade``.
+
+        The population is converged when the spread of its objective values --
+        measured as an **absolute range** ``max - min`` over the **finite** fitnesses
+        only -- has collapsed to within ``de_tolfun``.
+
+        This replaces the original **ratio** test ``max/min < 1 + stop_tolerance``,
+        which is a convergence statement only when the objective is positive and
+        bounded below by 0 (a chi-square, an SSE). On a likelihood objective -- a
+        negative log-likelihood, unbounded below -- an all-negative population lands
+        the ratio in ``(0, 1]`` and it fires at generation 0 regardless of the spread;
+        and any single ``inf``-scored failed simulation, paired with a negative
+        fitness, makes the ratio ``-inf`` and defeats *every* threshold. Both failure
+        modes are the negative sign, not a real convergence -- so the family was
+        unrunnable on any estimated-sigma likelihood fit.
+
+        The range form is sign-agnostic. Ignoring the non-finite entries is what makes
+        a failed simulation unable to either satisfy or defeat the test; it also
+        subsumes the original ``!= 0`` guard against dividing by an all-zero
+        population, which ``ade`` never had. An empty finite set (every member still
+        ``inf``, e.g. before the first result) is never "converged".
+        """
+        finite = np.asarray(self.fitnesses, dtype=float)
+        finite = finite[np.isfinite(finite)]
+        return bool(finite.size and (finite.max() - finite.min()) <= self.de_tolfun)
 
     def start_run(self):
         return NotImplementedError("start_run() not implemented in DifferentialEvolutionBase class")
@@ -399,8 +446,18 @@ class DifferentialEvolution(MultiStartOptimizer, DifferentialEvolutionBase):
                 logger.debug('Island %i completed %i iterations' % (island, self.iter_num[island]))
                 # print(sorted(self.fitnesses[island]))
 
-            # Convergence check
-            if (np.min(self.fitnesses) != 0) and (np.max(self.fitnesses) / np.min(self.fitnesses) < 1. + self.stop_tolerance):
+            # Convergence check: absolute range of the finite population (#561, ADR-0114).
+            # Only assessed once EVERY island has completed at least one iteration
+            # (``min(self.iter_num) >= 1``): until then some islands are still at their
+            # initial ``inf`` sentinel, and since the test (correctly) ignores non-finite
+            # fitnesses, a single finished island's collapsed subpopulation could
+            # otherwise stop the whole run before the others have searched at all. The
+            # old ratio test got this for free -- an unevaluated island's ``inf`` made the
+            # global ``max`` infinite -- but that same coupling is what let a failed sim
+            # defeat the test; the gate restores the "wait for the whole population" half
+            # without the sign/failed-sim half. (For a single island this holds from the
+            # first iteration on, so single-island DE is unaffected.)
+            if min(self.iter_num) >= 1 and self._population_converged():
                 return 'STOP'
 
             # Return a copy, so our internal data structure is not tampered with.
@@ -526,8 +583,8 @@ class AsynchronousDifferentialEvolution(MultiStartOptimizer, DifferentialEvoluti
                 logger.debug('Completed %i simulations' % self.sims_completed)
             if iters_complete >= self.max_iterations:
                 return 'STOP'
-            # Convergence check
-            if np.max(self.fitnesses) / np.min(self.fitnesses) < 1. + self.stop_tolerance:
+            # Convergence check: absolute range of the finite population (#561, ADR-0114).
+            if self._population_converged():
                 return 'STOP'
 
         if 'best' in self.strategy:

--- a/pybnf/parse.py
+++ b/pybnf/parse.py
@@ -75,7 +75,12 @@ numkeys_int = ['verbosity', 'parallel_count', 'delete_old_files', 'population_si
                'n_starts']
 numkeys_float = ['min_objective', 'cognitive', 'social', 'particle_weight',
                  'particle_weight_final', 'adaptive_n_max', 'adaptive_n_stop', 'adaptive_abs_tol', 'adaptive_rel_tol',
-                 'mutation_rate', 'mutation_factor', 'stop_tolerance', 'step_size', 'simplex_step', 'simplex_log_step',
+                 'mutation_rate', 'mutation_factor', 'stop_tolerance',
+                 # Differential Evolution (job_type = de / ade, #561/ADR-0114): the
+                 # convergence tolerance as an absolute range in objective units
+                 # (unset it follows stop_tolerance).
+                 'de_tolfun',
+                 'step_size', 'simplex_step', 'simplex_log_step',
                  'simplex_reflection', 'simplex_expansion', 'simplex_contraction', 'simplex_shrink', 'cooling',
                  'beta_max', 'bootstrap_max_obj', 'simplex_stop_tol', 'v_stop', 'gamma_prob', 'zeta', 'lambda',
                  'constraint_scale', 'neg_bin_r', 'stablizingCov',

--- a/tests/golden_configs/effective_config_golden.json
+++ b/tests/golden_configs/effective_config_golden.json
@@ -4333,6 +4333,10 @@
     "rand2"
    ],
    [
+    "de_tolfun",
+    null
+   ],
+   [
     "delete_old_files",
     1
    ],
@@ -6309,6 +6313,10 @@
     "rand1"
    ],
    [
+    "de_tolfun",
+    null
+   ],
+   [
     "delete_old_files",
     1
    ],
@@ -6652,6 +6660,10 @@
    [
     "de_strategy",
     "rand1"
+   ],
+   [
+    "de_tolfun",
+    null
    ],
    [
     "delete_old_files",
@@ -7051,6 +7063,10 @@
     "rand1"
    ],
    [
+    "de_tolfun",
+    null
+   ],
+   [
     "delete_old_files",
     1
    ],
@@ -7394,6 +7410,10 @@
    [
     "de_strategy",
     "rand1"
+   ],
+   [
+    "de_tolfun",
+    null
    ],
    [
     "delete_old_files",
@@ -8141,6 +8161,10 @@
     "rand1"
    ],
    [
+    "de_tolfun",
+    null
+   ],
+   [
     "delete_old_files",
     1
    ],
@@ -8484,6 +8508,10 @@
    [
     "de_strategy",
     "rand1"
+   ],
+   [
+    "de_tolfun",
+    null
    ],
    [
     "delete_old_files",
@@ -8831,6 +8859,10 @@
     "rand1"
    ],
    [
+    "de_tolfun",
+    null
+   ],
+   [
     "delete_old_files",
     1
    ],
@@ -9174,6 +9206,10 @@
    [
     "de_strategy",
     "rand1"
+   ],
+   [
+    "de_tolfun",
+    null
    ],
    [
     "delete_old_files",

--- a/tests/test_diff_evolution.py
+++ b/tests/test_diff_evolution.py
@@ -332,9 +332,10 @@ class TestDifferentialEvolutionPlumbing:
             assert recorded == [None, None, None]
 
     def test_convergence_stop(self, tmp_path):
-        """Oracle (convergence criterion): when max(fitness)/min(fitness) <
-        1 + stop_tolerance (and min != 0) the island reports 'STOP'. Equal
-        fitnesses give ratio exactly 1, below any positive tolerance."""
+        """Oracle (convergence criterion, #561/ADR-0114): when the absolute range of the
+        finite fitnesses, max - min, is <= de_tolfun (which follows stop_tolerance when
+        unset) the island reports 'STOP'. Equal fitnesses give range exactly 0, below any
+        non-negative tolerance."""
         de = algorithms.DifferentialEvolution(_de_config(tmp_path, islands=1, population_size=3,
                                                          stop_tolerance=0.002))
         assert self._run_one_island_generation(de, [5.0, 5.0, 5.0]) == 'STOP'
@@ -373,7 +374,7 @@ class TestDifferentialEvolutionPlumbing:
             nxt = []
             for i, ps in enumerate(current):
                 res = algorithms.Result(ps, self.d1s, ps.name)
-                res.score = 10.0 + i                  # distinct, nonzero: no convergence STOP
+                res.score = 10.0 + i                  # range 5 > de_tolfun: no convergence STOP
                 out = de.got_result(res)
                 if isinstance(out, list):
                     nxt += out
@@ -442,8 +443,9 @@ class TestAsyncDifferentialEvolution:
         assert out == 'STOP'
 
     def test_convergence_stop(self, tmp_path):
-        """Oracle (convergence criterion): at an iteration boundary, equal
-        fitnesses make max/min = 1 < 1 + stop_tolerance, so the run stops."""
+        """Oracle (convergence criterion, #561/ADR-0114): at an iteration boundary, equal
+        fitnesses make the finite range max - min = 0 <= de_tolfun (which follows
+        stop_tolerance when unset), so the run stops."""
         ade = algorithms.AsynchronousDifferentialEvolution(_ade_config(tmp_path, population_size=3,
                                                                        max_iterations=100,
                                                                        stop_tolerance=0.002))

--- a/tests/test_optimizer_integration.py
+++ b/tests/test_optimizer_integration.py
@@ -12,6 +12,7 @@ These are deliberately small (low dimension, modest budgets) so the suite stays
 fast enough to run on every change. The slow, tighter-tolerance recovery checks
 (e.g. the banana valley) are marked ``slow``.
 """
+import copy
 import json
 
 import numpy as np
@@ -19,6 +20,8 @@ import pytest
 
 from . import integration_harness as H
 from .context import algorithms, config, parse
+from pybnf.data import Data
+from pybnf.pset import Model
 
 
 # fit_type -> Algorithm subclass
@@ -1299,3 +1302,191 @@ def test_local_multistart_escapes_a_trap_a_single_run_falls_into(tmp_path, fit_t
     assert np.allclose(H.best_params(multi, 2), [6.0, 6.0], atol=0.3)                  # escaped off-center
     assert multi.trajectory.best_score() == pytest.approx(_TRAP_GLOBAL_NLL, abs=0.1)
     assert multi.trajectory.best_score() < single.trajectory.best_score() - 0.5
+
+
+# --------------------------------------------------------------------------- #
+# DE / ADE convergence is an absolute objective range over the finite
+# population, not a ratio (#561, ADR-0114)
+# --------------------------------------------------------------------------- #
+# The original DE-family test -- max(fit) / min(fit) < 1 + stop_tolerance -- reads as
+# convergence only on a positive objective bounded below by 0 (a chi-square, an SSE).
+# On a likelihood objective (a negative log-likelihood, unbounded below) it fires at
+# generation 0: an all-negative population lands the ratio in (0, 1], and a single
+# inf-scored failed simulation makes it -inf, below EVERY threshold -- so no value of
+# stop_tolerance disables it, and the whole Differential Evolution family was
+# unrunnable on any estimated-sigma likelihood fit. The test is now an absolute range
+# max - min over the FINITE fitnesses, carried by its own key de_tolfun (a range in
+# objective units, where stop_tolerance was a dimensionless ratio) that falls back to
+# stop_tolerance when unset.
+
+
+def _de_family_alg(tmp_path, fit_type, **overrides):
+    """A real ``de`` / ``ade`` algorithm over a (here unused) analytical target, so its
+    convergence helper can be exercised white-box on hand-set fitnesses."""
+    cls = {'de': algorithms.DifferentialEvolution,
+           'ade': algorithms.AsynchronousDifferentialEvolution}[fit_type]
+    tgt, exp = H.write_target(tmp_path, H.gaussian_spec([0.0, 0.0], [1.0, 1.0]))
+    conf = H.make_config(tmp_path, fit_type, tgt, exp, n_params=2,
+                         population_size=12, max_iterations=10, **overrides)
+    return cls(conf)
+
+
+def _set_fitnesses(alg, fit_type, fits):
+    """``de`` holds fitnesses nested per island; ``ade`` holds a flat list."""
+    alg.fitnesses = [list(fits)] if fit_type == 'de' else list(fits)
+
+
+@pytest.mark.parametrize('fit_type', ['de', 'ade'])
+def test_de_convergence_does_not_fire_on_an_all_negative_spread(tmp_path, fit_type):
+    """The #561 defect. A likelihood population spanning ~107 NLL units is NOT
+    converged, but under the ratio form its all-negative sign put max/min in (0, 1] --
+    below 1 + stop_tolerance for any non-negative tolerance -- so the run stopped at
+    generation 0. The absolute range does not fire: 106.5 is nowhere near the
+    tolerance."""
+    alg = _de_family_alg(tmp_path, fit_type, stop_tolerance=1e-6)
+    _set_fitnesses(alg, fit_type, [-59.5, -100.0, -166.0, -120.0])   # spread 106.5
+    # The ratio form fired on exactly this population...
+    assert np.max(alg.fitnesses) / np.min(alg.fitnesses) < 1.0 + alg.stop_tolerance
+    # ...the range form does not.
+    assert alg.de_tolfun == alg.stop_tolerance
+    assert alg._population_converged() is False
+
+
+@pytest.mark.parametrize('fit_type', ['de', 'ade'])
+def test_de_convergence_is_not_defeated_by_a_failed_simulation(tmp_path, fit_type):
+    """A failed simulation scores inf. Paired with any negative fitness the ratio
+    becomes inf / negative = -inf, below every threshold -- so even stop_tolerance =
+    -1e9 fired, and there was no value that disabled the test. The range form ignores
+    the non-finite entries: the failed point can neither satisfy nor defeat
+    convergence."""
+    alg = _de_family_alg(tmp_path, fit_type, stop_tolerance=1e-6)
+    _set_fitnesses(alg, fit_type, [-59.5, np.inf, -166.0, -120.0])
+    # Under the ratio form even a -1e9 threshold fired here: inf / min = -inf < 1 - 1e9.
+    assert np.max(alg.fitnesses) / np.min(alg.fitnesses) < 1.0 + (-1e9)
+    # The finite entries still span 106.5, so the range form does not fire.
+    assert alg._population_converged() is False
+
+
+@pytest.mark.parametrize('fit_type', ['de', 'ade'])
+def test_de_convergence_fires_when_the_finite_population_collapses(tmp_path, fit_type):
+    """The other half: this is not "never converge". A finite population collapsed to
+    within de_tolfun -- even a negative one -- is converged, and an inf-scored member is
+    simply ignored rather than blocking the stop."""
+    alg = _de_family_alg(tmp_path, fit_type, stop_tolerance=1e-3)
+    _set_fitnesses(alg, fit_type, [-59.5000, -59.4998, -59.4999, -59.5])   # spread 2e-4
+    assert alg._population_converged() is True
+    _set_fitnesses(alg, fit_type, [-59.5000, np.inf, -59.4999, -59.5])     # inf ignored
+    assert alg._population_converged() is True
+
+
+def test_de_tolfun_is_a_knob_of_its_own(tmp_path):
+    """de_tolfun is a range in objective units; stop_tolerance was a dimensionless
+    ratio. They are separated so a fit can set a meaningful objective-range stop without
+    reinterpreting the legacy key. Unset, de_tolfun follows stop_tolerance."""
+    alg = _de_family_alg(tmp_path, 'de', stop_tolerance=0.002, de_tolfun=5.0)
+    assert alg.stop_tolerance == 0.002 and alg.de_tolfun == 5.0
+    # A 3-unit spread: converged under the explicit 5.0 range.
+    alg.fitnesses = [[-100.0, -98.0, -97.0, -99.5]]
+    assert alg._population_converged() is True
+    # The fallback: unset de_tolfun IS stop_tolerance (here for ade too).
+    fallback = _de_family_alg(tmp_path, 'ade', stop_tolerance=0.002)
+    assert fallback.de_tolfun == 0.002
+
+
+def test_ade_convergence_survives_an_all_zero_population(tmp_path):
+    """ade never had de's ``!= 0`` guard, so an all-zero population computed
+    max/min = 0/0 = nan (a RuntimeWarning; nan < threshold is False, so it silently
+    never stopped -- yet on a real objective a whole population at exactly 0 IS
+    converged). The range form reports convergence with no division at all: under
+    ``errstate(all='raise')`` a stray 0/0 would raise instead."""
+    alg = _de_family_alg(tmp_path, 'ade', stop_tolerance=1e-6)
+    alg.fitnesses = [0.0, 0.0, 0.0]
+    with np.errstate(all='raise'):
+        assert alg._population_converged() is True
+
+
+def test_de_island_does_not_stop_the_run_before_other_islands_evaluate(tmp_path):
+    """Island-DE guard (#561, ADR-0114). Because the convergence test ignores non-finite
+    fitnesses, a single island that finishes its first iteration with a collapsed (here
+    identical, range-0) finite population must NOT stop the whole run while other islands
+    are still entirely unevaluated (all inf). The old ratio test got this for free -- an
+    unevaluated island's inf made the global max infinite -- but that same coupling is
+    what let a failed sim defeat the test; convergence is now assessed only once every
+    island has completed an iteration."""
+    tgt, exp = H.write_target(tmp_path, H.gaussian_spec([0.0, 0.0], [1.0, 1.0]))
+    conf = H.make_config(tmp_path, 'de', tgt, exp, n_params=2,
+                         population_size=20, max_iterations=20, islands=2,
+                         stop_tolerance=1e-3)
+    de = algorithms.DifferentialEvolution(conf)
+    start = de.start_run()                       # 20 psets: island 0 is [:10], island 1 [10:]
+    resp = None
+    for p in start[:10]:                         # complete island 0's first iteration...
+        res = algorithms.Result(p, ['# x\ty\n'], p.name)
+        res.score = 7.0                          # ...with an identical (range-0) population
+        resp = de.got_result(res)
+    assert de.iter_num == [1, 0]                 # island 0 done, island 1 still untouched
+    # Island 0's finite subpopulation is collapsed, but the run continues: it proposes
+    # island 0's next generation rather than stopping the whole (2-island) search.
+    assert resp != 'STOP' and len(resp) == 10
+
+
+class _ShiftedParaboloidModel(Model):
+    """Test-only model whose ``score`` column is ``0.5*sum((x-mu)^2) - shift``, so
+    ``direct_pass`` yields a NEGATIVE objective near the mode (``shift > 0``). The mode
+    is still ``mu`` (a well-posed fit); the objective just lives below 0 -- the regime
+    that made the ratio convergence test stop the DE family at generation 0 (#561)."""
+
+    def __init__(self, mu, shift, name='g', pset=None):
+        self.mu = np.asarray(mu, dtype=float)
+        self.shift = float(shift)
+        self.name = name
+        self.file_path = name
+        self.suffixes = ['target']
+        self.stochastic = False
+        self.has_observables = False
+        self.param_names = set()
+        self._pset = pset
+
+    def copy_with_param_set(self, pset):
+        m = copy.copy(self)
+        m._pset = pset
+        return m
+
+    def save(self, *args, **kwargs):
+        pass
+
+    def get_suffixes(self):
+        return self.suffixes
+
+    def execute(self, folder, filename, timeout):
+        x = np.array([self._pset['p%d' % (i + 1)] for i in range(len(self.mu))])
+        score = 0.5 * float(np.sum((x - self.mu) ** 2)) - self.shift
+        d = Data(arr=np.array([[0.0, score]]))
+        d.cols = {'index': 0, 'score': 1}
+        d.headers = {0: 'index', 1: 'score'}
+        return {'target': d}
+
+
+@pytest.mark.parametrize('fit_type', ['de', 'ade'])
+def test_de_family_advances_past_generation_zero_on_a_negative_objective(tmp_path, fit_type):
+    """End-to-end regression for #561: on an objective negative everywhere the
+    population lands, the DE family must keep searching, not stop inside generation 0.
+    Before the fix the all-negative gen-0 population satisfied the ratio test and the
+    run halted immediately -- the reported budget spent on 0 generations of search."""
+    tgt, exp = H.write_target(tmp_path, H.gaussian_spec([0.0, 0.0], [1.0, 1.0]))
+    conf = H.make_config(tmp_path, fit_type, tgt, exp, n_params=2,
+                         population_size=12, max_iterations=8,
+                         bounds=(-3.0, 3.0), stop_tolerance=1e-6)
+    conf.models['g'] = _ShiftedParaboloidModel([0.5, -0.5], shift=50.0)
+    alg = {'de': algorithms.DifferentialEvolution,
+           'ade': algorithms.AsynchronousDifferentialEvolution}[fit_type](conf)
+    H.drive(alg)
+
+    # The objective at the mode is -shift, so a working search drives well below 0 --
+    # the negative regime the ratio test could not handle.
+    assert alg.trajectory.best_score() < -1.0
+    # The generation counter advanced well past the generation-0 stop.
+    if fit_type == 'de':
+        assert max(alg.iter_num) >= 2
+    else:
+        assert alg.sims_completed >= 2 * alg.population_size


### PR DESCRIPTION
Fixes #561.

## The defect

`de` and `ade` tested convergence with a **ratio** of objectives,
`max(fit) / min(fit) < 1 + stop_tolerance`, which reads as convergence only on a
positive objective bounded below by 0 (a χ², an SSE). On a likelihood objective — a
negative log-likelihood, unbounded below — it fired at generation 0:

1. **All fitnesses negative.** `max/min` lands in `(0, 1]` (e.g. `-59.5 / -166.0 = 0.358`),
   below `1 + stop_tolerance` for any non-negative tolerance — a population spanning 107
   NLL units called converged.
2. **Any failed simulation with a negative fitness present.** A failed point scores `inf`,
   so `max/min = inf / (negative) = -inf`, below *every* threshold — so even
   `stop_tolerance = -1e9` still fired, and there was no configuration that disabled the
   test.

That is every estimated-σ likelihood problem — the whole Grein et al. 2026 benchmark
subset-I corpus (23/23 slugs) — so both members of the Differential Evolution family were
unrunnable there. This is the DE sibling of #550 / ADR-0106, which fixed exactly this
reasoning for CMA-ES.

## The fix (mirrors ADR-0106)

The convergence test is now an **absolute range in objective units**,
`max - min <= de_tolfun`, assessed over the **finite** fitnesses only:

- **Sign-agnostic.** An all-negative population spanning 107 NLL units has a range of 107,
  nowhere near any tolerance, so it does not fire.
- **Failed sims ignored.** A single `inf` can neither satisfy nor defeat the test. This
  also subsumes the `!= 0` guard `ade` never had — an all-zero population now reports
  converged (range 0) with no `0/0` division.
- **Its own key, `de_tolfun`.** A range in objective units, where `stop_tolerance` was a
  dimensionless ratio; the two cannot share one well-set value. Unset, `de_tolfun` falls
  back to `stop_tolerance`, so an existing config keeps its threshold magnitude.
- **Shared helper.** The check lives in one `DifferentialEvolutionBase` method, so `de`
  and `ade` cannot drift apart again (the missing `ade` guard was such a drift).
- **Island guard.** Ignoring `inf` removes the coupling the old ratio relied on (an
  unevaluated island's `inf` made the global `max` infinite). To keep a single finished
  island from stopping the whole multi-island run before the others have searched, the
  `de` call site assesses convergence only once every island has completed an iteration
  (`min(iter_num) >= 1`). Single-island DE and `ade` are unaffected.

## Tests

- White-box decision-point tests for both optimizers: an all-negative spread and an
  `inf`-defeated threshold are **not** converged; a collapsed finite population **is**;
  `de_tolfun` is its own knob falling back to `stop_tolerance`; the all-zero `ade`
  population no longer divides (asserted under `errstate(all='raise')`); the island guard
  holds one finished island open while another is unevaluated.
- End-to-end guard: both `de` and `ade` advance past generation 0 on an objective that is
  negative everywhere the population lands (a shifted paraboloid). Confirmed the pre-fix
  ratio stopped this exact config at generation 0.
- Golden effective-config corpus regenerated (the one new key across the nine DE-family
  fits); schema/parse consistency test covers `de_tolfun`.

Full suite green for the optimizer-integration, DE, config-golden, config-schema, parse,
config-class, new-era, and benchmark-harness test files.

## Docs

New ADR-0114 (the DE sibling of ADR-0106); `config_keys.rst` (`stop_tolerance` rewritten
as an absolute range + new `de_tolfun`); `algorithms.rst` (DE convergence narrative);
CHANGELOG.