### PR TITLE
docs(algorithms): the CMA-ES box-start description names start_point (#583)

### DIFF
--- a/docs/algorithms.rst
+++ b/docs/algorithms.rst
@@ -740,8 +740,9 @@ standalone (``job_type = cmaes``). Standalone, it accepts either of two starts:
 * a single starting **point** given with the ``var`` / ``logvar`` keys (local
   search, like Simplex and Powell); or
 * a bounded **box** given with the ``uniform_var`` / ``loguniform_var`` keys —
-  its *global-start* mode. CMA-ES begins at the box center and seeds its
-  covariance with the per-coordinate box widths, so the first generation spans the
+  its *global-start* mode. CMA-ES begins at the box center (or, if you name one,
+  at the :ref:`start_point <start_point>`) and seeds its covariance with the
+  per-coordinate box widths, so the first generation spans the
   whole box; candidates are reflected back into the box. Because covariance
   adaptation makes CMA-ES one of the strongest general-purpose black-box global
   optimizers, this is the recommended way to run it as a primary search (the


### PR DESCRIPTION
A three-line follow-up to #597.

That PR made a declared start point pin start 0 for every start-point optimizer, which turned
"CMA-ES begins at the box center" on the algorithms page into a claim that holds only when nothing
is declared. The equivalent sentences in `gradient_fitting.rst`, the local multi-start console
banner, and `local_base.py`'s docstrings were corrected there; this one sits on the algorithms page
rather than in the start-point path, so it was missed.

It cross-references the key rather than restating the semantics, so the two cannot drift apart
again.

Docs gate (`sphinx-build -W --keep-going`) passes.