### PR TITLE
The CVODE-error troubleshooting entry names the tolerance keys that fix it, and stops attributing bngsim's integrator to libRoadRunner (#586)

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -102,6 +102,8 @@ To avoid mistakes in configuration, you may optionally append “__FREE” to th
 
 Caution: If you are using `COPASI`_ to export SBML files, renaming a parameter is not straightforward. Typically, renaming a parameter only changes its ``name`` field, but PyBNF reads the ``id`` field.
 
+SBML files also do not carry the solver settings PyBNF runs them under. On ``sbml_backend = bngsim`` the CVODE tolerances are derived from the model's own species magnitudes, and :ref:`sbml_rtol <sbml_rtol>` / ``sbml_atol`` state them for the whole fit if you want to override that. A single model can also state its own on its :ref:`model: <model_decl>` declaration line (``atol:``, ``rtol:``, and a per-species ``species_atol:``), which is what to reach for when one model of a multi-model fit — or one species of one model — is the one that needs a different tolerance. If simulations are failing with CVODE errors, start at :doc:`troubleshooting`.
+
 Note that SBML files do not contain information about what time course or parameter scan simulations should be run on the model. Therefore, when using SBML files, it is required to specify this information in the configuration file with the :ref:`time_course <time_course_key>` and :ref:`param_scan <param_scan_key>` keys. For BNGL models, simulation actions should be specified in the BNGL file's ``begin actions`` block, which supports the full set of BioNetGen action arguments.
 
 .. _exp-file:

--- a/docs/config_keys.rst
+++ b/docs/config_keys.rst
@@ -1332,6 +1332,8 @@ Algorithm Options
   
     * ``sbml_integrator = rk4``
 
+.. _sbml_backend:
+
 **sbml_backend**
   Which simulation engine runs SBML models: ``roadrunner`` (the default, libRoadRunner) or
   ``bngsim`` (the BioNetGen simulator). The ``bngsim`` backend supports a restricted set of

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -41,9 +41,34 @@ If the SBML file was generated in COPASI, refer to `Unexpected behavior when gen
 
 CVODE errors
 """"""""""""
-For SBML models, if your logs in ``FailedSimLogs/`` include errors from CVODE such as "CV_ERR_FAILURE: Error test failures occurred too many times during one internal time step" or "CV_TOO_MUCH_WORK: The solver took mxstep internal steps but could not reach tout", it means that CVODE, the ODE integrator used in libRoadRunner to simulate SBML models, decided that the model was too difficult to simulate and gave up. This might happen when the solution to the ODE system is not sufficiently smooth. 
+For SBML models, if your logs in ``FailedSimLogs/`` include errors from CVODE such as "CV_ERR_FAILURE: Error test failures occurred too many times during one internal time step" or "CV_TOO_MUCH_WORK: The solver took mxstep internal steps but could not reach tout", it means that CVODE, the ODE integrator that simulates SBML models on both :ref:`sbml_backend <sbml_backend>` settings (through libRoadRunner on ``roadrunner``, through bngsim on ``bngsim``), decided that the model was too difficult to simulate and gave up. This might happen when the solution to the ODE system is not sufficiently smooth.
 
-It may be possible to run such simulations with a different SBML integrator, set with the ``sbml_integrator`` key. 
+It may be possible to run such simulations with a different SBML integrator, set with the ``sbml_integrator`` key.
+
+**Check the absolute tolerance first** when ``sbml_backend = bngsim``. Both of those errors are
+what an ``atol`` mismatched to the model's units looks like from the outside. CVODE weights each
+state by ``rtol*|y| + atol``, so an ``atol`` far *beneath* a species' own magnitude holds the
+integrator to an accuracy nobody asked for, and it pays in steps until it exhausts ``mxstep``.
+PyBNF derives ``atol`` from the model's species magnitudes for exactly this reason, but the
+derivation is only allowed to *tighten* by default, so a model whose species sit far above one
+keeps a tolerance 5+ decades tighter than its own scale asks for. See
+:ref:`sbml_rtol <sbml_rtol>` for the full account; in order of what to try:
+
+* ``sbml_atol = auto`` — let the derivation loosen as well as tighten. Costs nothing on a model
+  whose species sit at or below one, and is the first thing to try on one whose species are large.
+* ``sbml_atol = <number>`` — state one tolerance for every species of every model, replacing the
+  derivation entirely.
+* ``atol:`` / ``rtol:`` / ``species_atol:`` on a single model's :ref:`model: <model_decl>`
+  declaration (``edition >= 2``) — the same settings scoped to **one** model of a multi-model
+  fit, plus the only way to hand-write a tolerance for a **named species**. Use it when one
+  model, or one species, is the one giving trouble.
+* ``sbml_atol = tracking`` — an absolute tolerance that follows the trajectory rather than
+  staying where the initial values put it, for a species that decays far below its own starting
+  magnitude. It costs integrator steps; lower its depth if a model that integrated before stops.
+
+Going the other way — a trajectory that looks wrong rather than one that fails — is the same
+key: a model whose species sit *below* ``1e-8`` carries no significant digits at the backend
+default, and its forward sensitivities carry fewer still.
 
 
 Resource not available


### PR DESCRIPTION
Follow-up to #596 (ADR-0116), answering "is `species_atol` documented anywhere a user would look?" The reference entry in `config_keys.rst` landed with #596; this is the part that was missing.

## The gap

`docs/troubleshooting.rst` → *Failed simulations* → *For SBML simulations* → **CVODE errors** is where somebody with `CV_ERR_FAILURE` or `CV_TOO_MUCH_WORK` actually lands. It said two things that no longer hold:

1. that CVODE is "the ODE integrator used in libRoadRunner" — only half true since `sbml_backend = bngsim` carries its own;
2. that the remedy is "a different `sbml_integrator`" — which on bngsim means switching to **Gillespie**, not what someone with a stiff ODE wants.

Both of those errors are what an `atol` mismatched to the model's units looks like from the outside. That is the entire subject of ADR-0103 / 0105 / 0114 / 0116 — and none of it was reachable from the page describing its symptom.

## What changed

- **`docs/troubleshooting.rst`** — the entry now corrects the backend attribution, explains the mechanism in two sentences (CVODE weights each state by `rtol*|y| + atol`, so an `atol` far beneath a species' magnitude buys accuracy nobody asked for and pays in steps until `mxstep` runs out), and lists what to try **in order**: `sbml_atol = auto` → a number → the per-model `atol:` / `rtol:` / `species_atol:` fields when one model or one species is the problem → `tracking` for a species that decays out of its own tolerance. It also notes the opposite failure — a model below `1e-8` carrying no significant digits at the default.
- **`docs/config.rst`** — the SBML section gains the pointer it never had. An SBML file does not carry the solver settings PyBNF runs it under, and a reader there had no way to learn the tolerances are derived, let alone that they can be stated.
- **`docs/config_keys.rst`** — `sbml_backend` gains a `.. _sbml_backend:` label so it can be cross-referenced, matching `sbml_rtol`'s.

## Verification

`sphinx-build -W --keep-going` clean. All four new cross-references resolve in the built HTML (`config_keys.html#model-decl`, `#sbml-backend`, `#sbml-rtol`, and `troubleshooting.html`).

One rendering bug caught and fixed before committing: RST does not nest inline markup, so a bolded lead containing a literal printed its backticks verbatim. Confirmed against the built HTML rather than assumed.

Docs only — no code, no tests, no behaviour change.
