### PR TITLE
A model: declaration carries its own atol/rtol/species_atol, so a hand-written per-species vector has one model to mean (#586, ADR-0116)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,54 @@ All notable changes to PyBNF are documented below. This project adheres to
 ## [Unreleased]
 
 ### Added
+- **A `model:` declaration carries that model's own CVODE tolerances, so a per-species
+  absolute tolerance can finally be written by hand (#586, ADR-0116).** `sbml_atol` and
+  `sbml_rtol` are one key each over *every* SBML/Antimony model in a fit, and that — not the
+  grammar — is why neither could ever take a vector: a positional one is ordered against a
+  species list a conf author cannot see, and a species-keyed one has no reading across models
+  that do not share species names. Give the statement one model to be about and both
+  objections disappear. Under `edition >= 2` a single-model `model:` line now takes three
+  optional labeled fields, in any order:
+
+  - **`atol:`** takes exactly what `sbml_atol` takes (a number, `auto`, or
+    `tracking [decades]`), for that model alone.
+  - **`rtol:`** is the per-model `sbml_rtol`. A scalar, and only ever a scalar — CVODE takes
+    one relative tolerance and there is no per-species one to route.
+  - **`species_atol:`** is the hand-written vector, written as `<species> <number>` pairs:
+    `model: weber.xml, atol: auto, species_atol: PKD 1e-3, CERT 1e-2, rtol: 1e-9`.
+
+  **The map is a set of exceptions, not a replacement.** Every species it names takes the
+  number stated, verbatim — neither ADR-0103's `1e-8` ceiling nor ADR-0105's model-scalar
+  floor binds a number a person wrote, for the same reason a pinned `sbml_atol` number is not
+  clamped either. Every species it does *not* name keeps whatever it would have had: the
+  derived vector, a pinned scalar broadcast, or the backend default. The steady-state cutoff
+  stays the model-wide number, and under `atol: tracking` the map becomes the ceiling the
+  trajectory-following weights sit beneath.
+
+  **The species names are bngsim's, and an unknown one is an error at config load** that
+  lists the names the model does have. That matters twice: bngsim renames a species id
+  colliding with an Antimony reserved word (`NULL` integrates as `_ant_NULL`, and the error
+  says so), and a parameter driven by a rate rule becomes a state the `<listOfSpecies>` never
+  mentions — nameable here and reachable by nothing else. On
+  `Smith_BMCSystBiol2013`, the one subset-I slug where the two name lists disagree, the
+  derived vector declines outright and a hand-written map is the only route to
+  `CVodeSVtolerances` there.
+
+  **Nothing changes without one of those fields.** `sbml_atol`/`sbml_rtol` keep every meaning
+  and remain the fit-wide default; a job that states nothing gets the same `Simulator.run`
+  call it got before, argument for argument. A `model:` line carrying a tolerance field must
+  declare exactly one model, and that model must be an `.xml`/`.ant` one on
+  `sbml_backend = bngsim` integrated by CVODE. A BNGL model states `atol`/`rtol` in its own
+  `begin actions` block, the RoadRunner backend has its own integrator settings, and
+  `sbml_integrator = gillespie` runs every action stochastically — all three are refused
+  rather than accepted and ignored, as is a `species_atol` on a bngsim without
+  lanl/bngsim#196.
+
+  Measured on `Weber_BMC2015`: writing bngsim's own `rtol * y_i` rule by hand — the rule
+  ADR-0105 measured and declined to apply automatically — costs 192 integrator steps against
+  `auto`'s 184 and the clamped default's 210, agreeing with all of them to ~3e-08 at the
+  final state. The derivation is still the better default; what it could not do was be
+  overridden for one species of one model.
 - **The information criteria are checkpointed alongside the parameter sets, so a run is
   scoreable before it ends (#560).** `sorted_params_backup.txt` has been written throughout a
   run since forever; `information_criteria.txt` was written **only** on the terminal path. Every
@@ -82,6 +130,13 @@ All notable changes to PyBNF are documented below. This project adheres to
   says what it has not bisected.
 
 ### Fixed
+- **`sbml_rtol` is checked for finiteness, not just for sign, so `sbml_rtol = inf` no longer
+  reaches CVODE (#586).** The conf grammar's number token also matches `inf` (ADR-0047's open
+  truncation side), so `sbml_rtol = inf` parsed to a float that cleared the config check's
+  bare `tol <= 0.` and was installed as the relative tolerance — which turns relative error
+  control off rather than erroring. `sbml_atol` never had the hole, because
+  `parse_atol_setting` has always demanded finiteness. Found while adding the per-model
+  `rtol:` field of #586, which would otherwise have inherited the same check.
 - **`job_type = de` and `job_type = ade` no longer stop after generation 0 on a negative
   objective (#561, ADR-0115).** The Differential Evolution family tested convergence with a
   *ratio* of objectives — `max(fit) / min(fit) < 1 + stop_tolerance` — which reads as

--- a/docs/adr/0116-a-per-species-tolerance-has-no-reading-under-a-global-key-so-the-new-era-model-declaration-carries-atol-rtol-species-atol-and-checks-a-species-name-against-the-one-model-it-can-mean.md
+++ b/docs/adr/0116-a-per-species-tolerance-has-no-reading-under-a-global-key-so-the-new-era-model-declaration-carries-atol-rtol-species-atol-and-checks-a-species-name-against-the-one-model-it-can-mean.md
@@ -1,0 +1,344 @@
+# A per-species tolerance has no reading under a global key, so the new-era `model:` declaration carries `atol` / `rtol` / `species_atol` and checks a species name against the one model it can mean (issue #586)
+
+**Status: Accepted and implemented (2026-08-19). Extends ADR-0028, ADR-0103, ADR-0105 and
+ADR-0114; supersedes none.** The default path is byte-identical after this change: a job
+that states nothing new gets the same `Simulator.run` call it got before, and `sbml_atol` /
+`sbml_rtol` keep every meaning ADR-0114 gave them. What this adds is a place to say those
+things about *one* model, and one thing that could not be said at all.
+
+## The key, and why the grammar was never the problem
+
+ADR-0114 shipped `sbml_atol = auto` and `sbml_atol = tracking`, and closed by naming what
+it had not shipped:
+
+> **`sbml_atol` still does not take a hand-written vector**, which is #557's second ask.
+> […] The first clause is left open as **#586**: `sbml_atol` is one global key applying to
+> every SBML/Antimony model in a fit, so a positional vector has no ordering a conf author
+> can see and a species-keyed one has no unambiguous reading across models that do not
+> share species. That needs a per-model tolerance record and its own design.
+
+That is the whole of it, and it is worth restating because the obvious reading is wrong.
+The blocker was never that `sbml_atol = 1e-3 1e-6 1e-4` is hard to parse — it is trivial to
+parse. It is that neither spelling **means** anything definite once the key is global, and
+PyBNF fits run several models routinely (ADR-0041 multi-model interop; a PEtab problem with
+more than one `modelId`):
+
+- **A positional vector** is ordered against `bngsim.Model.species_names` — the *engine*
+  model's ordering, which a conf author cannot see and which is not the document's
+  `<listOfSpecies>` order in general. lanl/bngsim#212's `normalize_atol_vector` exists
+  precisely because a mis-ordered vector assigns one species' tolerance to another and
+  nothing downstream can tell: every entry is a plausible tolerance. Under two models with
+  different species counts, one line cannot even be length-checked against both.
+- **A species-keyed map** is safe to order and still has no reading across models. Is a
+  name absent from model B an error, or a per-model override B does not use? Do two models
+  sharing a species name share its tolerance? A name that collides across models with
+  different units silently means two different things.
+
+Both objections are about the **key**. Give the statement one model to be about and both
+disappear — the name has exactly one species list to be checked against, the ordering is
+that model's, and two models cannot collide because neither can see the other's line.
+
+ADR-0028 already built the place for it. A new-era `model:` declaration names one model
+file, is edition-gated, and is the sibling of `condition:` / `experiment:` / `parameter:`,
+every one of which already carries labeled sub-fields. #586 proposed exactly this, and this
+ADR is that proposal built.
+
+## The decision
+
+**The new-era `model:` declaration carries this model's own CVODE tolerances**, in any
+order after the file, and every field is optional:
+
+```
+model: weber.xml, atol: auto, species_atol: PKD 1e-3, CERT 1e-2, rtol: 1e-9
+```
+
+- **`atol:`** takes exactly what `sbml_atol` takes — a number, `auto`, or
+  `tracking [decades]` — and means exactly what that key means, for this model only.
+- **`rtol:`** is the per-model `sbml_rtol`. A scalar, and only ever a scalar: CVODE takes
+  one relative tolerance (`double rtol`), and bngsim has no `rtol_vec` to route a
+  per-species one to. #586 names a per-model `rtol` as something the record "also gives a
+  home for"; this is that home, and it is the whole of what that half can be.
+- **`species_atol:`** is the hand-written vector, written as `<species> <number>` pairs.
+
+`sbml_atol` and `sbml_rtol` remain the fit-wide defaults and are unchanged in every
+respect. A field here overrides the matching global key **for the one model it names**, and
+says nothing about the others. That is the property the global key could not have, and it
+is what makes a species name mean something.
+
+### 1. The record is refused where it could only be decoration
+
+A `model:` line carrying any of these fields must declare **exactly one** model, because
+`model: a.xml, b.xml, atol: 1e-4` cannot say which model the `1e-4` is about — and stopping
+one number from meaning several things at once is the entire point. Refused in `ploop`
+rather than in the grammar, so the message can say to give each model its own line.
+
+The model must also be one with a CVODE tolerance to state: an `.xml`/`.ant` model on
+`sbml_backend = bngsim`, integrated by CVODE. Three cases are pointed errors at config load
+because in each the record could only be decoration — a BNGL model takes `atol`/`rtol` from
+its own `begin actions` block, the RoadRunner backend has its own integrator settings, and
+`sbml_integrator = gillespie` makes `_resolve_method` return `'ssa'` for every action of
+every model, where a run carries no tolerances at all.
+
+This is stricter than the global key, which is guarded only on the backend and is a silent
+no-op today on a BNGL-only job with `sbml_backend = bngsim`, or on any job under
+`gillespie`. That asymmetry is deliberate: a key applying to "every SBML model, of which
+there are none" is a vacuous statement, while a record naming `egfr.bngl` is a mistake about
+that file.
+
+### 2. `species_atol` is an override layer, and a stated number is used verbatim
+
+The map does not replace the derivation. Every species it names takes the number stated;
+every species it does not keeps whatever it would otherwise have had — the ADR-0105 vector
+when there is one, and the model-wide scalar broadcast when there is not (a model whose
+species share one scale, an ordering the derivation cannot take, or a pinned `sbml_atol`).
+So `atol: 1e-6, species_atol: PKD 1e-3` reads as it looks — everything at `1e-6` except
+`PKD` — rather than as a contradiction one of the two has to lose.
+
+**Neither clamp binds a stated entry.** Not ADR-0103's `1e-8` ceiling, which ADR-0114
+established is a no-regression rule about the *derivation* rather than a property of the
+model; and not ADR-0105's model-scalar floor, which bounds how far a rule reading *initial
+values* may reach on its own. A number a person wrote is neither of those. It is the same
+kind of statement a pinned `sbml_atol` number is, and it wins for the same reason: the
+derivation's job is to answer when nobody has, and somebody has.
+
+The one bound kept is CVODE's own — finite and **strictly positive**. bngsim accepts `0` in
+a plain per-species vector and refuses it outright as a `TrackingAtol` ceiling, so accepting
+it here would make `species_atol: X 0` parse, integrate, and then fail the moment the same
+model added `atol: tracking`. One rule that holds under every setting is worth more than the
+one value it declines.
+
+Nor does the **"elementwise the scalar, so send the scalar"** off-ramp apply to a stated
+map. That off-ramp is ADR-0105's, and it is correct precisely because nobody asked for a
+vector: a model with no over-tightening to give back keeps its `CVodeSStolerances` call byte
+for byte (19 of 23 subset-I slugs) rather than paying lanl/bngsim#196's ~1 ulp
+`cvEwtSetSS`/`cvEwtSetSV` difference for a constant vector. Here somebody did ask, so the
+vector travels and pays that ulp for having been stated.
+
+### 3. The names are bngsim's, and that is checked rather than assumed
+
+A `species_atol` is written in the names bngsim **integrates the model under**
+(`Model.species_names`), not the SBML document's `<listOfSpecies>` ids. The two lists agree
+on almost every model and diverge in two ways that matter:
+
+- **bngsim renames an id that collides with an Antimony reserved word.** `NULL` loads as
+  `_ant_NULL`. This is not hypothetical: it is why `Smith_BMCSystBiol2013`'s derived vector
+  declines today, warning and falling back to the scalar (`_per_species_atol`).
+- **A parameter or compartment driven by a rate rule or an event assignment becomes a
+  state**, appended after every declared species. It has no id in `<listOfSpecies>` and no
+  declared initial value, so nothing read off the document can give it a tolerance at all.
+
+Engine names are the only list that can be both checked and applied, because they are the
+ordering a per-species vector *is*. Validating against document ids would accept a name that
+then silently did nothing — the failure this whole line of work exists to stop making. So
+an unknown name is a `ModelError` naming the species the model does have, and naming the
+`_ant_` rename outright when it recognizes the case, since that is the one a conf author
+cannot guess from their own file.
+
+That check runs **at config load**, which is what #586 asks for, and it costs nothing: the
+model constructor already loads a bngsim engine model to validate the file and throws it
+away. It now keeps that load's species names.
+
+### 4. Refused, not degraded
+
+A `species_atol` on a bngsim without lanl/bngsim#196 is a `ModelError` at construction and a
+`PybnfError` at config load, not a silent fallback to the scalar. The *derived* vector may
+fall back silently — nobody asked for it, and the scalar is a correct tolerance for that
+model, merely a less discriminating one. A hand-written map is somebody asking, and a stated
+tolerance that did not apply is a plausible trajectory with a wrong conclusion attached.
+This is exactly the line #557 drew for `sbml_atol = tracking`, applied to the one other
+setting that is a request rather than a permission.
+
+## What is deliberately not changed
+
+- **`sbml_atol` and `sbml_rtol` keep every meaning and stay the fit-wide default.** They
+  are not deprecated under edition 2 and gain no new spelling. A one-model job that wants
+  one number still writes one number in the place it always did.
+- **The scalar derivation, the vector derivation, and both clamps are untouched.** A model
+  that states nothing reaches the same `Simulator.run` call, argument for argument.
+- **The steady-state cutoff stays ADR-0105's pairing.** bngsim resolves a vector `atol` to
+  its own `1e-8` for every scalar-shaped consumer, and `steady_state_tol` is one, so a
+  stated vector travels with the model's derived (or pinned) scalar exactly as a derived one
+  does. Forgetting this would silently revert ADR-0103's steady-state fix and make every
+  `time = inf` measurement and every pre-equilibration phase return the initial state and
+  call it equilibrium.
+- **No sparse vector reaches bngsim.** There is no partial form to send: PyBNF densifies the
+  map against the engine species list and `normalize_atol_vector` takes the length contract
+  once, at setup.
+- **The vector remains a constant of the model, never of the fit point.** A number read out
+  of a conf is trivially that, and bngsim's live-state `AUTO` remains ruled out for the
+  reason ADR-0105 gives.
+
+## Verification
+
+### What the surface reaches that nothing else does, measured on the corpus
+
+Over the 23 subset-I slugs with a loadable `.xml`, the engine and document species-name sets
+disagree on **one**: `Smith_BMCSystBiol2013`, whose `NULL`/`null` load as
+`_ant_NULL`/`_ant_null`. On that model, today and after this change:
+
+| `Smith_BMCSystBiol2013` | what CVODE is called with |
+|---|---|
+| unset (the derivation) | **scalar** — the vector declines, unorderable past the rename |
+| `sbml_atol = auto` | **scalar** — same decline; `auto` lifts a clamp, not an ordering |
+| `species_atol: NULL 1e-3` | refused, naming `_ant_NULL` |
+| `species_atol: _ant_NULL 1e-3, _ant_null 1e-3` | **vector[133]**, entries in their own slots, cutoff stated |
+
+So on the one corpus model where the derivation cannot order a vector at all, a hand-written
+map is the only route to `CVodeSVtolerances` that exists. **Zero of the 23 have a promoted
+rate-rule state**, so the second capability §3 describes is real and the corpus has no case
+for it — recorded rather than claimed.
+
+### What a hand-written vector costs on the slug #557 was filed from
+
+`Weber_BMC2015`, seven species at `1.24e+02 .. 4.21e+07`, median `4.665e+05`; 100 time
+units, 101 output points, `rtol = 1e-8`, one fresh engine model per arm (a second `run()` on
+one Simulator continues from where the first stopped, ADR-0104):
+
+| `atol` | integrator steps | vs unset | max rel. state difference at `t_end` |
+|---|---:|---:|---:|
+| unset (the clamped derivation, `1e-08`) | 210 | 1.00x | — |
+| `auto` (ADR-0114's vector) | 184 | 0.88x | 3.3e-08 |
+| `species_atol` = `rtol * y_i`, by hand | 192 | 0.91x | 2.9e-08 |
+
+The third arm is the interesting one. `rtol * y_i` with **no model-median floor** is
+bngsim's own `derive_atol` default, and it is exactly the rule ADR-0105 measured and
+declined to apply on its own — over 100 points of `Brannmark_JBC2010`'s fit box it killed 91
+simulations out of 100 against the scalar's 39. This surface makes it reachable, per model,
+by a person who has decided to reach for it. And on Weber it is **worse than `auto`** — 192
+steps against 184, because `PKDDAGa` at 124 drops from the median's `4.67e-03` to
+`1.24e-06`, four decades tighter, for a species that is not the problem.
+
+That is the honest shape of this change, and it is worth stating plainly: **the surface is
+not a faster tolerance, it is a place to put a decision.** The derivation remains the better
+default on every slug measured; what it cannot do is be overridden for one species of one
+model, and now it can be.
+
+Neither arm is an accuracy trade: both agree with the clamped run's final state to ~3e-08,
+i.e. to the relative tolerance that governs it.
+
+### One hole closed on the way past
+
+`sbml_rtol` was checked for sign and not for finiteness (`if tol <= 0.`), and the conf
+grammar's number token also matches `inf` (ADR-0047's open truncation side). So
+`sbml_rtol = inf` parsed, cleared the check, and was installed as the relative tolerance —
+which turns relative error control off rather than erroring. `sbml_atol` never had it,
+because `parse_atol_setting` has always demanded finiteness. Fixed here rather than filed,
+because the per-model `rtol:` field would otherwise have inherited exactly the same check;
+`test_config_refuses_an_rtol_that_is_not_a_relative_tolerance` is the assertion.
+
+### The default path is untouched
+
+The fast tier is green at **4170 passed, 10 skipped** with the change in, up from 4086
+before it (the difference is this change's own tests). `test_a_stated_map_travels_even_when
+_it_agrees_with_the_scalar` asserts the unstated half of that directly: a model that states
+nothing still gets `{'rtol': 1e-08, 'atol': 1e-08}` and no `steady_state_tol`, which is the
+scalar call ADR-0105 promised 19 of 23 slugs would keep byte for byte.
+
+### The mechanism, in fixtures
+
+Parse and record: `test_the_model_line_states_one_models_own_tolerances`,
+`test_the_tolerance_fields_are_order_independent`,
+`test_a_declaration_that_states_no_tolerance_is_unchanged` (which is also the assertion that
+the legacy `model = f : d.exp` line still backtracks past the new fields),
+`test_a_multi_model_declaration_cannot_state_a_tolerance`,
+`test_a_model_is_given_its_tolerances_once`, `test_a_species_is_given_its_tolerance_once`,
+`test_the_model_format_hint_names_the_tolerance_fields`.
+
+Shape: `test_parse_species_atol_setting_reads_a_map`,
+`test_parse_species_atol_setting_refuses_what_is_not_a_tolerance` (which is where the
+strictly-positive decision is recorded).
+
+Composition: `test_the_species_a_map_does_not_name_keep_what_they_would_have_had`,
+`test_a_stated_entry_is_bound_by_neither_clamp`,
+`test_a_pinned_scalar_becomes_the_base_the_map_overrides`,
+`test_a_stated_map_becomes_the_tracking_ceiling`,
+`test_a_stated_map_keeps_the_steady_state_cutoff_the_models_own_scalar`,
+`test_a_stated_map_can_say_exactly_what_the_derivation_says` — the last being the property
+that says this is one mechanism rather than two: what the derivation computes is inside what
+a person can write.
+
+Ordering and reach: `test_a_stated_species_tolerance_reaches_the_run_call_by_name`,
+`test_a_stated_map_reaches_the_bngsim_run_call`,
+`test_a_stated_map_survives_the_rename_that_makes_the_derivation_decline`,
+`test_a_stated_map_is_a_constant_of_the_model_not_of_the_fit_point`,
+`test_the_model_still_integrates_to_its_closed_form_under_a_stated_vector` (an oracle, at a
+tolerance two decades above what any derivation produces).
+
+Names and refusals: `test_the_engine_species_names_are_captured_at_construction`,
+`test_an_unknown_species_is_refused_and_the_message_names_the_ones_it_has`,
+`test_a_renamed_species_is_named_in_the_refusal`,
+`test_a_stated_map_is_refused_rather_than_dropped_without_the_backend`, plus the Antimony
+trio in `tests/test_bngsim_antimony_bridge.py` —
+`test_an_antimony_model_takes_its_own_per_species_tolerance`,
+`test_an_antimony_reserved_word_species_is_named_by_the_name_bngsim_gives_it`, and
+`test_a_promoted_state_is_nameable_even_though_the_document_never_declares_it`.
+
+Config surface: `test_a_per_model_record_is_resolved_field_by_field`,
+`test_a_tolerance_for_an_undeclared_model_is_refused`,
+`test_a_model_with_no_cvode_tolerance_to_state_is_refused`,
+`test_a_per_model_tolerance_needs_the_bngsim_backend`,
+`test_config_refuses_a_per_model_setting_that_is_not_a_tolerance`, the two capability
+refusals, `test_the_per_model_tolerances_require_edition_2`, and the end-to-end
+`test_a_conf_states_one_models_tolerance_and_leaves_the_other_alone` — two models, one
+statement, no collision, which is #586 reduced to one assertion.
+
+## Alternatives considered
+
+**`atol:` carrying the pairs itself**, which is #586's own sketch
+(`model: weber.xml, atol: PKD 1e-3, CERT 1e-2`). The three forms are lexically disjoint — a
+lone number, a keyword, `<name> <number>` pairs — so it parses. It was split in two anyway,
+because `atol:` also has to be the per-model form of `sbml_atol` to be worth having in a
+multi-model fit, and one key cannot then carry both a mode and a map: `atol: auto,
+species_atol: PKD 1e-3` is a thing people will want to write, and under the merged spelling
+there is nowhere to write it. Two fields that each answer one question compose; one field
+answering two does not.
+
+**A `species_atol` keyed on document ids**, so a conf author can write what they read in
+their own model file. Rejected in §3: it accepts a name the engine does not carry, and the
+result is a stated tolerance that silently does nothing. The refusal message carries the
+translation instead, which costs one error and no ambiguity.
+
+**Filling unnamed species from the scalar rather than from the derivation.** Simpler to
+describe, and wrong in the direction that matters: it would make `species_atol: PKD 1e-3`
+silently *undo* ADR-0105's vector for every other species of that model. An override layer
+means the unnamed species are exactly where they were.
+
+**Leaving `sbml_atol` as the only surface and adding a positional vector to it.** This is
+what ADR-0105 declined ("a per-species vector in a `.conf` would need a new species-keyed
+grammar, and the case for it is hypothetical") and what #586 re-declined. Nothing about the
+key changed; only the place did.
+
+### Scope
+
+**In:** `pybnf/parse.py` (the `model:` sub-field grammar, the record helpers, the format
+hint), `pybnf/config.py` (`_resolve_model_tolerances`, the edition gate, the two
+constructor call sites), `pybnf/bngsim_sbml_model.py` (`parse_species_atol_setting`,
+`_config_species_atol`, `_engine_species_names`, `_check_stated_species_atol`,
+`_apply_stated_per_species_atol`, `_per_species_atol`),
+`pybnf/bngsim_antimony_model.py` (the kwarg), `docs/config_keys.rst`,
+`tests/test_sbml_solver_tolerances.py`, `tests/test_bngsim_antimony_bridge.py`.
+
+One grammar detail is worth recording because it is not obvious and was caught by review
+rather than by design. `model_file`'s regex is unanchored and lazy, so on a line where a
+comma can now be followed by something that is not a file it will run straight through the
+field — and through a trailing comment — to the next extension it can find:
+`model: decay.xml, atol: 1e-10  # tighter for decay.xml` parsed as *two* models, the second
+named `atol: 1e-10  # tighter for decay.xml`. The declaration's file token therefore sits
+behind a negative lookahead for a field label followed by its colon, which ends the file
+list exactly where the fields begin. Nothing else about the token is narrowed — `#` stays
+legal inside a filename, because the legacy `model = … : …` form still accepts it and two
+spellings of one declaration disagreeing about which files exist would be worse than the
+corner it would close. `test_a_tolerance_field_is_never_read_as_a_model_filename` and
+`test_a_model_file_written_after_a_tolerance_field_is_a_parse_error` hold both halves.
+
+**Out (unchanged):** `_derive_atol`, `_derive_atol_vector`, `_derive_per_species_atol`,
+`_effective_tolerances`, `_run_tolerance_kwargs`'s pairing rules, `pybnf/_bngsim_caps.py`,
+`pybnf/config_schema.py` (the record is a structural tuple key, so no schema field and no
+golden-config movement), the BNGL/`.net` tolerance route, and bngsim itself — nothing in
+lanl/bngsim needed changing for this.
+
+Relevant ADRs: **0028** (the `model:` declaration this rides), **0103** (the scalar
+derivation), **0105** (the per-species vector and both clamps), **0114** (`auto` /
+`tracking`, and the paragraph that opened this issue). Relevant issues: lanl/bngsim#196
+(`CVodeSVtolerances`), lanl/bngsim#212 (`normalize_atol_vector`), lanl/bngsim#213
+(`CVodeWFtolerances`). Closes issue **#586**.

--- a/docs/config_keys.rst
+++ b/docs/config_keys.rst
@@ -37,11 +37,68 @@ Required Keys
   per model; a comma list is shorthand for a few. Requires ``edition >= 2``; the legacy
   ``model = … : …`` form above continues to work at every edition.
 
+  A declaration of a **single** SBML (``.xml``) or Antimony (``.ant``) model on
+  ``sbml_backend = bngsim`` may also state that model's own CVODE tolerances, in any
+  order after the file:
+
+  * **atol:** ``<number>``, ``auto``, or ``tracking [<decades>]`` — the per-model form of
+    :ref:`sbml_atol <sbml_rtol>`, meaning exactly what that key means, for this model only.
+  * **rtol:** ``<number>`` — the per-model form of :ref:`sbml_rtol <sbml_rtol>`.
+  * **species_atol:** ``<species> <number>[, <species> <number>…]`` — a hand-written
+    absolute tolerance for named species of this model. Every species it does *not* name
+    keeps whatever it would otherwise have had, so this is a set of exceptions rather than
+    a replacement for the derivation.
+
+  ``sbml_atol`` and ``sbml_rtol`` remain the fit-wide defaults; a field here overrides the
+  matching global key for the one model it names, and states nothing about the others.
+  That is the point of putting them here: a global key applies to *every* SBML/Antimony
+  model in the fit, which is why neither could ever take a per-species vector — a
+  positional one is ordered against a species list a conf author cannot see, and a
+  species-keyed one has no reading across models that do not share species names.
+
+  A ``model:`` line carrying any of these fields must declare exactly one model, and that
+  model must be one with a CVODE tolerance to state. A BNGL model writes ``atol``/``rtol``
+  in its own ``begin actions`` block; the RoadRunner backend has its own integrator
+  settings; and ``sbml_integrator = gillespie`` runs every action stochastically, where
+  there are no CVODE tolerances at all. All three are refused here rather than accepted and
+  ignored. Requires ``edition >= 2``.
+
+  **The species names are bngsim's, not the document's**, and the difference is checked
+  rather than papered over: a name the model does not integrate is an error at config
+  load, listing the names it does have. Two cases make the two lists differ. bngsim
+  renames a species id that collides with an Antimony reserved word, so a model file
+  declaring ``NULL`` is integrated as ``_ant_NULL`` (the error says so when it recognizes
+  the case). And a parameter or compartment driven by a rate rule or an event assignment
+  becomes a state of its own, appended after every declared species — nameable here, and
+  reachable by nothing else, since it has no declared initial value for a derivation to
+  read.
+
+  **A number you write is used verbatim.** Neither clamp of the derivation applies to a
+  ``species_atol`` entry: not the ``1e-8`` ceiling, and not the model-wide floor. Those
+  bound how far a rule reading *initial values* may go on its own; a number in the conf is
+  a statement, exactly as a plain ``sbml_atol`` number is. It must be finite and strictly
+  positive — zero would be legal in a bare CVODE per-species vector and is refused as a
+  ``tracking`` ceiling, so the stricter rule is the one applied, and it is applied
+  everywhere.
+
+  The fields compose. ``atol: auto`` chooses the base the map is laid over; a plain
+  ``atol`` number makes that base the number, broadcast; ``atol: tracking`` makes the
+  resulting vector the trajectory-following **ceiling**. The steady-state convergence cutoff stays
+  the model-wide number in every case, for the reason :ref:`sbml_atol <sbml_rtol>` gives.
+  A ``species_atol`` needs a bngsim with per-species tolerance support and is refused —
+  not quietly dropped — without one.
+
   Examples:
 
     * ``model: egfr.bngl`` (one model; ``modelId`` = ``egfr``)
     * ``model: egfr.bngl, erbb2.bngl`` (comma list)
     * ``model: egfr.bngl`` then ``model: erbb2.bngl`` (multiple lines, union)
+    * ``model: weber.xml, atol: auto`` (this model trusts its own scale; the rest of the
+      fit is unaffected)
+    * ``model: weber.xml, species_atol: PKD 1e-3, CERT 1e-2`` (two species by hand,
+      everything else derived)
+    * ``model: weber.xml, atol: 1e-6, rtol: 1e-10, species_atol: PKD 1e-3`` (everything at
+      ``1e-6`` except ``PKD``)
 
 .. _condition:
 
@@ -1302,6 +1359,13 @@ Algorithm Options
   model in the fit. For BNGL models, write ``rtol``/``atol`` in the BNGL file's
   ``begin actions`` block instead — that is BioNetGen's own surface for them.
 
+  These two keys are the fit-wide **default**. Under ``edition >= 2`` a single model can
+  state its own instead, on its :ref:`model: <model_decl>` declaration line
+  (``atol:`` / ``rtol:``), and only there can a *per-species* vector be written by hand
+  (``species_atol:``) — a global key applies to every model in the fit, so a species name
+  on one has no unambiguous reading. Everything below describes what a value means; where
+  it is written decides how much of the fit it means it for.
+
   Leave both unset unless you have a reason not to. ``sbml_rtol`` then takes the
   backend default (``1e-8``), and the absolute tolerance is **derived from the model**
   in two steps.
@@ -1387,6 +1451,12 @@ Algorithm Options
   whole derivation: it integrates every species at that value, which is also the way to
   pin the pre-per-species behaviour exactly. ``auto`` and ``tracking`` are not that — they
   say how far the model's own state may set its tolerance, so the derivation stays on.
+
+  If what you want is a tolerance for **one species** that the derivation does not
+  produce, that is ``species_atol:`` on the :ref:`model: <model_decl>` line rather than
+  anything here: it names the species, it is checked against the model's own species list
+  at config load, and it leaves every other species exactly where this key would have put
+  it.
 
   What a looser tolerance costs is **smoothness**, not accuracy, and the distinction
   matters when choosing between ``auto`` and a hand-set number. On ``Weber_BMC2015`` four

--- a/pybnf/bngsim_antimony_model.py
+++ b/pybnf/bngsim_antimony_model.py
@@ -83,7 +83,7 @@ def _antimony_text_to_sbml_text(text, source_desc):
 
 class BngsimAntimonyModelNoTimeout(BngsimSbmlModelNoTimeout):
     def __init__(self, file, abs_file, pset=None, actions=(), save_files=False, integrator='cvode',
-                 strict_ssa=True, rtol=None, atol=None):
+                 strict_ssa=True, rtol=None, atol=None, species_atol=None):
         if integrator != 'cvode':
             raise ModelError(
                 'Antimony models currently support only sbml_integrator = cvode'
@@ -92,7 +92,7 @@ class BngsimAntimonyModelNoTimeout(BngsimSbmlModelNoTimeout):
         _require_bngsim_antimony_support()
 
         self._init_common_attrs(file, abs_file, pset, actions, save_files, integrator, strict_ssa,
-                                file_ext='.ant', rtol=rtol, atol=atol)
+                                file_ext='.ant', rtol=rtol, atol=atol, species_atol=species_atol)
         self.stochastic = False
 
         with open(self.abs_file_path, encoding='utf-8', errors='replace') as fh:

--- a/pybnf/bngsim_sbml_model.py
+++ b/pybnf/bngsim_sbml_model.py
@@ -137,6 +137,47 @@ def _positive_atol(value):
     return value
 
 
+def parse_species_atol_setting(species_atol):
+    """Normalize a per-model ``species_atol`` map into ``{name: float}`` (#586).
+
+    The sibling of :func:`parse_atol_setting` for the hand-written per-species vector the
+    new-era ``model:`` declaration carries (ADR-0116), and it exists for the same reason:
+    ``config.py`` rejects a bad one at config load and the model constructor is reachable
+    directly, so one function has to own what a value means or the two will disagree.
+
+    ``None`` (and an empty map) is ``None`` -- nothing stated. Otherwise every entry is
+    checked to be a finite **positive** number. Strictly positive rather than bngsim's
+    ``>= 0``: zero is a legal entry of a plain ``CVodeSVtolerances`` vector but says that
+    species has no absolute error control at all, and it is refused outright as a
+    ``TrackingAtol`` ceiling -- so accepting it here would make ``species_atol: X 0``
+    parse, integrate, and then fail the moment the same model added ``atol: tracking``.
+    One rule that holds under every setting is worth more than the one value it declines.
+
+    Species NAMES are not checked here: they belong to the model, and the check needs the
+    species list bngsim will integrate under (:meth:`_check_stated_species_atol`). Raises
+    ``ValueError`` naming the offending species; callers translate it into their own
+    error type rather than each re-deciding what the legal shapes are.
+    """
+    if species_atol is None:
+        return None
+    if not isinstance(species_atol, dict):
+        raise ValueError(
+            'expected a mapping of species name to absolute tolerance; got '
+            f'{type(species_atol).__name__}')
+    normalized = {}
+    for name, value in species_atol.items():
+        # A numeric *string* reads as the number, for parse_atol_setting's reason: a value
+        # can reach a model from somewhere other than the conf grammar. ``True`` does not,
+        # because ``float(True)`` is 1.0 and would pass silently.
+        if isinstance(value, bool):
+            raise ValueError(f"species '{name}': expected a positive number; got {value!r}")
+        try:
+            normalized[str(name)] = _positive_atol(value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"species '{name}': {exc}") from None
+    return normalized or None
+
+
 def _derive_atol(scale, rtol, default_atol, *, loosen=False, model_name=None, warned=None):
     """The absolute tolerance a model whose state lives at ``scale`` needs (#546).
 
@@ -469,10 +510,27 @@ class BngsimSbmlModelNoTimeout(Model):
     # lanl/bngsim#213's trajectory-following weights on top of that. The two are mutually
     # exclusive by construction, so ``_config_atol is not None`` remains exactly what it
     # was: "the user stated the number, take it".
+    #
+    # ``_config_species_atol`` is the fourth kind of statement and the only one that is not
+    # about the whole model: the hand-written ``{species: atol}`` map a new-era ``model:``
+    # declaration carries (#586, ADR-0116). It is an OVERRIDE LAYER rather than a
+    # replacement -- the species it names take the number stated, verbatim, and every other
+    # species keeps whatever the three settings above would have given it. ``None`` means
+    # "nothing stated", which is every model that does not use the syntax.
     _config_rtol = None
     _config_atol = None
     _atol_mode = None
     _atol_tracking_decades = None
+    _config_species_atol = None
+
+    # The species names bngsim will integrate this model under, captured from the engine
+    # load the constructor already pays for (:meth:`_load_engine_model_or_raise`). NOT the
+    # same list as ``_species_names``, which is the SBML document's ids: bngsim renames an
+    # id that collides with an Antimony reserved word (``NULL`` -> ``_ant_NULL``) and
+    # appends a state for every parameter or compartment a rate rule or event assignment
+    # drives. Those are the names a ``species_atol`` map is written in and checked against,
+    # because they are the ones a per-species vector is ordered by.
+    _engine_species_names = None
 
     # The model's per-species nominal values in bngsim's units, and their typical (median
     # strictly-positive) magnitude, both set from the parsed document by
@@ -490,7 +548,7 @@ class BngsimSbmlModelNoTimeout(Model):
     _atol_floor_warned = None
 
     def __init__(self, file, abs_file, pset=None, actions=(), save_files=False, integrator='cvode',
-                 strict_ssa=True, rtol=None, atol=None):
+                 strict_ssa=True, rtol=None, atol=None, species_atol=None):
         if integrator not in _SUPPORTED_INTEGRATORS:
             raise ModelError(
                 'sbml_backend = bngsim supports sbml_integrator in {}; got {}'.format(', '.join(_SUPPORTED_INTEGRATORS), integrator)
@@ -499,7 +557,7 @@ class BngsimSbmlModelNoTimeout(Model):
         _require_bngsim_sbml_support()
 
         self._init_common_attrs(file, abs_file, pset, actions, save_files, integrator, strict_ssa,
-                                file_ext='.xml', rtol=rtol, atol=atol)
+                                file_ext='.xml', rtol=rtol, atol=atol, species_atol=species_atol)
         self.stochastic = integrator == 'gillespie' or any(
             getattr(a, 'method', 'ode') == 'ssa' for a in actions
         )
@@ -515,14 +573,17 @@ class BngsimSbmlModelNoTimeout(Model):
         logger.debug('Loaded model %s with bngsim SBML backend', self.name)
 
     def _init_common_attrs(self, file, abs_file, pset, actions, save_files, integrator, strict_ssa,
-                           file_ext, rtol=None, atol=None):
+                           file_ext, rtol=None, atol=None, species_atol=None):
         """Set the model attributes shared by the SBML and Antimony backends.
 
         ``file_ext`` is stripped from the file name to form ``self.name`` ('.xml'
         for SBML, '.ant' for Antimony). ``self.stochastic`` is set by the caller
         because the two backends compute it differently. ``rtol``/``atol`` carry the
         config's explicit CVODE tolerances (#546); ``None`` leaves each to the
-        backend default / the scale derivation.
+        backend default / the scale derivation. ``species_atol`` carries this model's
+        own hand-written per-species map (#586); its species NAMES are checked once the
+        engine model has been loaded (:meth:`_check_stated_species_atol`), because the
+        list they are written against is bngsim's rather than the document's.
         """
         self.file_path = file
         self.abs_file_path = abs_file
@@ -546,9 +607,24 @@ class BngsimSbmlModelNoTimeout(Model):
                 'sbml_atol = tracking needs a bngsim whose Simulator.run takes a '
                 'trajectory-following absolute tolerance (lanl/bngsim#213, '
                 'bngsim.TrackingAtol); this build does not have one.')
+        try:
+            self._config_species_atol = parse_species_atol_setting(species_atol)
+        except ValueError as exc:
+            raise ModelError(f'Invalid species_atol for model {self.name}: {exc}') from exc
+        if self._config_species_atol and not BNGSIM_HAS_PER_SPECIES_ATOL:
+            # Refused rather than degraded, for the reason the tracking refusal above gives.
+            # The DERIVED vector may fall back to the scalar silently (:meth:`_per_species_atol`)
+            # because the scalar is a correct tolerance for that model and nobody asked for
+            # anything else; a hand-written map is somebody asking, and a stated tolerance
+            # that did not apply is a plausible trajectory with a wrong conclusion attached.
+            raise ModelError(
+                'species_atol needs a bngsim whose Simulator.run takes a per-species '
+                'absolute tolerance (lanl/bngsim#196, bngsim.normalize_atol_vector); this '
+                'build does not have one.')
         self._tolerance_cache = None
         self._atol_vector_cache = None
         self._atol_floor_warned = set()
+        self._engine_species_names = None
         self.suffixes = [(a.bng_codeword, a.suffix) for a in actions]
         self.mutants = [MutationSet()]
 
@@ -999,13 +1075,60 @@ class BngsimSbmlModelNoTimeout(Model):
 
     def _load_engine_model_or_raise(self, parse_error_message):
         """Load the bngsim engine model, letting FileNotFoundError propagate
-        unwrapped and converting any other failure into a ModelError."""
+        unwrapped and converting any other failure into a ModelError.
+
+        The loaded model is not kept -- the per-action engine models come from
+        :meth:`_get_engine_template`'s text-keyed cache -- but its **species names** are,
+        because they are the list a hand-written ``species_atol`` map is written against
+        (#586) and this load is already paid for. Checking the map here is what makes an
+        unknown species name an error at config load, where the conf author is, rather
+        than a silent no-op discovered from a trajectory.
+        """
         try:
-            self._load_bngsim_model_from_path(self.abs_file_path)
+            engine = self._load_bngsim_model_from_path(self.abs_file_path)
         except FileNotFoundError:
             raise
         except Exception as exc:
             raise ModelError(parse_error_message) from exc
+        self._engine_species_names = tuple(getattr(engine, 'species_names', None) or ())
+        self._check_stated_species_atol()
+
+    def _check_stated_species_atol(self):
+        """Refuse a ``species_atol`` naming a species this model does not integrate (#586).
+
+        The list checked against is the **engine** model's, not the SBML document's, and
+        the two really do differ: bngsim renames an id that collides with an Antimony
+        reserved word (``Smith_BMCSystBiol2013``'s ``NULL``/``null`` load as
+        ``_ant_NULL``/``_ant_null``) and promotes to a state every parameter or compartment
+        a rate rule or an event assignment drives, which the ``<listOfSpecies>`` does not
+        mention at all. Engine names are what a per-species vector is ordered by, so they
+        are the only list that can be both checked and applied; validating against document
+        ids would accept a name that then silently did nothing, which is the failure this
+        whole line of work exists to stop making.
+
+        The message names the species the model does have, because a name that reads wrong
+        is usually one of them spelled differently -- and it says so outright for the
+        ``_ant_`` case, which is the one a conf author cannot guess from their own file.
+        """
+        stated = getattr(self, '_config_species_atol', None)
+        names = getattr(self, '_engine_species_names', None)
+        if not stated or not names:
+            return
+        known = set(names)
+        unknown = [name for name in stated if name not in known]
+        if not unknown:
+            return
+        hints = [f"'{n}' (bngsim renames an id that collides with an Antimony reserved "
+                 f"word, so state it as '_ant_{n}')"
+                 for n in unknown if f'_ant_{n}' in known]
+        shown = list(names[:12]) + (['...'] if len(names) > 12 else [])
+        message = (
+            f'species_atol for model {self.name} names {len(unknown)} species this model '
+            f'does not integrate: {", ".join(sorted(unknown))}. It integrates '
+            f'{len(names)}: {", ".join(shown)}.')
+        if hints:
+            message += ' ' + ' '.join(hints) + '.'
+        raise ModelError(message)
 
     def copy_with_param_set(self, pset):
         newmodel = copy.deepcopy(self)
@@ -1943,16 +2066,86 @@ class BngsimSbmlModelNoTimeout(Model):
         than at the first ``run()`` -- which on a fit is a long way from where the vector
         was built. Memoized against the ordering it was built for, so a later action with
         a different species list rebuilds rather than silently reusing.
+
+        **A hand-written ``species_atol`` (#586) reaches none of those routes to ``None``.**
+        Every one of them says "nothing was stated here that a scalar does not already
+        cover", which is exactly what a map on the ``model:`` line is not: the species it
+        names take the number stated, and the ones it does not keep whatever the
+        derivation, a pinned scalar, or the backend default would have given them. So the
+        map is an override *layer* over that base rather than a fourth way to build it,
+        and the base is computed here exactly as it is for a model that states nothing --
+        except that a pinned ``sbml_atol`` still switches the derivation off, so its base
+        is that number broadcast rather than a vector derived around it.
         """
-        if not BNGSIM_HAS_PER_SPECIES_ATOL or getattr(self, '_config_atol', None) is not None:
+        stated = getattr(self, '_config_species_atol', None)
+        pinned = getattr(self, '_config_atol', None)
+        if not BNGSIM_HAS_PER_SPECIES_ATOL:
+            # Unreachable with a stated map: the constructor refuses that outright rather
+            # than degrading to the scalar (:meth:`_init_common_attrs`).
+            return None
+        if pinned is not None and not stated:
             return None
         names = tuple(getattr(engine_model, 'species_names', None) or ())
         cached = getattr(self, '_atol_vector_cache', None)
         if cached is not None and cached[0] == names:
             return cached[1]
-        vector = self._derive_per_species_atol(sim, names)
+        base = None if pinned is not None else self._derive_per_species_atol(sim, names)
+        vector = self._apply_stated_per_species_atol(sim, names, base) if stated else base
         self._atol_vector_cache = (names, vector)
         return vector
+
+    def _apply_stated_per_species_atol(self, sim, names, base):
+        """Lay a hand-written ``species_atol`` over the vector this model would have had (#586).
+
+        ``base`` is the derived vector when there is one and ``None`` when there is not --
+        a model whose species share one scale, an ordering the derivation could not take,
+        or a pinned ``sbml_atol``. ``None`` becomes the model's scalar broadcast over every
+        species, which is the tolerance those species are integrated at today, so the map
+        moves exactly the species it names and nothing else.
+
+        **A stated entry is used verbatim.** Neither clamp applies to it: not ADR-0103's
+        only-ever-tighten ceiling, which ADR-0114 established is a no-regression rule about
+        the *derivation* rather than a property of the model, and not ADR-0105's
+        model-scalar floor, which is a statement about how far a derivation read off
+        *initial values* may reach for on its own. A number a person wrote is neither of
+        those; it is the same kind of statement a pinned ``sbml_atol`` is, and it wins for
+        the same reason. The one bound kept is ``parse_species_atol_setting``'s: finite and
+        strictly positive, which is CVODE's own requirement.
+
+        Nor does the "elementwise the scalar, so send the scalar" off-ramp apply. That
+        exists so a model with no over-tightening to give back keeps its ``CVodeSStolerances``
+        call byte for byte (19 of 23 subset-I slugs), and it is correct precisely because
+        nobody asked for a vector. Here somebody did, so a map whose entries happen to
+        agree with the scalar still travels as a vector, and pays #196's ~1 ulp
+        ``cvEwtSetSS``/``cvEwtSetSV`` difference for having been stated.
+        """
+        stated = self._config_species_atol
+        if not names:
+            raise ModelError(
+                f'species_atol was stated for model {self.name}, but bngsim reports no '
+                'species to order it against.')
+        unknown = sorted(name for name in stated if name not in set(names))
+        if unknown:
+            # The constructor already checked this against the engine model it loaded, so
+            # reaching here means the action's engine model carries a different species
+            # list. Raised rather than warned-and-dropped: the config author stated these.
+            raise ModelError(
+                f'species_atol for model {self.name} names {len(unknown)} species this '
+                f'action does not integrate: {", ".join(unknown)}.')
+        _, scalar_atol = self._effective_tolerances(sim)
+        derived = base is not None
+        if not derived:
+            base = [scalar_atol] * len(names)
+        vector = [stated.get(name, atol) for name, atol in zip(names, base)]
+        logger.debug(
+            'bngsim SBML model %s: species_atol states %d of %d species by hand (%s); the '
+            'rest keep the %s. Range [%g, %g], steady-state cutoff %g.',
+            getattr(self, 'name', None), len(stated), len(names),
+            ', '.join(f'{n}={stated[n]:g}' for n in sorted(stated)),
+            'tolerance the derivation gives them' if derived else 'model-wide scalar',
+            min(vector), max(vector), scalar_atol)
+        return bngsim.normalize_atol_vector(
+            vector, len(names), names, where='the per-model species_atol')
 
     def _derive_per_species_atol(self, sim, names):
         """Build (and validate, and log) the vector :meth:`_per_species_atol` memoizes.
@@ -1983,10 +2176,14 @@ class BngsimSbmlModelNoTimeout(Model):
             # ``_ant_NULL``/``_ant_null``.
             logger.warning(
                 'bngsim SBML model %s: the engine model integrates %d species the SBML '
-                'document does not declare under those names (%s), so the per-species '
-                'absolute tolerance cannot be ordered against the state without guessing; '
-                'integrating at the scalar tolerance instead.',
-                model_name, len(missing), ', '.join(sorted(missing)[:4]))
+                'document does not declare under those names (%s), so the DERIVED '
+                'per-species absolute tolerance cannot be ordered against the state '
+                'without guessing; %s.',
+                model_name, len(missing), ', '.join(sorted(missing)[:4]),
+                'the species named by species_atol still take the tolerances stated for '
+                'them, and every other species integrates at the scalar'
+                if getattr(self, '_config_species_atol', None)
+                else 'integrating at the scalar tolerance instead')
             return None
         vector = [by_species[name] for name in names]
         moved = sum(1 for atol in vector if atol != scalar_atol)

--- a/pybnf/config.py
+++ b/pybnf/config.py
@@ -14,11 +14,13 @@ from pydantic import ValidationError
 from .pset import BNGLModel, ModelError, SbmlModel, SbmlModelNoTimeout, FreeParameter, TimeCourse, ParamScan, \
     Mutation, MutationSet
 from .bngsim_sbml_model import (
+    BNGSIM_HAS_PER_SPECIES_ATOL,
     BNGSIM_HAS_SBML,
     BNGSIM_HAS_TRACKING_ATOL,
     BNGSIM_SBML_ERROR,
     BngsimSbmlModelNoTimeout,
     parse_atol_setting,
+    parse_species_atol_setting,
 )
 from .bngsim_antimony_model import (
     BNGSIM_HAS_ANTIMONY,
@@ -553,9 +555,16 @@ class Configuration:
         Mutates ``d``.
         """
         declared = d.pop('model', None)
-        if declared:
+        # A per-model tolerance record (#586) can only ride a ``model:`` line, so the
+        # marker above already gates it; named here too so the gate does not depend on that
+        # coincidence, and so the error says which syntax was refused.
+        stated_tolerances = any(isinstance(k, tuple) and k[0] == 'model_tolerances' for k in d)
+        if declared or stated_tolerances:
             ed = edition.resolve_edition(d.get('edition'))
-            edition.require_edition(ed, 2, "the 'model:' declaration syntax")
+            edition.require_edition(
+                ed, 2,
+                "the 'model:' declaration syntax" if declared else
+                "the 'model:' line's per-model solver tolerances")
 
     @staticmethod
     def _resolve_run_selector(d):
@@ -755,6 +764,115 @@ class Configuration:
         
                 
 
+    def _resolve_model_tolerances(self):
+        """The per-model CVODE tolerance records, checked and keyed by model file (#586).
+
+        The new-era ``model:`` declaration carries this model's own ``atol:`` / ``rtol:`` /
+        ``species_atol:`` (ADR-0116), parsed into ``('model_tolerances', <file>)`` structural
+        keys. ``sbml_atol`` and ``sbml_rtol`` remain the fit-wide defaults; a record
+        overrides them for the one model it names, field by field, so a job can state one
+        model's tolerance without saying anything about the others -- which is the whole of
+        what one global key could not do, and the reason a hand-written per-species vector
+        had no unambiguous reading until now.
+
+        Everything checkable without the model is checked here, at config load, before any
+        model is built:
+
+        * the record names a model this job actually declares;
+        * that model is one with a CVODE tolerance to state -- an ``.xml``/``.ant`` model on
+          ``sbml_backend = bngsim``, integrated by CVODE rather than by Gillespie. A
+          ``.bngl`` model takes ``atol``/``rtol`` from its own ``begin actions`` block, the
+          RoadRunner backend has its own integrator settings, and
+          ``sbml_integrator = gillespie`` makes every action of every model stochastic
+          (``_resolve_method``), where a run carries no tolerances at all -- so accepting
+          the record in any of the three would silently do nothing;
+        * the values have a legal shape, through the same ``parse_atol_setting`` /
+          ``parse_species_atol_setting`` the model constructor uses, so the two cannot
+          disagree about what a value means;
+        * the backend can carry what was asked for (``tracking``, a per-species vector).
+
+        What is *not* checked here is the one thing that needs the model: whether a
+        ``species_atol`` names species this model has. That is checked in the constructor,
+        against the species list bngsim will integrate under, and still at config load --
+        ``_load_models`` runs before the fit starts.
+        """
+        records = {key[1]: value for key, value in self.config.items()
+                   if isinstance(key, tuple) and key[0] == 'model_tolerances'}
+        if not records:
+            return {}
+        backend = self.config.get('sbml_backend')
+        resolved = {}
+        if not BNGSIM_HAS_SBML:
+            # Ahead of the capability probes below, which would otherwise report a specific
+            # missing bngsim API to somebody who has no bngsim at all. This is the same
+            # message ``_load_models`` gives that job one step later.
+            raise PybnfError(
+                f'sbml_backend = bngsim was requested, but {BNGSIM_SBML_ERROR}.')
+        declared = self.config.get('models') or ()
+        for mf, record in records.items():
+            if mf not in declared:
+                raise PybnfError(
+                    f"Solver tolerances were stated for model '{mf}', which this job does "
+                    'not declare. State them on that model\'s own `model:` line.')
+            if not re.search(r'\.(xml|ant)$', mf):
+                raise PybnfError(
+                    f"Model '{mf}' cannot take the `model:` line's solver tolerances "
+                    f'({", ".join(sorted(record))}): they are CVODE settings, and only an '
+                    'SBML (.xml) or Antimony (.ant) model on sbml_backend = bngsim uses '
+                    'them. A BNGL model states atol/rtol in its own begin actions block.')
+            if backend != 'bngsim':
+                raise PybnfError(
+                    f"Model '{mf}' states solver tolerances "
+                    f'({", ".join(sorted(record))}) on its `model:` line, which is only '
+                    f'supported when sbml_backend = bngsim. Current sbml_backend is '
+                    f'"{backend}".')
+            if self.config.get('sbml_integrator') == 'gillespie':
+                # A stochastic run has no CVODE tolerances to set -- BngsimSbmlModel's
+                # _resolve_method returns 'ssa' for every action under this integrator, and
+                # a stochastic run's kwargs carry neither rtol nor atol. Refused for the
+                # same reason a .bngl model and the RoadRunner backend are: a tolerance
+                # accepted and then not applied is the failure this surface exists to stop.
+                raise PybnfError(
+                    f"Model '{mf}' states solver tolerances "
+                    f'({", ".join(sorted(record))}) on its `model:` line, but '
+                    'sbml_integrator = gillespie runs every action stochastically, and a '
+                    'stochastic run has no CVODE tolerances to set.',
+                    'Use sbml_integrator = cvode, or drop the tolerance fields.')
+            own = {}
+            if 'rtol' in record:
+                if not np.isfinite(record['rtol']) or record['rtol'] <= 0.:
+                    raise PybnfError(
+                        f"Model '{mf}': `rtol:` must be a finite positive number; got "
+                        f"{record['rtol']}.")
+                own['rtol'] = record['rtol']
+            if 'atol' in record:
+                try:
+                    _, atol_mode, _ = parse_atol_setting(record['atol'])
+                except ValueError as exc:
+                    raise PybnfError(f"Model '{mf}': `atol:` {exc}") from exc
+                if atol_mode == 'tracking' and not BNGSIM_HAS_TRACKING_ATOL:
+                    raise PybnfError(
+                        f"Model '{mf}': `atol: tracking` needs a bngsim whose "
+                        'Simulator.run takes a trajectory-following absolute tolerance '
+                        '(lanl/bngsim#213, bngsim.TrackingAtol); this build does not have '
+                        'one.',
+                        'Upgrade bngsim, or state a number (or "auto") instead.')
+                own['atol'] = record['atol']
+            if 'species_atol' in record:
+                try:
+                    species_atol = parse_species_atol_setting(record['species_atol'])
+                except ValueError as exc:
+                    raise PybnfError(f"Model '{mf}': `species_atol:` {exc}") from exc
+                if species_atol and not BNGSIM_HAS_PER_SPECIES_ATOL:
+                    raise PybnfError(
+                        f"Model '{mf}': `species_atol:` needs a bngsim whose Simulator.run "
+                        'takes a per-species absolute tolerance (lanl/bngsim#196, '
+                        'bngsim.normalize_atol_vector); this build does not have one.',
+                        'Upgrade bngsim, or state one `atol:` number for the whole model.')
+                own['species_atol'] = species_atol
+            resolved[mf] = own
+        return resolved
+
     def _load_models(self):
         """
         Loads models specified in configuration file in a dictionary keyed on
@@ -789,6 +907,10 @@ class Configuration:
         # the model checker (``fit_type == 'check'``) suppresses it at every edition.
         modern = edition.is_modern(edition.resolve_edition(self.config.get('edition')))
 
+        # Per-model CVODE tolerances stated on the ``model:`` line (#586, ADR-0116),
+        # validated once here so a bad one is a config-load error naming the model file.
+        per_model_tol = self._resolve_model_tolerances()
+
         md = {}
         for mf in self.config['models']:
             # Initialize model type based on extension
@@ -812,14 +934,16 @@ class Configuration:
                         # bngsim now enforces wall_time_sim in-process via
                         # SimulationTimeout, so the subprocess wrapper is no
                         # longer needed for either zero or positive timeouts.
+                        own = per_model_tol.get(mf, {})
                         model = BngsimSbmlModelNoTimeout(
                             mf,
                             self._absolute(mf),
                             save_files=save_flag,
                             integrator=self.config['sbml_integrator'],
                             strict_ssa=strict_ssa,
-                            rtol=self.config.get('sbml_rtol'),
-                            atol=self.config.get('sbml_atol'),
+                            rtol=own.get('rtol', self.config.get('sbml_rtol')),
+                            atol=own.get('atol', self.config.get('sbml_atol')),
+                            species_atol=own.get('species_atol'),
                         )
                     elif self.config['wall_time_sim'] == 0:
                         model = SbmlModelNoTimeout(
@@ -845,14 +969,16 @@ class Configuration:
                     # bngsim now enforces wall_time_sim in-process via
                     # SimulationTimeout, so the subprocess wrapper is no
                     # longer needed for either zero or positive timeouts.
+                    own = per_model_tol.get(mf, {})
                     model = BngsimAntimonyModelNoTimeout(
                         mf,
                         self._absolute(mf),
                         save_files=save_flag,
                         integrator=self.config['sbml_integrator'],
                         strict_ssa=strict_ssa,
-                        rtol=self.config.get('sbml_rtol'),
-                        atol=self.config.get('sbml_atol'),
+                        rtol=own.get('rtol', self.config.get('sbml_rtol')),
+                        atol=own.get('atol', self.config.get('sbml_atol')),
+                        species_atol=own.get('species_atol'),
                     )
                 elif re.search(r'\.target$', mf):
                     from .analytical_model import AnalyticalModel
@@ -2540,8 +2666,13 @@ class Configuration:
                         'one.',
                         'Upgrade bngsim, or state a number (or "auto") instead.')
                 continue
-            if tol <= 0.:
-                raise PybnfError(f'Config option "{tol_key}" must be a positive number; got {tol}.')
+            # Finite as well as positive: the conf grammar's number token also matches
+            # ``inf`` (an open truncation side, ADR-0047), so ``sbml_rtol = inf`` parses to
+            # a float that clears a bare ``> 0`` and then reaches CVODE as a relative
+            # tolerance that turns error control off.
+            if not np.isfinite(tol) or tol <= 0.:
+                raise PybnfError(
+                    f'Config option "{tol_key}" must be a finite positive number; got {tol}.')
         # Check that the integrator is valid
         if self.config['sbml_backend'] == 'bngsim':
             bngsim_integrators = ('cvode', 'gillespie')

--- a/pybnf/parse.py
+++ b/pybnf/parse.py
@@ -255,7 +255,57 @@ def parse(s):
     # error-stopped (``-``). A parse action tags it ``model_decl`` so ploop can route
     # the colon form -- whose tokens are otherwise shaped like ``mdmgram``'s -- to the
     # declaration handler. Edition-gated (>= 2) in config.py.
-    model_decl_gram = mdmkey + colon - _DelimitedList(model_file) - comment
+    #
+    # The declaration also carries this model's own CVODE tolerances (#586, ADR-0116):
+    #   model: <file>[, atol: <num>|auto|tracking [<decades>]][, rtol: <num>]
+    #                [, species_atol: <species> <num>[, <species> <num>...]]
+    # ``sbml_atol``/``sbml_rtol`` are one global key each, applying to every SBML/Antimony
+    # model in the fit, which is why neither could ever take a per-species vector: a
+    # positional one has no ordering a conf author can see, and a species-keyed one has no
+    # reading across models that do not share species names. Scoping the statement to one
+    # declared model file answers both -- the names are checked against that model's own
+    # species list, and two models cannot collide. Each field is the usual labeled
+    # ``pp.Group(pp.Suppress(',') + <label> + colon + <value>)`` of the ``experiment:`` /
+    # ``condition:`` family, combined with ``pp.Each`` so they may appear in any order, and
+    # every one of them is optional. ``atol:`` takes exactly what ``sbml_atol`` takes (the
+    # mode alternative first, for parse_atol_setting's reason); ``species_atol:`` takes
+    # ``<name> <value>`` pairs, whose delimited list ends cleanly at the next labeled field
+    # because ``rtol: 1e-9`` fails the ``<name> <num>`` shape and backtracks out.
+    # A comma list of files is still legal and a field still ends it -- a ``model:`` line
+    # that carries fields must declare exactly ONE model, which ploop enforces with a
+    # pointed message rather than the grammar with a parse failure.
+    md_species = pp.Word(pp.alphas + '_', pp.alphanums + '_')
+    md_atol_value = (sbml_atol_mode + pp.Optional(num)) | num
+    md_atol_field = pp.Group(pp.Suppress(',') + pp.CaselessLiteral('atol') + colon - md_atol_value)
+    md_rtol_field = pp.Group(pp.Suppress(',') + pp.CaselessLiteral('rtol') + colon - num)
+    md_species_atol_field = pp.Group(
+        pp.Suppress(',') + pp.CaselessLiteral('species_atol') + colon
+        - _DelimitedList(pp.Group(md_species + num)))
+    md_tolerance_fields = (pp.Optional(md_atol_field) & pp.Optional(md_rtol_field)
+                           & pp.Optional(md_species_atol_field))
+    # The declaration's file token is the shared ``model_file`` regex behind a guard, and the
+    # guard exists because that regex is UNANCHORED and lazy: it will start mid-line and run
+    # across commas, colons, spaces and ``#`` to reach the next extension it can find.
+    # Harmless while a ``model:`` line was files-and-nothing-else, and not harmless once a
+    # comma can be followed by something that is not a file. Without it,
+    # ``model: decay.xml, atol: 1e-10  # tighter for decay.xml`` hands ``_DelimitedList`` the
+    # comma and lets the regex swallow the field, the comment and all, as a second "model
+    # file" named ``atol: 1e-10  # tighter for decay.xml`` -- and
+    # ``model: a.xml, atol: 1e-4, b.xml`` swallows ``b.xml`` the same way, walking straight
+    # past the one-model rule the field list is supposed to obey.
+    #
+    # A tolerance field label is never a filename, so the file list ends where the fields
+    # begin. The lookahead needs the label AND its colon, so a model genuinely named
+    # ``rtol.xml`` still parses. A file written *after* a field is then a plain parse error
+    # carrying the ``model`` format hint, which is where the line's legal shape is spelled
+    # out. Nothing else about the token is narrowed -- in particular ``#`` stays legal
+    # inside a filename, because the legacy ``model = ... : ...`` form still accepts it and
+    # two spellings of one declaration disagreeing about which files exist would be worse
+    # than the corner it would close.
+    md_field_label = _one_of('atol rtol species_atol', caseless=True)
+    model_decl_file = ~(md_field_label + pp.Literal(':')) + model_file
+    model_decl_gram = (mdmkey + colon - _DelimitedList(model_decl_file)
+                       + md_tolerance_fields - comment)
     model_decl_gram.set_parse_action(lambda t: ['model_decl'] + list(t)[1:])
 
     # normalization mapping grammar
@@ -650,6 +700,58 @@ def flatten(vs):
     return vs[0] if len(vs) == 1 else vs
 
 
+def _one_declared_model(files, fields):
+    """The single model a ``model:`` line's tolerance fields are about (#586).
+
+    A ``model:`` line may declare several files, and a tolerance field on such a line has
+    no reading: ``model: a.xml, b.xml, atol: 1e-4`` cannot say which model the ``1e-4`` is
+    a statement about, and the whole point of moving the tolerance off ``sbml_atol`` was to
+    stop a single number meaning several things at once (ADR-0116). Refused here rather
+    than in the grammar so the message can say what to do about it.
+    """
+    if len(files) == 1:
+        return files[0]
+    labels = ', '.join(sorted({str(f[0]).lower() for f in fields}))
+    raise PybnfError(
+        f'A `model:` line that states its own solver tolerances ({labels}) must declare '
+        f'exactly one model; this one declares {len(files)} ({", ".join(files)}). '
+        'Give each model its own `model:` line.')
+
+
+def _model_tolerance_record(fields):
+    """The ``('model_tolerances', <file>)`` payload of one ``model:`` line (#586).
+
+    ``atol`` is normalized exactly the way the global ``sbml_atol`` key is -- a number
+    becomes a float and a mode becomes one lower-cased string -- so the two reach
+    :func:`~pybnf.bngsim_sbml_model.parse_atol_setting`, the one authority on that value's
+    shape, in the same shape. ``species_atol`` becomes a plain ``{name: float}`` dict; the
+    names are not checked here, because the species list belongs to the model and the
+    model has not been loaded yet (config.py checks them, with a message that lists the
+    names the model actually has).
+    """
+    record = {}
+    for field in fields:
+        label = str(field[0]).lower()
+        if label == 'species_atol':
+            by_species = {}
+            for entry in field[1:]:
+                name, value = str(entry[0]), float(entry[1])
+                if name in by_species:
+                    raise PybnfError(
+                        f"Species '{name}' is given a species_atol more than once on one "
+                        '`model:` line.')
+                by_species[name] = value
+            record[label] = by_species
+        elif label == 'atol':
+            tokens = [str(t) for t in field[1:]]
+            record[label] = (float(tokens[0]) if _NUMERIC_VALUE.fullmatch(tokens[0])
+                             else ' '.join(tokens).lower())
+        else:
+            # ``rtol``, and any later single-number field the grammar adds.
+            record[label] = float(field[1])
+    return record
+
+
 def ploop(ls):  # parse loop
     d = {}
     models = set()
@@ -709,11 +811,25 @@ def ploop(ls):  # parse loop
                 # declared files in the structural 'model' marker so config.py can
                 # edition-gate the new syntax (>= edition 2). modelId = filename stem;
                 # stem-uniqueness is enforced when models load (Model.name).
-                for mf in l[1:]:
+                #
+                # The line's optional tolerance fields (#586) arrive as pp.Groups, i.e. as
+                # LISTS among the plain-string filenames, so the two are separated by type
+                # rather than by position -- pp.Each puts the fields in whatever order the
+                # author wrote them.
+                files = [x for x in l[1:] if isinstance(x, str)]
+                fields = [x for x in l[1:] if not isinstance(x, str)]
+                for mf in files:
                     if mf not in d:
                         d[mf] = []
                     models.add(mf)
-                d.setdefault('model', []).extend(l[1:])
+                d.setdefault('model', []).extend(files)
+                if fields:
+                    tol_key = ('model_tolerances', _one_declared_model(files, fields))
+                    if tol_key in d:
+                        raise PybnfError(
+                            f"Model '{tol_key[1]}' is given solver tolerances more than once. "
+                            'Put every tolerance field for one model on one `model:` line.')
+                    d[tol_key] = _model_tolerance_record(fields)
             elif l[0] in dictkeys:
                 # Multiple declarations allowed; config dict entry should contain a list of all the declarations.
                 # Convert the line into a dict of key-value pairs. Keep everything as strings, check later
@@ -1043,6 +1159,11 @@ def ploop(ls):  # parse loop
                 fmt = "'model=modelfile.bngl : datafile.exp' or 'model=modelfile.bngl : datafile1.exp, datafile2.exp'" \
                       " (legacy), or the new-era declaration 'model: modelfile.bngl' or " \
                       "'model: modelfile1.bngl, modelfile2.bngl' (requires edition >= 2)." \
+                      " A single-model declaration may also state that model's own CVODE" \
+                      " tolerances in any order: 'atol: <number>|auto|tracking [decades]'," \
+                      " 'rtol: <number>', and 'species_atol: <species> <number>[, <species>" \
+                      " <number>...]' -- e.g. 'model: weber.xml, atol: auto, species_atol:" \
+                      " PKD 1e-3, CERT 1e-2' (bngsim SBML/Antimony models only)." \
                       " Supported modelfile extensions are .bngl, .xml, .ant, and .target"
             elif key == 'normalization':
                 fmt = f"'{key}=s' or '{key}=s : datafile1.exp, datafile2.exp' where s is a string ('init', 'peak', " \

--- a/tests/test_bngsim_antimony_bridge.py
+++ b/tests/test_bngsim_antimony_bridge.py
@@ -272,3 +272,88 @@ def test_bngsim_antimony_mutants_modify_parameters(tmp_path):
 
     expected = 10.0 * math.exp(-0.6 * 10.0)
     assert abs(dat['S'][-1] - expected) < 1e-4
+
+
+# --- #586: a per-model tolerance record reaches the Antimony backend too --------- #
+#
+# The Antimony path shares every line of the SBML backend's tolerance code (it subclasses
+# it and overrides only the loader), so this is not a second implementation. It is here
+# because Antimony is where the one thing a conf author cannot see happens: bngsim renames
+# a species id that collides with an Antimony reserved word, so a ``species_atol`` written
+# from the model file names something the engine does not carry.
+
+_ANTIMONY_RESERVED_NAME_MODEL_TEXT = """model reserved_decay()
+  species NULL, S;
+  k = 0.3;
+  J0: S -> NULL; k*S;
+  S = 10;
+  NULL = 0.5;
+end
+"""
+
+
+def _antimony_model(tmp_path, text=_ANTIMONY_MODEL_TEXT, name='test_decay.ant', **kwargs):
+    path = tmp_path / name
+    path.write_text(text)
+    return bngsim_antimony_model.BngsimAntimonyModelNoTimeout(
+        str(path), str(path), **kwargs)
+
+
+@pytest.mark.bngsim_antimony
+def test_an_antimony_model_takes_its_own_per_species_tolerance(tmp_path):
+    """The same record, the same seam, ordered against the same engine species list."""
+    model = _antimony_model(tmp_path, species_atol={'S': 1e-3})
+    engine = model._engine_model_for_action()
+    kwargs = model._run_tolerance_kwargs(model._make_simulator(engine, 'ode'), engine)
+
+    assert dict(zip(engine.species_names, kwargs['atol']))['S'] == 1e-3
+    assert 'steady_state_tol' in kwargs
+
+
+@pytest.mark.bngsim_antimony
+def test_an_antimony_reserved_word_species_is_named_by_the_name_bngsim_gives_it(tmp_path):
+    """``NULL`` in the model file is ``_ant_NULL`` in the state vector, and says so.
+
+    This is the case that decides which of the two candidate name spaces a hand-written
+    map is written in. The SBML document's ids would let a person write what they see and
+    then silently do nothing; the engine's names are the ones a per-species vector is
+    ordered by, so they are the only list that can be both checked and applied -- and the
+    refusal spells out the rename rather than leaving it to be discovered.
+    """
+    with pytest.raises(pset.ModelError, match='_ant_NULL'):
+        _antimony_model(tmp_path, text=_ANTIMONY_RESERVED_NAME_MODEL_TEXT,
+                        name='reserved_decay.ant', species_atol={'NULL': 1e-3})
+
+    model = _antimony_model(tmp_path, text=_ANTIMONY_RESERVED_NAME_MODEL_TEXT,
+                            name='reserved_decay.ant', species_atol={'_ant_NULL': 1e-3})
+    engine = model._engine_model_for_action()
+    kwargs = model._run_tolerance_kwargs(model._make_simulator(engine, 'ode'), engine)
+
+    assert dict(zip(engine.species_names, kwargs['atol']))['_ant_NULL'] == 1e-3
+
+
+@pytest.mark.bngsim_antimony
+def test_a_promoted_state_is_nameable_even_though_the_document_never_declares_it(tmp_path):
+    """A rate rule on a parameter appends a state the ``<listOfSpecies>`` does not mention.
+
+    Nothing read off the document can give that state a tolerance -- it has no declared
+    initial value to derive one from and no id in the species list to key one on -- so this
+    is a tolerance only a hand-written entry can reach at all.
+    """
+    text = """model promoted()
+  species A, B;
+  growth = 0.05;
+  J0: A -> B; growth*A;
+  A = 10; B = 0;
+  growth' = 0.01*growth;
+end
+"""
+    model = _antimony_model(tmp_path, text=text, name='promoted.ant',
+                            species_atol={'growth': 1e-9})
+
+    assert 'growth' not in model.species_names
+    assert model._engine_species_names == ('A', 'B', 'growth')
+
+    engine = model._engine_model_for_action()
+    kwargs = model._run_tolerance_kwargs(model._make_simulator(engine, 'ode'), engine)
+    assert dict(zip(engine.species_names, kwargs['atol']))['growth'] == 1e-9

--- a/tests/test_sbml_solver_tolerances.py
+++ b/tests/test_sbml_solver_tolerances.py
@@ -307,19 +307,22 @@ def _write(tmp_path, text, name):
 
 
 def _piecewise_model(tmp_path, *, text=_PIECEWISE_SBML, name='pw.xml', rtol=None, atol=None,
-                     extra=()):
+                     species_atol=None, extra=()):
     """A :class:`BngsimSbmlModelNoTimeout` over the piecewise fixture.
 
     ``extra`` adds ``(name, value)`` free parameters to the fit point, which is how the
     tests that move a species' *initial condition* are written -- a species id is a
     fittable name here, exactly as it is on a PEtab problem that estimates one.
+    ``species_atol`` carries the hand-written per-species map a new-era ``model:``
+    declaration states (#586); ``None`` is every model that states nothing.
     """
     xml = _write(tmp_path, text, name)
     ps = PSet([FreeParameter(p, 'uniform_var', 1e-9, 10., value=v)
                for p, v in (('k0', K0), ('k1', K1), ('k2', K2)) + tuple(extra)])
     action = TimeCourse({'time': str(T_END), 'step': str(T_END / N_STEPS)})
     return bngsim_sbml_model.BngsimSbmlModelNoTimeout(
-        xml, xml, pset=ps, actions=(action,), rtol=rtol, atol=atol)
+        xml, xml, pset=ps, actions=(action,), rtol=rtol, atol=atol,
+        species_atol=species_atol)
 
 
 def _tolerance_kwargs(model):
@@ -1412,11 +1415,28 @@ def test_config_accepts_the_modes_under_the_bngsim_backend(value):
         _tolerance_config(value, backend='roadrunner')._load_simulators()
 
 
-@pytest.mark.parametrize('value', ['nonsense', 'tracking -1', 0, -1])
+@pytest.mark.parametrize('value', ['nonsense', 'tracking -1', 0, -1, float('inf')])
 def test_config_refuses_a_setting_that_is_not_a_tolerance(value):
     """Refused at config load rather than as a ModelError once the run has started."""
     with pytest.raises(PybnfError, match='sbml_atol'):
         _tolerance_config(value)._load_simulators()
+
+
+@pytest.mark.parametrize('value', [0.0, -1.0, float('inf'), float('nan')])
+def test_config_refuses_an_rtol_that_is_not_a_relative_tolerance(value):
+    """Finite as well as positive, which a bare ``> 0`` check did not catch.
+
+    The conf grammar's number token also matches ``inf`` (ADR-0047's open truncation side),
+    so ``sbml_rtol = inf`` parsed to a float that cleared the old check and reached CVODE as
+    a relative tolerance with error control effectively off. ``sbml_atol`` never had the
+    hole -- ``parse_atol_setting`` has always demanded finiteness -- so this closes the one
+    key that did, alongside the per-model ``rtol:`` that would otherwise have inherited it.
+    """
+    cfg = _tolerance_config(None)
+    cfg.config['sbml_rtol'] = value
+
+    with pytest.raises(PybnfError, match='sbml_rtol'):
+        cfg._load_simulators()
 
 
 def test_config_refuses_tracking_without_the_backend_capability(monkeypatch):
@@ -1425,3 +1445,648 @@ def test_config_refuses_tracking_without_the_backend_capability(monkeypatch):
 
     with pytest.raises(PybnfError, match='lanl/bngsim#213'):
         _tolerance_config('tracking')._load_simulators()
+
+
+# --- #586: the tolerance is a statement about ONE model, not about the fit -------- #
+#
+# ``sbml_atol`` and ``sbml_rtol`` are one global key each, applying to every SBML/Antimony
+# model in a fit, and that is why neither could ever take a hand-written per-species
+# vector: a positional one is ordered against a species list a conf author cannot see, and
+# a species-keyed one has no reading across models that do not share species names. Both
+# problems are about the *key*, so ADR-0116 moves the statement onto the new-era ``model:``
+# declaration, where it names one model file:
+#
+#     model: weber.xml, atol: auto, species_atol: PKD 1e-3, CERT 1e-2, rtol: 1e-9
+#
+# ``atol:`` / ``rtol:`` are the per-model form of the two global keys and override them for
+# that model alone; ``species_atol:`` is the vector, laid over whatever the derivation, a
+# pinned number, or the backend default would have given each species.
+
+_needs_per_species_atol_ctor = pytest.mark.skipif(
+    not BNGSIM_HAS_PER_SPECIES_ATOL,
+    reason='the model constructor refuses a species_atol without lanl/bngsim#196')
+
+
+def _model_tolerance_dict(text):
+    """The ``{model file: record}`` a conf snippet's ``model:`` lines parse to."""
+    from pybnf import parse
+
+    d = parse.ploop([line + '\n' for line in text.splitlines()])
+    return {k[1]: v for k, v in d.items()
+            if isinstance(k, tuple) and k[0] == 'model_tolerances'}
+
+
+@pytest.mark.parametrize('line, mf, expected', [
+    ('model: m.xml, atol: 1e-4', 'm.xml', {'atol': 1e-4}),
+    ('model: m.xml, atol: auto', 'm.xml', {'atol': 'auto'}),
+    ('model: m.xml, atol: tracking', 'm.xml', {'atol': 'tracking'}),
+    ('model: m.xml, atol: tracking 6', 'm.xml', {'atol': 'tracking 6'}),
+    ('model: m.xml, rtol: 1e-10', 'm.xml', {'rtol': 1e-10}),
+    ('model: sub/dir/m.ant, species_atol: PKD 1e-3, CERT 1e-2', 'sub/dir/m.ant',
+     {'species_atol': {'PKD': 1e-3, 'CERT': 1e-2}}),
+    ('model: m.xml, species_atol: _ant_NULL 1e-3', 'm.xml',
+     {'species_atol': {'_ant_NULL': 1e-3}}),
+    ('model: m.xml, atol: auto, species_atol: A 1e-3, rtol: 1e-9', 'm.xml',
+     {'atol': 'auto', 'species_atol': {'A': 1e-3}, 'rtol': 1e-9}),
+    ('MODEL: m.xml, ATOL: AUTO', 'm.xml', {'atol': 'auto'}),
+    ('model: m.xml, atol: 1e-4  # a comment', 'm.xml', {'atol': 1e-4}),
+])
+def test_the_model_line_states_one_models_own_tolerances(line, mf, expected):
+    """Every spelling the declaration takes, and what it parses to (#586).
+
+    ``atol:`` is normalized exactly as ``sbml_atol`` is -- a number to a float, a mode to
+    one lower-cased string -- so both reach ``parse_atol_setting``, the one authority on
+    that value's shape, in the same shape.
+    """
+    assert _model_tolerance_dict(line) == {mf: expected}
+
+
+def test_the_tolerance_fields_are_order_independent():
+    """``pp.Each``, like every other labeled-field record in the new era."""
+    one = _model_tolerance_dict('model: m.xml, atol: auto, rtol: 1e-9, species_atol: A 1')
+    two = _model_tolerance_dict('model: m.xml, species_atol: A 1, rtol: 1e-9, atol: auto')
+    assert one == two == {'m.xml': {'atol': 'auto', 'rtol': 1e-9, 'species_atol': {'A': 1.0}}}
+
+
+@pytest.mark.parametrize('text', [
+    'model: egfr.bngl',
+    'model: egfr.bngl, erbb2.bngl',
+    'model = egfr.bngl : d.exp',
+    'model = egfr.bngl : none',
+])
+def test_a_declaration_that_states_no_tolerance_is_unchanged(text):
+    """The fields are optional, and the legacy ``model =`` line still backtracks to it.
+
+    ``mdmkey + colon`` is a non-error-stop ``+`` precisely so ``model = f : d.exp`` can
+    fall through to the legacy grammar; adding optional fields after the file list must
+    not disturb that, and this is the assertion that says so.
+    """
+    from pybnf import parse
+
+    assert _model_tolerance_dict(text) == {}
+    assert parse.parse(text)[0] in ('model', 'model_decl')
+
+
+@pytest.mark.parametrize('line, expected_files', [
+    # The file regex is unanchored and lazy, so before the guard it crossed the comma
+    # before a field and ran to the next extension it could find -- here, one inside the
+    # COMMENT -- producing a second "model file" named `atol: 1e-10  # ... decay.xml`.
+    ('model: decay.xml, atol: 1e-10  # tighter than the default for decay.xml',
+     ['decay.xml']),
+    ('model: a.xml, species_atol: A 1e-3, B 1e-2  # compare against b.xml', ['a.xml']),
+    # ...and a model genuinely named after a field label still parses, because the
+    # lookahead needs the label AND its colon.
+    ('model: rtol.xml, atol: 1e-4', ['rtol.xml']),
+    ('model: a.xml, rtol.xml', ['a.xml', 'rtol.xml']),
+])
+def test_a_tolerance_field_is_never_read_as_a_model_filename(line, expected_files):
+    """A comment mentioning a model file must not be absorbed into the file list (#586)."""
+    from pybnf import parse
+
+    tokens = parse.parse(line)
+    assert [t for t in tokens[1:] if isinstance(t, str)] == expected_files
+
+
+def test_a_model_file_written_after_a_tolerance_field_is_a_parse_error():
+    """Rather than the field being swallowed as a filename and the model silently added.
+
+    The refusal is the ``model`` format hint, which spells out the whole legal shape of the
+    line; what matters is that no bogus model reaches the models set.
+    """
+    from pybnf import parse
+
+    with pytest.raises(PybnfError) as exc:
+        parse.ploop(['model: a.xml, atol: 1e-4, b.xml\n'])
+    assert 'species_atol' in str(exc.value)
+
+
+def test_a_multi_model_declaration_cannot_state_a_tolerance():
+    """The whole point was to stop one number meaning several things at once."""
+    with pytest.raises(PybnfError, match='exactly one model'):
+        _model_tolerance_dict('model: a.xml, b.xml, atol: 1e-4')
+
+
+def test_a_model_is_given_its_tolerances_once():
+    """Two ``model:`` lines for one file would leave the second silently winning."""
+    with pytest.raises(PybnfError, match='more than once'):
+        _model_tolerance_dict('model: a.xml, atol: 1e-4\nmodel: a.xml, rtol: 1e-9')
+
+
+def test_a_species_is_given_its_tolerance_once():
+    with pytest.raises(PybnfError, match="Species 'A'.*more than once"):
+        _model_tolerance_dict('model: a.xml, species_atol: A 1e-3, A 1e-4')
+
+
+def test_the_model_format_hint_names_the_tolerance_fields():
+    """A mistyped field reports what the line takes rather than a bare parse failure."""
+    from pybnf import parse
+
+    with pytest.raises(PybnfError) as exc:
+        parse.ploop(['model: a.xml, bogus: 3\n'])
+    message = str(exc.value)
+    assert 'species_atol' in message and 'atol:' in message and 'rtol:' in message
+
+
+# --- the shape authority, shared by config.py and the model constructor ---------- #
+@pytest.mark.parametrize('value, expected', [
+    (None, None),
+    ({}, None),
+    ({'A': 1e-3}, {'A': 1e-3}),
+    ({'A': 1}, {'A': 1.0}),
+    ({'A': 1e-3, 'B': 2e-2}, {'A': 1e-3, 'B': 2e-2}),
+    ({'A': '1e-3'}, {'A': 1e-3}),
+])
+def test_parse_species_atol_setting_reads_a_map(value, expected):
+    """``{name: float}`` or ``None``; an empty map states nothing, like an absent one."""
+    from pybnf.bngsim_sbml_model import parse_species_atol_setting
+
+    assert parse_species_atol_setting(value) == expected
+
+
+@pytest.mark.parametrize('value', [
+    {'A': 0},        # legal in a bare CVodeSVtolerances vector, refused as a ceiling
+    {'A': -1e-3},
+    {'A': float('nan')},
+    {'A': float('inf')},
+    {'A': True},
+    {'A': 'auto'},
+    [('A', 1e-3)],
+])
+def test_parse_species_atol_setting_refuses_what_is_not_a_tolerance(value):
+    """Strictly positive, so one rule holds under ``tracking`` too.
+
+    bngsim accepts ``0`` in a plain per-species vector and refuses it outright as a
+    ``TrackingAtol`` ceiling. Accepting it here would make ``species_atol: X 0`` parse,
+    integrate, and then fail the moment the same model added ``atol: tracking`` -- so the
+    stricter of the two rules is the one taken, and it is taken everywhere.
+    """
+    from pybnf.bngsim_sbml_model import parse_species_atol_setting
+
+    with pytest.raises(ValueError):
+        parse_species_atol_setting(value)
+
+
+# --- the vector a person writes ------------------------------------------------- #
+@_needs_per_species_atol
+def test_a_stated_species_tolerance_reaches_the_run_call_by_name(tmp_path):
+    """Ordered against the ENGINE species list, asserted by name rather than by position.
+
+    A mis-ordered vector assigns one species' tolerance to another and every entry is a
+    plausible tolerance, so nothing downstream would say so -- which is why the ordering
+    is asserted here the way the derived vector's is.
+    """
+    model = _piecewise_model(tmp_path, text=_TWO_SCALE_SBML, name='pw_stated.xml',
+                             species_atol={'Big': 1e-2})
+    engine, kwargs = _tolerance_kwargs(model)
+
+    assert dict(zip(engine.species_names, kwargs['atol'])) == pytest.approx(
+        {'X': _TWO_SCALE_SCALAR, 'Big': 1e-2})
+
+
+@_needs_per_species_atol
+def test_the_species_a_map_does_not_name_keep_what_they_would_have_had(tmp_path):
+    """The map is an override layer, not a replacement for the derivation.
+
+    Under ``atol: auto`` the large-spread fixture derives ``{X: 1e-1, Mid: 1e-4,
+    Tiny: 1e-4}``; naming ``Tiny`` alone moves ``Tiny`` alone.
+    """
+    derived = _piecewise_model(tmp_path, text=_LARGE_SPREAD_SBML, name='pw_base.xml',
+                               atol='auto')
+    _, base_kwargs = _tolerance_kwargs(derived)
+
+    model = _piecewise_model(tmp_path, text=_LARGE_SPREAD_SBML, name='pw_layer.xml',
+                             atol='auto', species_atol={'Tiny': 1e-12})
+    engine, kwargs = _tolerance_kwargs(model)
+
+    by_name = dict(zip(engine.species_names, kwargs['atol']))
+    base_by_name = dict(zip(engine.species_names, base_kwargs['atol']))
+    assert by_name['Tiny'] == 1e-12
+    assert {k: v for k, v in by_name.items() if k != 'Tiny'} == pytest.approx(
+        {k: v for k, v in base_by_name.items() if k != 'Tiny'})
+
+
+@_needs_per_species_atol
+@pytest.mark.parametrize('stated', [1e-2, 1e-20])
+def test_a_stated_entry_is_bound_by_neither_clamp(tmp_path, stated):
+    """A number a person wrote is a statement, so the derivation's clamps do not touch it.
+
+    The upper one is ADR-0103's only-ever-tighten ceiling, which ADR-0114 established is a
+    no-regression rule about the derivation rather than a property of the model; the lower
+    one is ADR-0105's model-scalar floor, which is about how far a derivation read off
+    *initial values* may reach for on its own. ``1e-2`` is four decades above the first and
+    ``1e-20`` ten below ``_DERIVED_ATOL_FLOOR``; both arrive verbatim.
+    """
+    model = _piecewise_model(tmp_path, text=_TWO_SCALE_SBML, name=f'pw_clamp{stated:g}.xml',
+                             species_atol={'X': stated})
+    engine, kwargs = _tolerance_kwargs(model)
+
+    assert dict(zip(engine.species_names, kwargs['atol']))['X'] == stated
+
+
+@_needs_per_species_atol
+def test_a_pinned_scalar_becomes_the_base_the_map_overrides(tmp_path):
+    """A pinned ``atol`` still switches the derivation off; it does not switch the map off.
+
+    So ``atol: 1e-6, species_atol: X 1e-3`` reads exactly as it looks -- everything at
+    ``1e-6`` except ``X`` -- rather than as a contradiction one of the two has to lose.
+    """
+    model = _piecewise_model(tmp_path, text=_TWO_SCALE_SBML, name='pw_pin.xml',
+                             atol=1e-6, species_atol={'X': 1e-3})
+    engine, kwargs = _tolerance_kwargs(model)
+
+    assert dict(zip(engine.species_names, kwargs['atol'])) == pytest.approx(
+        {'X': 1e-3, 'Big': 1e-6})
+    assert kwargs['steady_state_tol'] == 1e-6
+
+
+@_needs_per_species_atol
+def test_a_stated_map_travels_even_when_it_agrees_with_the_scalar(tmp_path):
+    """The "elementwise the scalar, so send the scalar" off-ramp is for the derivation.
+
+    That off-ramp exists so a model with no over-tightening to give back keeps its
+    ``CVodeSStolerances`` call byte for byte -- correct precisely because nobody asked for
+    a vector. Here somebody did, so the vector travels and pays lanl/bngsim#196's ~1 ulp
+    ``cvEwtSetSS``/``cvEwtSetSV`` difference for having been stated.
+    """
+    unstated = _piecewise_model(tmp_path, text=_ORDER_ONE_SBML, name='pw_one_a.xml')
+    assert _tolerance_kwargs(unstated)[1] == {'rtol': _BNGSIM_DEFAULT_RTOL,
+                                              'atol': _BNGSIM_DEFAULT_ATOL}
+
+    stated = _piecewise_model(tmp_path, text=_ORDER_ONE_SBML, name='pw_one_b.xml',
+                              species_atol={'X': _BNGSIM_DEFAULT_ATOL})
+    engine, kwargs = _tolerance_kwargs(stated)
+    assert kwargs['atol'] == [_BNGSIM_DEFAULT_ATOL] * len(engine.species_names)
+    assert kwargs['steady_state_tol'] == _BNGSIM_DEFAULT_ATOL
+
+
+@_needs_per_species_atol
+def test_a_stated_map_keeps_the_steady_state_cutoff_the_models_own_scalar(tmp_path):
+    """ADR-0105's pairing, unchanged: bngsim's cutoff has no per-species reading to take.
+
+    Left unstated it falls back to the Simulator's own ``1e-8`` rather than to anything
+    derived, which on a model whose states are ~1e-8 makes every ``time = inf`` measurement
+    and every pre-equilibration phase return the initial state and call it equilibrium.
+    """
+    model = _piecewise_model(tmp_path, text=_TWO_SCALE_SBML, name='pw_ss.xml',
+                             species_atol={'X': 1e-3})
+    _, kwargs = _tolerance_kwargs(model)
+
+    assert kwargs['steady_state_tol'] == pytest.approx(_TWO_SCALE_SCALAR)
+
+
+@_needs_tracking_atol
+@_needs_per_species_atol
+def test_a_stated_map_becomes_the_tracking_ceiling(tmp_path):
+    """``tracking`` follows the trajectory *beneath* a ceiling; the map states the ceiling."""
+    model = _piecewise_model(tmp_path, text=_TWO_SCALE_SBML, name='pw_track_map.xml',
+                             atol='tracking 4', species_atol={'Big': 1e-2})
+    engine, kwargs = _tolerance_kwargs(model)
+
+    assert kwargs['atol'].decades == 4.0
+    assert dict(zip(engine.species_names, kwargs['atol'].ceiling)) == pytest.approx(
+        {'X': _TWO_SCALE_SCALAR, 'Big': 1e-2})
+    assert kwargs['steady_state_tol'] == pytest.approx(_TWO_SCALE_SCALAR)
+
+
+@_needs_per_species_atol
+def test_a_stated_map_can_say_exactly_what_the_derivation_says(tmp_path):
+    """The surface is expressive enough to reproduce ``auto``'s own vector by hand.
+
+    Not a use anybody has, but it is the property that says this is one mechanism rather
+    than two: what the derivation computes is inside what a person can write, so the
+    difference between them is who decided, not what can be expressed.
+    """
+    derived = _piecewise_model(tmp_path, text=_LARGE_SPREAD_SBML, name='pw_eq_a.xml',
+                               atol='auto')
+    engine, base_kwargs = _tolerance_kwargs(derived)
+    by_hand = dict(zip(engine.species_names, base_kwargs['atol']))
+
+    stated = _piecewise_model(tmp_path, text=_LARGE_SPREAD_SBML, name='pw_eq_b.xml',
+                              atol='auto', species_atol=by_hand)
+    _, kwargs = _tolerance_kwargs(stated)
+
+    assert kwargs['atol'] == pytest.approx(base_kwargs['atol'])
+    assert kwargs['steady_state_tol'] == pytest.approx(base_kwargs['steady_state_tol'])
+
+
+@_needs_per_species_atol
+def test_a_stated_map_is_a_constant_of_the_model_not_of_the_fit_point(tmp_path):
+    """A tolerance that moved with a fitted initial condition would step the objective.
+
+    Trivially true of a number read out of the conf, and asserted anyway because it is the
+    property the whole derivation is arranged around (bngsim's ``AUTO`` is what it rules
+    out) and a later implementation that resolved the map against live state would break it
+    silently.
+    """
+    at_nominal = _piecewise_model(tmp_path, text=_TWO_SCALE_SBML, name='pw_const_a.xml',
+                                  species_atol={'X': 1e-3})
+    moved = _piecewise_model(tmp_path, text=_TWO_SCALE_SBML, name='pw_const_b.xml',
+                             species_atol={'X': 1e-3}, extra=(('Big', 1e-3),))
+
+    assert _tolerance_kwargs(moved)[1] == _tolerance_kwargs(at_nominal)[1]
+
+
+@_needs_per_species_atol
+def test_a_stated_map_reaches_the_bngsim_run_call(tmp_path, monkeypatch):
+    """What ``Simulator.run`` is actually called with, not just what the seam computes."""
+    model = _piecewise_model(tmp_path, text=_TWO_SCALE_SBML, name='pw_stated_run.xml',
+                             species_atol={'Big': 1e-2})
+    engine = model._engine_model_for_action()
+    captured = {}
+
+    class _CapturingSim:
+        _rtol, _atol = _BNGSIM_DEFAULT_RTOL, _BNGSIM_DEFAULT_ATOL
+
+        def run(self, **kwargs):
+            captured.update(kwargs)
+            raise RuntimeError('stop here')
+
+    monkeypatch.setattr(model, '_make_simulator', lambda engine_model, method: _CapturingSim())
+    with pytest.raises(RuntimeError, match='stop here'):
+        model._run_simulation(engine, 1.0, 2, method='ode')
+
+    assert dict(zip(engine.species_names, captured['atol'])) == pytest.approx(
+        {'X': _TWO_SCALE_SCALAR, 'Big': 1e-2})
+    assert captured['steady_state_tol'] == pytest.approx(_TWO_SCALE_SCALAR)
+
+
+@_needs_per_species_atol
+def test_a_stated_map_survives_the_rename_that_makes_the_derivation_decline(tmp_path):
+    """The map reaches a model the derived vector cannot order at all.
+
+    ``test_a_species_the_document_does_not_name_falls_back_and_says_so`` is the derivation
+    on this shape: the engine renames an id that collides with an Antimony reserved word,
+    the document and engine name sets disagree, and the vector is abandoned for the scalar.
+    A stated map is written in engine names to begin with, so it is not merely unaffected
+    -- it is the only way those models reach ``CVodeSVtolerances`` at all.
+
+    The rename is staged onto the model rather than written into the fixture, exactly as
+    the derivation's own version of this test stages it: the SBML ids here carry no
+    reserved word, so a real load of this document renames nothing.
+    """
+    model = _piecewise_model(tmp_path, text=_TWO_SCALE_SBML, name='pw_ren_map.xml')
+    model._config_species_atol = {'_ant_Big': 1e-2}
+
+    class _RenamedEngine:
+        species_names = ('X', '_ant_Big')
+
+    kwargs = model._run_tolerance_kwargs(object(), _RenamedEngine())
+
+    assert kwargs['atol'] == pytest.approx([_TWO_SCALE_SCALAR, 1e-2])
+    assert kwargs['steady_state_tol'] == pytest.approx(_TWO_SCALE_SCALAR)
+
+
+# --- the names are checked, against the list that is actually used --------------- #
+def test_the_engine_species_names_are_captured_at_construction(tmp_path):
+    """The list a map is checked against, taken from a load the constructor already pays for."""
+    model = _piecewise_model(tmp_path, text=_TWO_SCALE_SBML, name='pw_names.xml')
+
+    assert model._engine_species_names == ('X', 'Big')
+
+
+@_needs_per_species_atol_ctor
+def test_an_unknown_species_is_refused_and_the_message_names_the_ones_it_has(tmp_path):
+    """At config load, where the conf author is -- not from a trajectory later."""
+    with pytest.raises(ModelError) as exc:
+        _piecewise_model(tmp_path, text=_TWO_SCALE_SBML, name='pw_unknown.xml',
+                         species_atol={'Bigg': 1e-2})
+
+    message = exc.value.message
+    assert 'Bigg' in message and 'X' in message and 'Big' in message
+
+
+@_needs_per_species_atol_ctor
+def test_a_renamed_species_is_named_in_the_refusal(tmp_path):
+    """The one case a conf author cannot guess from their own model file.
+
+    bngsim renames an id that collides with an Antimony reserved word, so a person reading
+    ``<species id="NULL">`` and writing ``species_atol: NULL 1e-3`` names something that
+    does not exist. The message says what to write instead rather than leaving them to
+    find ``_ant_NULL`` in a 133-name list.
+    """
+    model = _piecewise_model(tmp_path, text=_TWO_SCALE_SBML, name='pw_rename_msg.xml')
+    model._engine_species_names = ('X', '_ant_NULL')
+    model._config_species_atol = {'NULL': 1e-3}
+
+    with pytest.raises(ModelError, match='_ant_NULL'):
+        model._check_stated_species_atol()
+
+
+@_needs_per_species_atol_ctor
+def test_a_stated_map_is_refused_rather_than_dropped_without_the_backend(tmp_path, monkeypatch):
+    """The derived vector may fall back to the scalar silently; a stated one may not.
+
+    Nobody asked for the derived vector, and the scalar is a correct tolerance for that
+    model -- just a less discriminating one. A hand-written map is somebody asking, and a
+    stated tolerance that did not apply is a plausible trajectory with a wrong conclusion
+    attached, which is the failure #557 refused for ``tracking`` and this refuses here.
+    """
+    monkeypatch.setattr(bngsim_sbml_model, 'BNGSIM_HAS_PER_SPECIES_ATOL', False)
+
+    with pytest.raises(ModelError, match='lanl/bngsim#196'):
+        _piecewise_model(tmp_path, text=_TWO_SCALE_SBML, name='pw_nocap.xml',
+                         species_atol={'X': 1e-3})
+
+
+@_needs_per_species_atol_ctor
+def test_a_stated_map_is_shape_checked_by_the_constructor_too(tmp_path):
+    """The model is reachable directly, so it cannot defer a malformed map to the first run."""
+    with pytest.raises(ModelError, match='species_atol'):
+        _piecewise_model(tmp_path, text=_TWO_SCALE_SBML, name='pw_badshape.xml',
+                         species_atol={'X': -1.0})
+
+
+# --- the whole trajectory, under a hand-written vector -------------------------- #
+@_needs_per_species_atol
+def test_the_model_still_integrates_to_its_closed_form_under_a_stated_vector(tmp_path):
+    """A tolerance no derivation would produce still lands on the analytic answer.
+
+    ``X`` is stated at ``1e-6`` -- two decades ABOVE the backend default, which is where
+    the clamped derivation stops and one decade above what ``auto`` computes for it
+    (``rtol * 10``). So this is not a species being handed something the derivation would
+    have given it anyway; it is the reach a hand-written entry adds, integrated and checked
+    against the closed form rather than against another tolerance.
+
+    Restricted to where the exact solution is well clear of the stated tolerance, for
+    ``test_the_released_species_still_integrates_to_its_closed_form``'s reason: below that,
+    asking ``X`` to be relatively accurate is asking the absolute tolerance not to be one.
+    """
+    model = _piecewise_model(tmp_path, text=_WIDE_SPREAD_SBML, name='wide_stated.xml',
+                             species_atol={'X': 1e-6})
+    engine = model._engine_model_for_action()
+    sim = model._make_simulator(engine, 'ode')
+    kwargs = model._run_tolerance_kwargs(sim, engine)
+    assert dict(zip(engine.species_names, kwargs['atol']))['X'] == 1e-6
+
+    result = sim.run(t_span=(0.0, _WIDE_T_END), n_points=81, **kwargs)
+    t = np.asarray(result.time)
+    got = np.asarray(result.species[:, list(engine.species_names).index('X')])
+    exact = _exact_x(t, 10.0)
+    clear = exact > 1e-1
+    np.testing.assert_allclose(got[clear], exact[clear], rtol=1e-3)
+
+
+# --- the config surface --------------------------------------------------------- #
+def _per_model_config(mf, record, *, backend='bngsim', models=None):
+    """A bare :class:`Configuration` carrying one per-model tolerance record."""
+    cfg = object.__new__(config.Configuration)
+    cfg.models = {}
+    cfg.config = {'bng_command': '', 'sbml_backend': backend, 'sbml_integrator': 'cvode',
+                  'sbml_ssa_strict': 1, 'sbml_atol': None, 'sbml_rtol': None,
+                  'models': {mf} if models is None else models,
+                  ('model_tolerances', mf): record}
+    return cfg
+
+
+def test_a_per_model_record_is_resolved_field_by_field():
+    """What reaches the model constructor: only the fields the line actually stated."""
+    cfg = _per_model_config('m.xml', {'atol': 'auto', 'rtol': 1e-9,
+                                      'species_atol': {'A': 1e-3}})
+
+    assert cfg._resolve_model_tolerances() == {
+        'm.xml': {'atol': 'auto', 'rtol': 1e-9, 'species_atol': {'A': 1e-3}}}
+
+
+def test_a_job_with_no_per_model_record_resolves_to_nothing():
+    cfg = _per_model_config('m.xml', {})
+    del cfg.config[('model_tolerances', 'm.xml')]
+
+    assert cfg._resolve_model_tolerances() == {}
+
+
+def test_a_tolerance_for_an_undeclared_model_is_refused():
+    cfg = _per_model_config('m.xml', {'atol': 1e-4}, models={'other.xml'})
+
+    with pytest.raises(PybnfError, match='does not declare'):
+        cfg._resolve_model_tolerances()
+
+
+@pytest.mark.parametrize('mf', ['m.bngl', 'm.target'])
+def test_a_model_with_no_cvode_tolerance_to_state_is_refused(mf):
+    """A BNGL model states ``atol``/``rtol`` in its own ``begin actions`` block."""
+    cfg = _per_model_config(mf, {'atol': 1e-4})
+
+    with pytest.raises(PybnfError, match='begin actions'):
+        cfg._resolve_model_tolerances()
+
+
+def test_a_per_model_tolerance_needs_the_bngsim_backend():
+    """RoadRunner has its own integrator settings, so accepting it would do nothing."""
+    cfg = _per_model_config('m.xml', {'atol': 1e-4}, backend='roadrunner')
+
+    with pytest.raises(PybnfError, match='sbml_backend = bngsim'):
+        cfg._resolve_model_tolerances()
+
+
+def test_a_per_model_tolerance_is_refused_under_the_gillespie_integrator():
+    """A stochastic run has no CVODE tolerances to set, so the record could only decorate.
+
+    ``sbml_integrator = gillespie`` makes ``_resolve_method`` return ``'ssa'`` for every
+    action of every model, and a stochastic run's kwargs carry neither ``rtol`` nor
+    ``atol`` (``test_a_stochastic_run_sets_no_tolerances``). It is the third case in the
+    same family as a ``.bngl`` model and the RoadRunner backend, and is refused with them.
+    """
+    cfg = _per_model_config('m.xml', {'species_atol': {'A': 1e-3}})
+    cfg.config['sbml_integrator'] = 'gillespie'
+
+    with pytest.raises(PybnfError, match='gillespie'):
+        cfg._resolve_model_tolerances()
+
+
+def test_a_per_model_tolerance_reports_a_missing_bngsim_as_a_missing_bngsim(monkeypatch):
+    """Not as a specific missing API, which is what the capability probes would say.
+
+    With no bngsim at all, every probe is False, so the `species_atol` refusal would
+    otherwise tell somebody who cannot import the library that their build lacks
+    ``bngsim.normalize_atol_vector``.
+    """
+    monkeypatch.setattr(config, 'BNGSIM_HAS_SBML', False)
+    monkeypatch.setattr(config, 'BNGSIM_HAS_PER_SPECIES_ATOL', False)
+    cfg = _per_model_config('m.xml', {'species_atol': {'A': 1e-3}})
+
+    with pytest.raises(PybnfError, match='sbml_backend = bngsim was requested'):
+        cfg._resolve_model_tolerances()
+
+
+@pytest.mark.parametrize('record, match', [
+    ({'atol': 'nonsense'}, 'atol'),
+    ({'atol': 'tracking -1'}, 'decades'),
+    ({'atol': 0}, 'atol'),
+    ({'atol': float('inf')}, 'atol'),
+    ({'rtol': 0.0}, 'rtol'),
+    ({'rtol': -1.0}, 'rtol'),
+    ({'rtol': float('inf')}, 'rtol'),
+    ({'species_atol': {'A': 0.0}}, 'species_atol'),
+    ({'species_atol': {'A': -1.0}}, 'species_atol'),
+])
+def test_config_refuses_a_per_model_setting_that_is_not_a_tolerance(record, match):
+    """Refused at config load, naming the model, rather than once the run has started."""
+    cfg = _per_model_config('m.xml', record)
+
+    with pytest.raises(PybnfError, match=match) as exc:
+        cfg._resolve_model_tolerances()
+    assert 'm.xml' in str(exc.value)
+
+
+def test_config_refuses_a_per_model_tracking_without_the_backend_capability(monkeypatch):
+    monkeypatch.setattr(config, 'BNGSIM_HAS_TRACKING_ATOL', False)
+    cfg = _per_model_config('m.xml', {'atol': 'tracking'})
+
+    with pytest.raises(PybnfError, match='lanl/bngsim#213'):
+        cfg._resolve_model_tolerances()
+
+
+def test_config_refuses_a_species_atol_without_the_backend_capability(monkeypatch):
+    monkeypatch.setattr(config, 'BNGSIM_HAS_PER_SPECIES_ATOL', False)
+    cfg = _per_model_config('m.xml', {'species_atol': {'A': 1e-3}})
+
+    with pytest.raises(PybnfError, match='lanl/bngsim#196'):
+        cfg._resolve_model_tolerances()
+
+
+def test_the_per_model_tolerances_require_edition_2():
+    """They ride the ``model:`` declaration, which is edition-2 syntax."""
+    with pytest.raises(PybnfError, match='edition 2'):
+        config.Configuration._resolve_model_declarations(
+            {('model_tolerances', 'm.xml'): {'atol': 1e-4}, 'edition': None})
+
+
+def test_a_conf_states_one_models_tolerance_and_leaves_the_other_alone(tmp_path, monkeypatch):
+    """The whole of #586, end to end: two models, one statement, no collision.
+
+    ``sbml_atol`` is one key over every SBML/Antimony model in the fit, so before this
+    there was no way to say "this species of this model" -- a positional vector had no
+    ordering a conf author could see, and a species-keyed one had no reading across models
+    that do not share species names. Here ``one.xml`` states a per-species vector by name
+    and ``two.xml``, which has no ``X`` at all, is untouched and keeps the global key.
+    """
+    from pybnf import parse
+
+    _write(tmp_path, _TWO_SCALE_SBML, 'one.xml')
+    _write(tmp_path, _ORDER_ONE_SBML.replace('"X"', '"Solo"').replace('<ci>X</ci>',
+                                                                     '<ci>Solo</ci>'),
+           'two.xml')
+    conf = (
+        'edition = 2\n'
+        'job_type = de\n'
+        'objective = sos\n'
+        'sbml_backend = bngsim\n'
+        'population_size = 4\n'
+        'max_iterations = 1\n'
+        'uniform_var = k0 1e-9 10\n'
+        'sbml_atol = 1e-7\n'
+        'model: one.xml, atol: auto, species_atol: X 1e-11, rtol: 1e-10\n'
+        'model: two.xml\n'
+    )
+    monkeypatch.chdir(tmp_path)
+    cfg = config.Configuration(parse.ploop(conf.splitlines(keepends=True)))
+
+    one, two = cfg.models['one'], cfg.models['two']
+    assert (one._config_rtol, one._atol_mode, one._config_atol) == (1e-10, 'auto', None)
+    assert one._config_species_atol == {'X': 1e-11}
+    assert (two._config_rtol, two._atol_mode, two._config_atol) == (None, None, 1e-7)
+    assert two._config_species_atol is None
+
+    engine, kwargs = _tolerance_kwargs(one)
+    assert dict(zip(engine.species_names, kwargs['atol']))['X'] == 1e-11
+    assert _tolerance_kwargs(two)[1] == {'rtol': _BNGSIM_DEFAULT_RTOL, 'atol': 1e-7}


### PR DESCRIPTION
Closes #586.

## What was blocking it

`sbml_atol` and `sbml_rtol` are **one key each over every SBML/Antimony model in a fit**, and that — not the grammar — is why neither could ever take a hand-written per-species vector. A positional vector (`sbml_atol = 1e-3 1e-6 1e-4`) is ordered against a species list a conf author cannot see; a species-keyed map has no reading across models that do not share species names. Both objections are about the *key*, so the statement moves onto the new-era `model:` declaration (ADR-0028), where it names one model file.

## The surface

Under `edition >= 2`, a **single-model** `model:` line takes three optional labeled fields, in any order:

```
model: weber.xml, atol: auto, species_atol: PKD 1e-3, CERT 1e-2, rtol: 1e-9
```

| field | meaning |
|---|---|
| `atol:` | the per-model `sbml_atol` — a number, `auto`, or `tracking [decades]` |
| `rtol:` | the per-model `sbml_rtol`. A scalar, and only ever a scalar: CVODE has no per-species relative tolerance |
| `species_atol:` | the hand-written vector, as `<species> <number>` pairs |

`sbml_atol`/`sbml_rtol` stay the fit-wide defaults; a field overrides the matching key **for the one model it names** and says nothing about the others.

## Semantics worth reviewing

- **The map is a set of exceptions, not a replacement.** Named species take the number stated, **verbatim** — neither ADR-0103's `1e-8` ceiling nor ADR-0105's model-scalar floor binds a number a person wrote, for the same reason a pinned `sbml_atol` number is not clamped either. Unnamed species keep the derived vector, a pinned scalar broadcast, or the backend default.
- **The steady-state cutoff stays the model-wide number** (ADR-0105's pairing), and under `atol: tracking` the map becomes the trajectory-following **ceiling**.
- **Names are bngsim's, not the document's.** An unknown one is an error at config load listing the names the model *does* have. That matters twice: bngsim renames an id colliding with an Antimony reserved word (`NULL` integrates as `_ant_NULL`, and the error says so), and a parameter driven by a rate rule becomes a state `<listOfSpecies>` never mentions — nameable here and reachable by nothing else.
- **Refused, not degraded.** A line carrying a field must declare exactly one model, and that model must be an `.xml`/`.ant` one on `sbml_backend = bngsim` integrated by CVODE. A BNGL model, the RoadRunner backend, and `sbml_integrator = gillespie` are all pointed errors — as is a `species_atol` on a bngsim without lanl/bngsim#196.

**Nothing changes without one of those fields.** A job that states nothing gets the same `Simulator.run` call it got before, argument for argument.

## Measured

On `Smith_BMCSystBiol2013` — the one of 23 subset-I slugs where the engine and document species-name sets disagree — the derived vector declines outright today, so a hand-written map is the only route to `CVodeSVtolerances` there:

| `Smith_BMCSystBiol2013` | what CVODE is called with |
|---|---|
| unset (the derivation) | **scalar** — the vector declines, unorderable past the rename |
| `sbml_atol = auto` | **scalar** — same decline |
| `species_atol: NULL 1e-3` | refused, naming `_ant_NULL` |
| `species_atol: _ant_NULL 1e-3, _ant_null 1e-3` | **vector[133]**, entries in their own slots, cutoff stated |

On `Weber_BMC2015` (100 time units, 101 points, `rtol = 1e-8`, fresh engine per arm):

| `atol` | steps | vs unset | max rel. state diff at `t_end` |
|---|---:|---:|---:|
| unset (clamped derivation, `1e-08`) | 210 | 1.00x | — |
| `auto` | 184 | 0.88x | 3.3e-08 |
| `species_atol` = `rtol * y_i`, by hand | 192 | 0.91x | 2.9e-08 |

The third arm is bngsim's own `derive_atol` rule — the one ADR-0105 measured and declined to apply automatically. It is now reachable per model, and on Weber it is **worse than `auto`**, which is exactly why it is not the default. The honest summary is in the ADR: this is not a faster tolerance, it is a place to put a decision.

## Also fixed here

`sbml_rtol = inf` was accepted. The conf number token matches `inf` (ADR-0047's open truncation side) and the config check was sign-only (`tol <= 0.`), so it reached CVODE and turned relative error control off. `sbml_atol` never had the hole. Found while adding the per-model `rtol:`, which would have inherited the same check — fixed rather than filed, with a regression test.

## Verification

- Fast tier: **4170 passed, 10 skipped** (up from 4086 — the difference is this change's tests).
- `sphinx-build -W` clean.
- ~50 new tests across `tests/test_sbml_solver_tolerances.py` and `tests/test_bngsim_antimony_bridge.py`, covering the grammar, the shape authority, every composition cell, the name checks and refusals, an oracle run at a tolerance two decades above what any derivation produces, and an end-to-end two-model conf.
- No bngsim change was needed.

Design and measurements: `docs/adr/0116-*.md`.
