### PR TITLE
feat(algorithms): checkpoint the information criteria beside the parameter sets, so a run is scoreable before it ends (#560)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ All notable changes to PyBNF are documented below. This project adheres to
 ## [Unreleased]
 
 ### Added
+- **The information criteria are checkpointed alongside the parameter sets, so a run is
+  scoreable before it ends (#560).** `sorted_params_backup.txt` has been written throughout a
+  run since forever; `information_criteria.txt` was written **only** on the terminal path. Every
+  downstream consumer of a fit's result needs both, so a run was un-scoreable at every moment
+  except its last — even though the best parameter vector had been on disk the whole time and the
+  number was fully determined long before the process exited. That gap is not cosmetic:
+  `log_likelihood` in `information_criteria.txt` is the only place PyBNF reports the **full
+  normalized** log-likelihood (every dropped per-point constant restored), while the minimized
+  `Obj` column of the parameter table is the *reduced* objective, so an absolute AIC/BIC — or any
+  benchmark score built on one — could not be computed from the checkpoint alone.
+  Each checkpoint now also writes `Results/information_criteria_backup.txt` (and
+  `information_criteria_refine_backup.txt` during a refine, mirroring the parameter file beside
+  it). Same format as the final artifact, differing only in `#` comments that mark it a snapshot
+  and name the parameter set it describes, so one parser reads either file. The final
+  `information_criteria.txt` is unchanged, in name, content, and meaning.
+  Cost is one extra simulation per checkpoint, and only when the checkpoint has something new to
+  say. Nothing is spent while the best fit is unchanged — the file on disk already describes it,
+  which is exactly the long converged tail that motivated the issue: a `gntr` fit of
+  `Brannmark_JBC2010` (100 starts × 1000 iterations) reached its final objective with ~40 minutes
+  left, all of it spent waiting for a file rather than for an answer. Nothing is spent at all
+  unless the objective is a proper likelihood, since no information criterion is defined for
+  `sos` / `sod` / `norm_sos` / `kl` / `wasserstein` / `direct_pass`. Otherwise it is one
+  simulation per `backup_every * population_size * smoothing` returns — 1 in 1000 at the common
+  `backup_every = 10, population_size = 100`. The new key **`backup_information_criteria`**
+  (default 1) turns it off for a model where even that is too expensive.
+  A killed or crashed long run is worth what it should be, too: the parameters survived it
+  already, and now the score does.
 - **`sbml_atol` takes `auto` and `tracking`, so a model whose own scale asks for a *looser*
   absolute tolerance can have one (#557, ADR-0114).** ADR-0103's derivation is allowed only to
   tighten. That is a no-regression rule and it is why the derivation could be applied to every model

--- a/docs/config_keys.rst
+++ b/docs/config_keys.rst
@@ -972,6 +972,28 @@ Output Options
 
     * ``backup_every = 10``
 
+**backup_information_criteria**
+  If 1, each checkpoint also writes ``Results/information_criteria_backup.txt`` — the AIC/BIC/AICc
+  and full normalized log-likelihood of the best fit so far — alongside
+  ``Results/sorted_params_backup.txt``. Both halves of a scoreable result are then on disk
+  throughout the run, so a fit that is still going, or that was killed or crashed, can be scored
+  from its own artifacts; without it, ``Results/information_criteria.txt`` appears only when the
+  run terminates normally. The checkpoint file has the same format as the final one, with extra
+  ``#`` comment lines marking it as a snapshot of a run in progress; the final artifact is
+  unchanged.
+
+  Cost is one extra simulation per checkpoint, and only when the checkpoint has something new to
+  report: nothing is spent while the best fit is unchanged (the file already describes it), and
+  nothing is spent at all unless the objective is a proper likelihood, since no information
+  criterion is defined otherwise. The cadence is ``backup_every``. Set this to 0 for a model
+  where even that is too expensive.
+
+  Default: 1
+
+  Example:
+
+    * ``backup_information_criteria = 0``
+
 **save_best_data**
   If 1, run an extra simulation at the end of fitting using the best-fit parameters, and save the best-fit .gdat and .scan files to the Results directory. 
   

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -57,7 +57,7 @@ PyBNF enforces a maximum run time for simulations, with a default value of 1 hou
 
 A time limit is also enforced for network generation in BNGL models. The default value is 1 hour, and this can be modified with the ``wall_time_gen`` key.
 
-Both of these bound one *unit of work*, not the fit. To bound the fit as a whole -- for a fixed compute allocation, or so a run that is not converging still leaves usable results -- set ``wall_time_fit`` (seconds). When it expires PyBNF stops launching work and writes its normal end-of-fit results for the best parameter set found so far, plus a ``Results/stop_reason.txt`` saying why it stopped. Killing the process externally instead leaves no such results.
+Both of these bound one *unit of work*, not the fit. To bound the fit as a whole -- for a fixed compute allocation, or so a run that is not converging still leaves usable results -- set ``wall_time_fit`` (seconds). When it expires PyBNF stops launching work and writes its normal end-of-fit results for the best parameter set found so far, plus a ``Results/stop_reason.txt`` saying why it stopped. Killing the process externally writes none of that end-of-fit output; what survives is the run's periodic checkpoint -- ``Results/sorted_params_backup.txt`` and, for a likelihood objective, ``Results/information_criteria_backup.txt`` (see ``backup_information_criteria``) -- which is enough to score the best fit reached, but is a snapshot rather than the run's stated result.
 
 Which methods did my run actually execute?
 ------------------------------------------

--- a/pybnf/algorithms/base.py
+++ b/pybnf/algorithms/base.py
@@ -135,6 +135,14 @@ class Algorithm(ABC):
     #: the run loop's own tail -- always read a well-defined empty map.
     _profiled_noise = {}
 
+    #: Name of the parameter set ``Results/information_criteria_backup.txt`` currently
+    #: describes (#560), or None while no checkpoint has been written. The checkpoint costs
+    #: one re-simulation, so it is skipped while this still names the best fit -- the file on
+    #: disk already describes it. A **class** attribute for the same reason ``_profiled_noise``
+    #: is: an algorithm unpickled from a backup written before this existed reads a
+    #: well-defined None and simply writes its first checkpoint.
+    _ic_checkpoint_name = None
+
     def __init__(self, config):
         """
         Instantiates an Algorithm with a Configuration object.  Also initializes a
@@ -252,6 +260,10 @@ class Algorithm(ABC):
         self.trajectory = Trajectory(self.config.config['num_to_output'])
         self.job_id_counter = 0
         self.output_counter = 0
+        # The next run writes its own Results directory, so nothing there describes a
+        # best fit yet -- and PSet names restart from iter0run0, so a name carried over
+        # from the previous run would suppress the first checkpoint (#560).
+        self._ic_checkpoint_name = None
         self.job_group_dir = dict()
         self.fail_count = 0
         self.success_count = 0
@@ -1087,6 +1099,13 @@ class Algorithm(ABC):
                 print0('Too many open files! See "Troubleshooting" in the documentation for how to deal with this '
                        'problem.')
 
+        # Then the other half of a scoreable result: the absolute log-likelihood behind the
+        # information criteria, which lives in no parameter table (#560). LAST, because it is
+        # the only part of a checkpoint that can take a while -- it re-simulates the best fit
+        # -- and a kill during it must not leave the resume state a whole interval behind the
+        # parameter sets it belongs with.
+        self._checkpoint_information_criteria()
+
     def get_backup_every(self):
         """
         Returns a number telling after how many individual simulation returns should we back up the algorithm.
@@ -1591,7 +1610,73 @@ class Algorithm(ABC):
             logger.exception('Failed to compute information criteria for the best fit')
             return None
 
-    def _emit_information_criteria(self, ic):
+    def _checkpoint_information_criteria(self):
+        """Write ``Results/information_criteria_backup.txt`` for the best fit so far -- the
+        information-criteria half of the run's checkpoint (#560).
+
+        ``sorted_params_backup.txt`` has been checkpointed since forever, but the information
+        criteria were written only on the terminal path, so the two halves of a scoreable
+        result had entirely different lifetimes: a run was un-scoreable at every moment
+        except its last, even though the best parameter vector had been on disk the whole
+        time. That matters because ``log_likelihood`` here is the only place PyBNF reports
+        the FULL normalized log-likelihood -- the minimized ``Obj`` column of the parameter
+        table is the *reduced* objective -- so an absolute AIC/BIC, or any benchmark score
+        built on one, cannot be computed from the parameter checkpoint alone. A killed,
+        crashed, or simply not-yet-finished run now carries both halves.
+
+        Cheap by construction, and free unless it has something new to say:
+
+        * a no-op unless the objective is a proper likelihood (the gate in
+          :meth:`_compute_information_criteria`), so nothing is spent on the ``sos`` /
+          ``sod`` / ``norm_sos`` / ``kl`` / ``wasserstein`` / ``direct_pass`` fits for which
+          no information criterion is defined;
+        * a no-op while the best fit is unchanged -- the file on disk already describes it.
+          That is exactly the long converged tail of a search, where the reported number has
+          stopped moving and only stragglers are still running;
+        * otherwise one extra simulation per checkpoint, i.e. one per ``backup_every *
+          population_size * smoothing`` simulation returns. ``backup_information_criteria =
+          0`` turns it off for a model where even that is too expensive.
+
+        Failures are logged and swallowed by the two helpers this calls: a diagnostics file
+        must never abort a run, and a *periodic* one must not start aborting one mid-flight
+        either.
+        """
+        if not self.config.config['backup_information_criteria']:
+            return
+        if len(self.trajectory) == 0:
+            return
+        best_name = self.trajectory.best_fit_name()
+        if best_name == self._ic_checkpoint_name:
+            logger.debug('Best fit is unchanged since the last information-criteria checkpoint; '
+                         'not re-simulating it')
+            return
+        # _compute_information_criteria captures the profiled noise scales at whatever point
+        # it scores, and profiled_noise.txt reports the run's FINAL best fit, so a checkpoint
+        # must not leave a mid-run value behind for the end-of-run tail to report if its own
+        # scoring pass fails.
+        saved_profiled_noise = self._profiled_noise
+        try:
+            ic = self._compute_information_criteria(self.trajectory.best_fit())
+        finally:
+            self._profiled_noise = saved_profiled_noise
+        if ic is None:
+            return
+        # Mirrors sorted_params_backup.txt / sorted_params_refine_backup.txt, so both halves
+        # of one phase's checkpoint carry the same name, and the final artifact keeps its
+        # exact current meaning.
+        name = 'refine_backup' if self.refine else 'backup'
+        wrote = self._emit_information_criteria(
+            ic, name=name,
+            preamble=['# CHECKPOINT of a run still in progress: the best fit SO FAR, not the',
+                      "#   run's result. That is information_criteria.txt, written at the end.",
+                      '# Parameter set: %s -- its row in sorted_params_%s.txt.' % (best_name, name)])
+        if wrote:
+            # Only a written file licenses skipping the next recompute; a transient I/O
+            # failure must not leave the checkpoint permanently stale on a run whose best
+            # fit never changes again.
+            self._ic_checkpoint_name = best_name
+
+    def _emit_information_criteria(self, ic, name='', preamble=()):
         """Write ``Results/information_criteria.txt`` (and a console line) for a fit.
 
         ``ic`` is the :class:`~pybnf.objective.InformationCriteria` from
@@ -1599,11 +1684,20 @@ class Algorithm(ABC):
         objective, or no best fit -- in which case nothing is written. AIC/BIC/AICc
         rank this fit against competing models (lower is better); this is the
         first-class form of the AIC lesson 45 (model selection) computes by hand.
+
+        :param name: File suffix. ``''`` (the default) writes the run's result,
+            ``information_criteria.txt``; anything else writes
+            ``information_criteria_<name>.txt`` -- today the periodic checkpoint
+            (:meth:`_checkpoint_information_criteria`, #560). A checkpoint differs from
+            the result only in its ``#`` comments and in staying off the console, so one
+            parser reads either file.
+        :param preamble: Extra ``#`` comment lines placed above the standard header.
+        :return: True if a file was written.
         """
         if ic is None:
-            return
+            return False
         aicc_str = ('%.10g' % ic.aicc) if ic.aicc is not None else 'n/a (n <= k+1)'
-        lines = [
+        lines = list(preamble) + [
             '# Information criteria for the best-fit parameter set (lower is better).',
             '# Valid for a likelihood objective only (normal / lognormal / lnnormal / laplace /',
             '#   neg_bin / student_t). Computed from the full normalized log-likelihood',
@@ -1619,17 +1713,22 @@ class Algorithm(ABC):
             'BIC\t%.10g' % ic.bic,
             'AICc\t%s' % aicc_str,
         ]
-        path = str(Path(self.res_dir) / 'information_criteria.txt')
+        filename = 'information_criteria.txt' if name == '' else 'information_criteria_%s.txt' % name
+        path = str(Path(self.res_dir) / filename)
         try:
             with open(path, 'w') as f:
                 f.write('\n'.join(lines) + '\n')
         except Exception:
-            logger.exception('Failed to write information_criteria.txt')
-            return
+            logger.exception('Failed to write %s' % filename)
+            return False
         logger.info('Wrote information criteria %s' % path)
-        print1('Information criteria (best fit): AIC=%.6g  BIC=%.6g  AICc=%s  '
-               '(k=%d, n=%d, lnL=%.6g)'
-               % (ic.aic, ic.bic, aicc_str, ic.k, ic.n, ic.log_likelihood))
+        if name == '':
+            # The checkpoint says the same thing about a run still in progress, on a
+            # cadence; like the parameter-set checkpoint beside it, it stays in the log.
+            print1('Information criteria (best fit): AIC=%.6g  BIC=%.6g  AICc=%s  '
+                   '(k=%d, n=%d, lnL=%.6g)'
+                   % (ic.aic, ic.bic, aicc_str, ic.k, ic.n, ic.log_likelihood))
+        return True
 
     def _emit_profiled_noise(self):
         """Write ``Results/profiled_noise.txt`` for a fit that profiles a noise scale out of

--- a/pybnf/config_schema.py
+++ b/pybnf/config_schema.py
@@ -202,6 +202,13 @@ class GlobalConfig(PyBNFConfigModel):
     bng_command: str = Field(default_factory=_default_bng_command)
     smoothing: int = 1
     backup_every: int = 1
+    # Also checkpoint the best fit's information criteria (#560): every backup that finds a
+    # new best fit re-simulates it once and writes Results/information_criteria_backup.txt,
+    # so a run that has not terminated -- or was killed -- is scoreable from its own
+    # artifacts, rather than only after the terminal path writes information_criteria.txt.
+    # Already a no-op for an objective that is not a proper likelihood. 0 = off, for a model
+    # where one extra simulation per backup interval is too expensive.
+    backup_information_criteria: int = 1
     time_course: Any = ()
     param_scan: Any = ()
     min_objective: float = float('-inf')

--- a/pybnf/parse.py
+++ b/pybnf/parse.py
@@ -36,7 +36,8 @@ numkeys_int = ['verbosity', 'parallel_count', 'delete_old_files', 'population_si
                'hist_bins', 'refine', 'simplex_max_iterations', 'wall_time_sim', 'wall_time_gen',
                # The fit's total wall-clock budget in seconds (#529): 0 = unbounded.
                'wall_time_fit', 'verbosity',
-               'exchange_every', 'backup_every', 'bootstrap', 'crossover_number', 'ind_var_rounding',
+               'exchange_every', 'backup_every', 'backup_information_criteria',
+               'bootstrap', 'crossover_number', 'ind_var_rounding',
                # Profile every estimated free-parameter noise scale out analytically instead
                # of searching it (#562, ADR-0108): 0 = off.
                'noise_profiling',

--- a/tests/golden_configs/effective_config_golden.json
+++ b/tests/golden_configs/effective_config_golden.json
@@ -11,6 +11,10 @@
     1
    ],
    [
+    "backup_information_criteria",
+    1
+   ],
+   [
     "banana.target",
     [
      "target.exp"
@@ -430,6 +434,10 @@
    ],
    [
     "backup_every",
+    1
+   ],
+   [
+    "backup_information_criteria",
     1
    ],
    [
@@ -887,6 +895,10 @@
     1
    ],
    [
+    "backup_information_criteria",
+    1
+   ],
+   [
     "banana.target",
     [
      "target.exp"
@@ -1330,6 +1342,10 @@
    ],
    [
     "backup_every",
+    1
+   ],
+   [
+    "backup_information_criteria",
     1
    ],
    [
@@ -1864,6 +1880,10 @@
    ],
    [
     "backup_every",
+    1
+   ],
+   [
+    "backup_information_criteria",
     1
    ],
    [
@@ -2433,6 +2453,10 @@
     1
    ],
    [
+    "backup_information_criteria",
+    1
+   ],
+   [
     "beta",
     [
      1.0
@@ -2991,6 +3015,10 @@
     1
    ],
    [
+    "backup_information_criteria",
+    1
+   ],
+   [
     "beta",
     [
      1.0
@@ -3410,6 +3438,10 @@
    ],
    [
     "backup_every",
+    1
+   ],
+   [
+    "backup_information_criteria",
     1
    ],
    [
@@ -3867,6 +3899,10 @@
     1
    ],
    [
+    "backup_information_criteria",
+    1
+   ],
+   [
     "beta",
     [
      1.0
@@ -4309,6 +4345,10 @@
     1
    ],
    [
+    "backup_information_criteria",
+    1
+   ],
+   [
     "bngl_backend",
     "auto"
    ],
@@ -4647,6 +4687,10 @@
    ],
    [
     "backup_every",
+    1
+   ],
+   [
+    "backup_information_criteria",
     1
    ],
    [
@@ -5042,6 +5086,10 @@
     1
    ],
    [
+    "backup_information_criteria",
+    1
+   ],
+   [
     "bngl_backend",
     "auto"
    ],
@@ -5316,6 +5364,10 @@
   [
    [
     "backup_every",
+    1
+   ],
+   [
+    "backup_information_criteria",
     1
    ],
    [
@@ -5607,6 +5659,10 @@
   [
    [
     "backup_every",
+    1
+   ],
+   [
+    "backup_information_criteria",
     1
    ],
    [
@@ -5948,6 +6004,10 @@
     1
    ],
    [
+    "backup_information_criteria",
+    1
+   ],
+   [
     "bngl_backend",
     "auto"
    ],
@@ -6286,6 +6346,10 @@
   [
    [
     "backup_every",
+    1
+   ],
+   [
+    "backup_information_criteria",
     1
    ],
    [
@@ -6635,6 +6699,10 @@
   [
    [
     "backup_every",
+    1
+   ],
+   [
+    "backup_information_criteria",
     1
    ],
    [
@@ -7008,6 +7076,10 @@
   [
    [
     "backup_every",
+    1
+   ],
+   [
+    "backup_information_criteria",
     1
    ],
    [
@@ -7388,6 +7460,10 @@
     1
    ],
    [
+    "backup_information_criteria",
+    1
+   ],
+   [
     "bngl_backend",
     "auto"
    ],
@@ -7750,6 +7826,10 @@
    ],
    [
     "backup_every",
+    1
+   ],
+   [
+    "backup_information_criteria",
     1
    ],
    [
@@ -8137,6 +8217,10 @@
     1
    ],
    [
+    "backup_information_criteria",
+    1
+   ],
+   [
     "bngl_backend",
     "auto"
    ],
@@ -8483,6 +8567,10 @@
   [
    [
     "backup_every",
+    1
+   ],
+   [
+    "backup_information_criteria",
     1
    ],
    [
@@ -8835,6 +8923,10 @@
     1
    ],
    [
+    "backup_information_criteria",
+    1
+   ],
+   [
     "bngl_backend",
     "auto"
    ],
@@ -9181,6 +9273,10 @@
   [
    [
     "backup_every",
+    1
+   ],
+   [
+    "backup_information_criteria",
     1
    ],
    [
@@ -9533,6 +9629,10 @@
     1
    ],
    [
+    "backup_information_criteria",
+    1
+   ],
+   [
     "bngl_backend",
     "auto"
    ],
@@ -9856,6 +9956,10 @@
   [
    [
     "backup_every",
+    1
+   ],
+   [
+    "backup_information_criteria",
     1
    ],
    [
@@ -10207,6 +10311,10 @@
     1
    ],
    [
+    "backup_information_criteria",
+    1
+   ],
+   [
     "bngl_backend",
     "auto"
    ],
@@ -10541,6 +10649,10 @@
    ],
    [
     "backup_every",
+    1
+   ],
+   [
+    "backup_information_criteria",
     1
    ],
    [
@@ -10930,6 +11042,10 @@
     1
    ],
    [
+    "backup_information_criteria",
+    1
+   ],
+   [
     "beta",
     [
      0.5,
@@ -11306,6 +11422,10 @@
     1
    ],
    [
+    "backup_information_criteria",
+    1
+   ],
+   [
     "beta",
     [
      1.0
@@ -11634,6 +11754,10 @@
   [
    [
     "backup_every",
+    1
+   ],
+   [
+    "backup_information_criteria",
     1
    ],
    [
@@ -11975,6 +12099,10 @@
     1
    ],
    [
+    "backup_information_criteria",
+    1
+   ],
+   [
     "bngl_backend",
     "auto"
    ],
@@ -12313,6 +12441,10 @@
   [
    [
     "backup_every",
+    1
+   ],
+   [
+    "backup_information_criteria",
     1
    ],
    [

--- a/tests/test_benchmark_harness.py
+++ b/tests/test_benchmark_harness.py
@@ -85,6 +85,11 @@ _EXCLUDE = frozenset({
     # refused for the sampler fit_types this oracle covers -- so it says nothing about the
     # synthesized configs this test compares. Excluded alongside its sibling noise_location.
     'noise_profiling',
+    # Post-freeze checkpoint key (#560): also write the information criteria beside the
+    # parameter sets at each backup. On by default, but a no-op for every benchmark here --
+    # each .target names direct_pass or ave_norm_sos, and no information criterion is defined
+    # for an objective that is not a proper likelihood, so nothing is computed or written.
+    'backup_information_criteria',
 })
 
 

--- a/tests/test_run_loop.py
+++ b/tests/test_run_loop.py
@@ -36,7 +36,7 @@ import pickle
 import numpy as np
 import pytest
 
-from .context import algorithms, budget as budget_mod, pset, printing
+from .context import algorithms, budget as budget_mod, objective, pset, printing
 from pybnf.pset import Trajectory, FailedSimulationError
 
 
@@ -906,7 +906,15 @@ class _PicklableCfg:
         self.variables = variables
 
 
-def _bare_backup_algo(tmp_path, *, refine=False, delete_old_files=0):
+class _PicklableObjective:
+    """Objective stand-in for the backup tests. ``supports_pointwise_log_likelihood``
+    is the gate the information-criteria path reads (#560); False here, so a bare
+    backup neither re-simulates nor writes a criteria checkpoint unless a test opts in."""
+
+    supports_pointwise_log_likelihood = False
+
+
+def _bare_backup_algo(tmp_path, *, refine=False, delete_old_files=0, backup_ic=1):
     """Minimal *picklable* Algorithm carrying what backup()/output_results read.
 
     The trajectory is deliberately excluded from the pickle (Algorithm.should_pickle)
@@ -919,11 +927,13 @@ def _bare_backup_algo(tmp_path, *, refine=False, delete_old_files=0):
     variables = [pset.FreeParameter('v1__FREE', 'uniform_var', 0, 100)]
     algo = object.__new__(_ConcreteAlgorithm)
     algo.config = _PicklableCfg(
-        {'output_dir': out, 'delete_old_files': delete_old_files, 'num_to_output': 100},
+        {'output_dir': out, 'delete_old_files': delete_old_files, 'num_to_output': 100,
+         'backup_information_criteria': backup_ic},
         variables)
     algo.res_dir = res_dir
     algo.refine = refine
     algo.output_counter = 0
+    algo.objective = _PicklableObjective()
     algo.trajectory = Trajectory(100)
     algo.trajectory.add(_pset('iter0run0', 5.0), 5.0, 'iter0run0')
     return algo
@@ -951,6 +961,201 @@ class TestBackup:
         assert isinstance(loaded_algo, algorithms.Algorithm)
         np.testing.assert_allclose(loaded_algo.trajectory.best_score(), 5.0)
         assert [p.name for p in loaded_pending] == ['pending0', 'pending1']
+
+
+# --------------------------------------------------------------------------- #
+# The information-criteria half of the checkpoint (#560)
+#
+# sorted_params_backup.txt has always been checkpointed; information_criteria.txt
+# was written only on the terminal path, so a run was un-scoreable at every moment
+# except its last. These cover the second half now written beside it: that it is
+# written, what it says, and the several ways it costs nothing.
+# --------------------------------------------------------------------------- #
+def _ic(log_likelihood=-12.5):
+    return objective.information_criteria(log_likelihood, k=2, n=10)
+
+
+def _kv(text):
+    """The key/value lines of an information-criteria file (comments dropped) — the
+    part a consumer parses, and the part a checkpoint shares with the final file."""
+    return dict(line.split('\t', 1) for line in text.splitlines() if not line.startswith('#'))
+
+
+class _CountingCompute:
+    """Stands in for _compute_information_criteria, counting the re-simulations the
+    checkpoint asks for and recording which pset each one scored."""
+
+    def __init__(self, ic=None):
+        self.ic = _ic() if ic is None else ic
+        self.scored = []
+
+    def __call__(self, best_pset):
+        self.scored.append(best_pset.name)
+        return self.ic
+
+
+class _WatchingCompute:
+    """Records which halves of the checkpoint are already on disk when the re-simulation is
+    asked for. Module-level (not a closure) because backup() pickles the algorithm it is
+    attached to."""
+
+    def __init__(self, out_dir):
+        self.out_dir = out_dir
+        self.on_disk = []
+
+    def __call__(self, best_pset):
+        self.on_disk.extend(p for p in ('alg_backup.bp', 'Results/sorted_params_backup.txt')
+                            if os.path.isfile(self.out_dir + '/' + p))
+        return _ic()
+
+
+class TestInformationCriteriaCheckpoint:
+
+    def test_backup_writes_the_criteria_beside_the_parameter_sets(self, tmp_path, monkeypatch):
+        """The point of #560: both halves of a scoreable result are on disk during the
+        run. The checkpoint carries the same key/value lines as the final artifact — one
+        parser reads either — and its comments say which parameter set it describes and
+        that the run is not over."""
+        algo = _bare_backup_algo(tmp_path)
+        monkeypatch.setattr(algo, '_compute_information_criteria', _CountingCompute())
+
+        algo.backup()
+
+        text = open(algo.res_dir + '/information_criteria_backup.txt').read()
+        assert 'CHECKPOINT' in text
+        assert 'iter0run0' in text and 'sorted_params_backup.txt' in text
+        # The run's own artifact is untouched: it still means "this run's result".
+        assert not os.path.exists(algo.res_dir + '/information_criteria.txt')
+        # Written now, it differs from the checkpoint only in comments.
+        algo._emit_information_criteria(_ic())
+        assert _kv(text) == _kv(open(algo.res_dir + '/information_criteria.txt').read())
+        assert _kv(text)['log_likelihood'] == '-12.5'
+
+    def test_a_checkpoint_reports_to_the_log_not_the_console(self, tmp_path, monkeypatch, capsys):
+        """A checkpoint fires on a cadence, so — like the parameter-set checkpoint beside
+        it — it reports to the log, not to the console. Only the end-of-run file prints."""
+        monkeypatch.setattr(printing, 'verbosity', 1)
+        algo = _bare_backup_algo(tmp_path)
+        monkeypatch.setattr(algo, '_compute_information_criteria', _CountingCompute())
+
+        algo.backup()
+        assert 'Information criteria' not in capsys.readouterr().out
+
+        algo._emit_information_criteria(_ic())
+        assert 'Information criteria (best fit)' in capsys.readouterr().out
+
+    def test_an_unchanged_best_fit_is_not_re_simulated(self, tmp_path, monkeypatch):
+        """The whole cost of this feature is one simulation per checkpoint, and it is
+        only paid when there is something new to say. A search's long converged tail —
+        the 40 minutes of stragglers that motivated #560 — re-simulates nothing: the file
+        on disk already describes the best fit."""
+        algo = _bare_backup_algo(tmp_path)
+        compute = _CountingCompute()
+        monkeypatch.setattr(algo, '_compute_information_criteria', compute)
+
+        algo.backup()
+        algo.backup()
+        algo.backup()
+        assert compute.scored == ['iter0run0']
+
+        algo.trajectory.add(_pset('iter9run3', 1.0), 1.0, 'iter9run3')
+        algo.backup()
+        assert compute.scored == ['iter0run0', 'iter9run3']
+        assert 'iter9run3' in open(algo.res_dir + '/information_criteria_backup.txt').read()
+
+    def test_a_failed_write_is_retried_at_the_next_checkpoint(self, tmp_path):
+        """Only a file that was actually written licenses skipping the next recompute.
+        Otherwise one transient I/O error would leave a run whose best fit never changes
+        again with no criteria checkpoint at all — the exact failure #560 removes."""
+        algo = _bare_backup_algo(tmp_path)
+        compute = _CountingCompute()
+        algo._compute_information_criteria = compute
+        algo._emit_information_criteria = lambda *a, **k: False
+
+        algo._checkpoint_information_criteria()
+        algo._checkpoint_information_criteria()
+        assert compute.scored == ['iter0run0', 'iter0run0']
+
+    def test_a_non_likelihood_objective_costs_nothing(self, tmp_path):
+        """No information criterion is defined for sos / kl / direct_pass, so the gate in
+        _compute_information_criteria makes the checkpoint a no-op — no re-simulation, no
+        file, on the objectives where there would be nothing to write."""
+        algo = _bare_backup_algo(tmp_path)   # objective.supports_pointwise_log_likelihood False
+
+        algo.backup()
+
+        assert not os.path.exists(algo.res_dir + '/information_criteria_backup.txt')
+        assert os.path.isfile(algo.res_dir + '/sorted_params_backup.txt')
+
+    def test_backup_information_criteria_0_turns_it_off(self, tmp_path, monkeypatch):
+        """The escape hatch for a model where one extra simulation per backup interval is
+        too expensive. Everything else about the checkpoint is unchanged."""
+        algo = _bare_backup_algo(tmp_path, backup_ic=0)
+        compute = _CountingCompute()
+        monkeypatch.setattr(algo, '_compute_information_criteria', compute)
+
+        algo.backup()
+
+        assert compute.scored == []
+        assert not os.path.exists(algo.res_dir + '/information_criteria_backup.txt')
+        assert os.path.isfile(algo.res_dir + '/sorted_params_backup.txt')
+
+    def test_a_refine_checkpoints_under_its_own_name(self, tmp_path, monkeypatch):
+        """A refine's parameter checkpoint is sorted_params_refine_backup.txt, so its
+        criteria checkpoint is information_criteria_refine_backup.txt: both halves of one
+        phase's checkpoint carry the same name, and neither is confused with the fit's."""
+        algo = _bare_backup_algo(tmp_path, refine=True)
+        monkeypatch.setattr(algo, '_compute_information_criteria', _CountingCompute())
+
+        algo.backup()
+
+        text = open(algo.res_dir + '/information_criteria_refine_backup.txt').read()
+        assert 'sorted_params_refine_backup.txt' in text
+        assert not os.path.exists(algo.res_dir + '/information_criteria_backup.txt')
+
+    def test_an_empty_trajectory_has_nothing_to_score(self, tmp_path):
+        """A backup can land before the first result comes back (an expired budget, a
+        slow first generation); there is no best fit to re-simulate, and asking the
+        Trajectory for one would raise."""
+        algo = _bare_backup_algo(tmp_path)
+        algo.trajectory = Trajectory(100)
+        compute = _CountingCompute()
+        algo._compute_information_criteria = compute
+
+        algo._checkpoint_information_criteria()
+
+        assert compute.scored == []
+        assert not os.path.exists(algo.res_dir + '/information_criteria_backup.txt')
+
+    def test_the_re_simulation_runs_after_the_resume_state_is_written(self, tmp_path):
+        """Re-simulating the best fit is the only slow part of a checkpoint, so it runs last:
+        a kill during it leaves the parameter sets and the resume pickle current, and one
+        interval of criteria is the most that can be lost."""
+        algo = _bare_backup_algo(tmp_path)
+        watch = _WatchingCompute(str(tmp_path))
+        algo._compute_information_criteria = watch
+
+        algo.backup()
+
+        assert watch.on_disk == ['alg_backup.bp', 'Results/sorted_params_backup.txt']
+
+    def test_a_checkpoint_leaves_no_mid_run_profiled_noise_behind(self, tmp_path):
+        """profiled_noise.txt reports the scales estimated at the run's FINAL best fit, and
+        the scoring pass the checkpoint runs captures them at whatever point it scored. A
+        checkpoint must not leave that behind for the end-of-run tail to report if its own
+        scoring pass fails."""
+        algo = _bare_backup_algo(tmp_path)
+
+        def _mid_run_scoring(best_pset):
+            algo._profiled_noise = {'sigma': 3.0}
+            return _ic()
+
+        algo._compute_information_criteria = _mid_run_scoring
+
+        algo._checkpoint_information_criteria()
+
+        assert os.path.isfile(algo.res_dir + '/information_criteria_backup.txt')
+        assert algo._profiled_noise == {}
 
 
 class _ResumeProbe(algorithms.Algorithm):


### PR DESCRIPTION
Closes #560.

## The gap

`sorted_params_backup.txt` is checkpointed throughout a run. `information_criteria.txt` was
written **only** on the terminal path. Every downstream consumer of a fit's result needs
both, so a run was un-scoreable at every moment except its last — even though the best
parameter vector had been on disk the whole time and the number was fully determined long
before the process exited.

Not cosmetic: `log_likelihood` in `information_criteria.txt` is the only place PyBNF reports
the **full normalized** log-likelihood (every dropped per-point constant restored), while
the minimized `Obj` column of the parameter table is the *reduced* objective. An absolute
AIC/BIC — or a benchmark score built on one — cannot be computed from the parameter
checkpoint alone.

## What changed

Each backup now also writes `Results/information_criteria_backup.txt` (and
`information_criteria_refine_backup.txt` during a refine, mirroring the parameter file
beside it, so both halves of one phase's checkpoint carry the same name).

The checkpoint has the same format as the final artifact, differing only in `#` comment
lines that mark it a snapshot and name the parameter set it describes — so one parser reads
either file, and the row it pairs with in `sorted_params_backup.txt` is stated:

```
# CHECKPOINT of a run still in progress: the best fit SO FAR, not the
#   run's result. That is information_criteria.txt, written at the end.
# Parameter set: gen6ind4 -- its row in sorted_params_backup.txt.
# Information criteria for the best-fit parameter set (lower is better).
...
k	2
n	21
log_likelihood	-54.06490712
AIC	112.1298142
```

`information_criteria.txt` is unchanged in name, content, and meaning. The checkpoint stays
off the console — like the parameter checkpoint beside it, it reports to the log.

## What it costs

One extra simulation per checkpoint, paid only when the checkpoint has something new to say:

- **nothing at all** unless the objective is a proper likelihood — the existing
  `supports_pointwise_log_likelihood` gate already makes `sos` / `sod` / `norm_sos` / `kl` /
  `wasserstein` / `direct_pass` a no-op, since no information criterion is defined there;
- **nothing while the best fit is unchanged**, because the file on disk already describes
  it. That is exactly the case in the issue: a `gntr` fit of `Brannmark_JBC2010` reached its
  final objective with ~40 minutes left, all of it spent waiting for a file rather than for
  an answer;
- otherwise one simulation per `backup_every * population_size * smoothing` returns — 1 in
  1000 at the common `backup_every = 10, population_size = 100`.

New global key **`backup_information_criteria`** (default 1) turns it off for a model where
even that is too expensive. The cadence knob is the existing `backup_every`.

## Three details that keep it safe

- It runs **last** in `backup()`, after the pickle. Re-simulating is the only slow part of a
  checkpoint, and a kill during it must not leave the resume state a whole interval behind
  the parameter sets it belongs with.
- The profiled noise scales the scoring pass captures are saved and restored around it:
  `profiled_noise.txt` reports the run's **final** best fit, so a checkpoint must not leave a
  mid-run value behind for the end-of-run tail to report if its own scoring pass fails.
- Only a file that was actually written licenses skipping the next recompute, so one
  transient I/O error cannot leave a run whose best fit never changes again with no criteria
  checkpoint at all. `reset()` clears the marker too — a bootstrap replicate writes its own
  `Results-boot{N}` and its PSet names restart, so a carried-over name would have suppressed
  the replicate's first checkpoint.

## Verification

- 10 new tests in `tests/test_run_loop.py`: the file is written and pairs with the params
  row; format parity with the final artifact; no console line; unchanged best fit is not
  re-simulated; a failed write is retried; the non-likelihood no-op; the key off; the refine
  name; an empty trajectory; the ordering after the pickle; no mid-run profiled noise left
  behind.
- End to end on the `05_noisy_decay` bootstrap tutorial (`objective = chi_sq`, `refine = 1`,
  `bootstrap = 2`): the fit, the refine, and each replicate wrote their own checkpoint, every
  one naming the top row of the params file written beside it.
- Full default tier green (3958 passed, 20 skipped) and the Sphinx `-W` docs gate builds
  clean.
- Two frozen snapshots touched by the new global key: `effective_config_golden.json`
  regenerated via `PYBNF_REGEN_GOLDEN=1`, and the benchmark oracle's `_EXCLUDE` gains the key
  with a note (every benchmark there names `direct_pass` or `ave_norm_sos`, so it is a
  genuine no-op for them) rather than regenerating a snapshot whose value is being an
  independent pre-migration witness.

No ADR: this extends an existing checkpoint rather than establishing a seam, and the
alternative the issue considered — reporting the reduced objective plus the restored
constant — is rejected there for the reason it states, that the constant's
parameter-independence is a per-problem measurement PyBNF cannot assert generically.
