### PR TITLE
docs(tutorial): teach start_point where a user meets it — lesson 44 and the quickstart's next step (#583)

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -142,6 +142,27 @@ Once you have your config file edited as needed, run PyBNF from the folder conta
     
 Congratulations, you've just completed your first PyBNF fitting job!
 
+Picking up where a fit left off
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Your results are in ``output/Results/``. ``sorted_params.txt`` lists the best parameter sets
+found, best first. A common next step is to run again *from* that best fit rather than
+starting over — with a longer budget, a different algorithm, or tighter bounds. Name the point
+with :ref:`start_point <start_point>`, one line per parameter, in each parameter's own units::
+
+    start_point = var1 4.31
+    start_point = var2 0.87
+    start_point = var3 2.05
+
+Everything else about the config stays as it is: the ``uniform_var`` lines still declare the
+bounds the search stays inside, so this is a *bounded* restart from a known point rather than
+an unconstrained one. Name only the parameters you want to pin; any you leave out start where
+they would have anyway. A value outside its declared bounds is refused rather than quietly
+moved, and every run records where it actually began in ``Results/start_point.txt``.
+
+(If you simply want a local polish appended to the end of a search, ``refine = 1`` does that in
+one command — see :ref:`config_keys`.)
+
 .. note::
 
    Ready for more? The :ref:`tutorial` tours PyBNF's modern (edition-2) features

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -59,7 +59,8 @@ Optimizers and identifiability
   ``migrate_every``, ``num_to_migrate``).
 - `44. Initialization <https://github.com/lanl/PyBNF/tree/main/examples/tutorial/44_initialization>`__
   — where the search starts: seeding the initial population from an informative
-  prior (``initialization``).
+  prior, or pinning the start at a point you already have — a previous fit's
+  result, a published value (``initialization``, ``start_point``).
 
 Objectives and noise models
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/examples/tutorial/44_initialization/README.md
+++ b/examples/tutorial/44_initialization/README.md
@@ -1,6 +1,6 @@
 # Lesson 44 — Where the search starts (initialization)
 
-**Feature:** `initialization` / `initialization_distribution` · **Difficulty:** ★★ (recovery tier)
+**Feature:** `initialization` / `initialization_distribution` / `start_point` · **Difficulty:** ★★ (recovery tier)
 
 Before a population optimizer takes its first step, it has to **draw an initial
 population**. Two config keys control that draw:
@@ -9,6 +9,11 @@ population**. Two config keys control that draw:
 | --- | --- | --- |
 | `initialization` | **how** the points are spread | `lh` (Latin hypercube, space-filling — the default) · `rand` (independent uniform draws) |
 | `initialization_distribution` | **where** they are drawn from | `prior` (each parameter's prior distribution — the default) · `bounds` (uniform within finite bounds) |
+
+A third key answers the same question a different way. Instead of describing a
+distribution to draw from, **`start_point`** names the point itself — see
+[Starting from a point you already have](#starting-from-a-point-you-already-have)
+below.
 
 ## `initialization` — how the points are spread
 
@@ -51,6 +56,55 @@ shapes the posterior — lessons [15](../15_petab_priors)/[27](../27_priors)/[32
 an unbounded `normal_var` has no finite bounds to draw from, which is why `prior`
 is the default.
 
+## Starting from a point you already have
+
+Both confs above describe a **distribution** and let PyBNF draw from it. Often you
+do not have a distribution — you have a **point**. You already fit the model and
+want the next run to pick up from `Results/sorted_params.txt` instead of starting
+over; or the point comes from a paper, a collaborator, or a PEtab problem's
+`nominalValue`. That is what `start_point` is for, one line per parameter:
+
+```
+start_point = alpha  1.35
+start_point = gamma  0.72
+```
+
+- **[`start_point.conf`](start_point.conf)** starts `cmaes` at that point — which
+  is *not* the truth, but about 12% and 10% off it, the way a real previous fit's
+  answer would be — over the same flat bounds `uninformed.conf` fails from. It
+  finishes at `(1.19993, 0.80007)`, an objective of ~1e-08. **The start point did
+  not supply the answer; it supplied the basin**, and the optimizer did the rest.
+
+```bash
+pybnf -c start_point.conf    # pinned start, flat bounds -> polishes to the truth
+```
+
+Three things worth knowing:
+
+- The value is always in the parameter's **own units**, never a log — a
+  `loguniform_var` parameter still takes `start_point = k 0.017`, not `-1.77`.
+- A value **outside** the declared bounds is refused, not moved. PyBNF does not
+  clamp an out-of-box start to the nearest bound; left alone it would be folded
+  back to an arbitrary interior point and the fit would report a plausible number
+  from somewhere you never asked for.
+- It is **partial by design**. Name only the parameters you are confident about;
+  the rest start exactly where they would have anyway.
+
+`cmaes` is single-start, so the start point *is* its start. With a population
+method (`de`, `pso`, `ss`) it pins **one** member and the rest are still drawn —
+deliberately, since the rest of the population is what tells you whether your point
+was any good.
+
+Whatever the method, every run writes **`Results/start_point.txt`** recording where
+it actually began, each parameter's value and its source (`start_point`,
+`box_center`, `sampled`, …). Read it whenever a fit lands somewhere surprising: a
+fit that began in the wrong place looks exactly like one that began in the right
+place.
+
+> `refine = 1` runs an automatic local polish *after* a search finishes, which is
+> the right tool when you want one command to do both. Reach for `start_point` when
+> the point comes from somewhere else, as it does here.
+
 ## The catch, and the fix
 
 The tiny budget is a magnifying glass: it isolates the *initialization* effect.
@@ -61,11 +115,13 @@ fighting chance when the budget is tight and the landscape is hard.
 
 ## The test
 
-Both confs are verified by the manifest-driven recovery suite
+All three confs are verified by the manifest-driven recovery suite
 ([`tests/test_tutorial_examples.py`](../../../tests/test_tutorial_examples.py),
 `-m recovery`): `prior_seeded.conf` recovers `(alpha, gamma)` within 5% from the
-tiny budget, and `uninformed.conf` must miss by ≥10% (so the contrast is not
-vacuous).
+tiny budget, `uninformed.conf` must miss by ≥10% (so the contrast is not
+vacuous), and `start_point.conf` recovers within 1% — a tighter tolerance than the
+others, because a seeded local polish should land on the answer rather than merely
+near it.
 
 ## Notes
 

--- a/examples/tutorial/44_initialization/start_point.conf
+++ b/examples/tutorial/44_initialization/start_point.conf
@@ -1,0 +1,89 @@
+# =============================================================================
+#  Starting from a point you already have          start_point = <param> <value>
+# =============================================================================
+#  The two confs beside this one control where a population is DRAWN FROM. This
+#  one answers the other question: what if you already know roughly where the
+#  answer is, and want the fit to START THERE?
+#
+#  The everyday case is refining a fit you have already run. You fit the model,
+#  looked at `Results/sorted_params.txt`, and want the next run to pick up from
+#  that best parameter set instead of starting over. Same story if the point comes
+#  from a paper, a collaborator, or a PEtab problem's `nominalValue`.
+#
+#  `start_point` says it directly -- one line per parameter, the parameter's name
+#  and its value:
+#
+#        start_point = alpha  1.35
+#        start_point = gamma  0.72
+#
+#  Two things to know about the value you write:
+#
+#    * It is always in the parameter's OWN units. Never a log. A parameter
+#      declared with `loguniform_var` or `parameter_scale: log10` still takes
+#      `start_point = k 0.017`, not `-1.77`.
+#    * It must be inside the bounds you declared. If it is not, PyBNF REFUSES to
+#      run rather than quietly moving it -- an out-of-box start would otherwise be
+#      folded back to an arbitrary interior point, and the fit would go on to
+#      report a perfectly plausible number from somewhere you never asked for.
+#
+#  You do not have to name every parameter. Anything you leave out starts exactly
+#  where it would have anyway, so you can pin the one rate you are confident about
+#  and let the rest be drawn.
+#
+#  WHAT THIS RUN SHOWS. The start below is deliberately NOT the truth
+#  (alpha = 1.2, gamma = 0.8). It is a nearby point, the way a real previous fit's
+#  answer would be -- about 12% and 10% off. CMA-ES begins there and polishes: it
+#  finishes at (1.19993, 0.80007), an objective of ~1e-08. The start point did not
+#  supply the answer; it supplied the BASIN, and the optimizer did the rest.
+#
+#  That is the contrast with the other two confs, which reach the same basin by
+#  drawing a whole population from an informative prior (prior_seeded.conf) or
+#  fail to reach it at all from flat bounds on a tiny budget (uninformed.conf).
+#  Three ways to answer one question: where does the search begin?
+#
+#  HOW IT INTERACTS WITH THE METHOD. `cmaes` is a single-start optimizer, so the
+#  start point IS its start. With a population method (`de`, `pso`, `ss`) or a
+#  multi-start one, it pins ONE member -- or start 0 -- and every other member is
+#  still drawn as usual. That is on purpose: the rest of the population is what
+#  tells you whether your point was any good. It is not a way to make every chain
+#  identical.
+#
+#  WHERE THE FIT ACTUALLY STARTED. Every run writes `Results/start_point.txt`,
+#  listing each parameter's start value, where that value came from
+#  (`start_point`, `box_center`, `sampled`, ...) and the box it was checked
+#  against. Read it whenever a fit lands somewhere surprising -- a fit that began
+#  in the wrong place looks exactly like one that began in the right place.
+#
+#  RELATED KEYS. `refine = 1` runs an automatic local polish AFTER a search
+#  finishes, which is the right tool when you want one command to do both. Use
+#  `start_point` when the point comes from somewhere else, as it does here. The
+#  older `starting_params` key does something similar for the Bayesian samplers
+#  ONLY, and matches values by position rather than by name; prefer `start_point`.
+# =============================================================================
+
+output_dir = output/start_point
+
+edition = 2
+model: oscillator.bngl
+bngl_backend = bngsim
+job_type = cmaes
+objective = sos
+
+experiment: timecourse, data: oscillator.exp
+
+# The same flat bounds as uninformed.conf -- no informative prior here. The head
+# start comes entirely from the start point below. The bounds still matter: they
+# are the box CMA-ES searches, and the box the start point is checked against.
+uniform_var = alpha  0.1  5.0
+uniform_var = gamma  0.1  5.0
+
+# Where to begin: a point near the answer, as a previous fit would have left it.
+# Both values are well inside the [0.1, 5.0] bounds declared above.
+start_point = alpha  1.35
+start_point = gamma  0.72
+
+population_size = 10
+max_iterations  = 40      # enough generations to polish the seed down to the truth
+
+verbosity = 1
+random_seed = 1234

--- a/examples/tutorial/_manifest.py
+++ b/examples/tutorial/_manifest.py
@@ -1071,6 +1071,11 @@ EXAMPLES = (
             ConfCheck('uninformed.conf', recover={'alpha': 1.2, 'gamma': 0.8},
                       dragged_min_err=0.10,
                       note='no informative prior to seed from -> tiny budget cannot find the basin'),
+            # The third way to answer "where does the search begin": pin it. A start point
+            # near the answer -- the point a previous fit would have handed you, ~12% and
+            # ~10% off the truth -- puts cmaes in the right basin from flat bounds, and the
+            # optimizer polishes the rest of the way.
+            ConfCheck('start_point.conf', recover={'alpha': 1.2, 'gamma': 0.8}, tol=0.01),
         ),
     ),
     Example(


### PR DESCRIPTION
Follow-up to #597, which shipped `start_point` documented only in the key reference, the gradient
page, and troubleshooting — all places you find it *after* you know it exists.

Refining a fit from a previous run's result is roughly the second thing anyone does, so the feature
belongs earlier than a reference lookup. (I originally argued the opposite and was wrong: I'd met
`start_point` in a benchmarking context and framed it as an advanced tool.)

## Lesson 44

Lesson 44 already asks this exact question — it is titled *"where the search starts"* and holds two
confs that answer it by describing a **distribution** to draw from: an informative prior
(`prior_seeded.conf`) and flat bounds (`uninformed.conf`). `start_point` answers it a third way —
name the **point** — so it belongs beside them rather than in a lesson of its own, and it reuses the
model, data and landscape already there.

`start_point.conf` starts `cmaes` at `(1.35, 0.72)`: deliberately **not** the truth, about 12% and
10% off it, the way a real previous fit's answer would be. Over the same flat bounds
`uninformed.conf` fails from, it polishes to `(1.19993, 0.80007)`, objective ~1e-08. The lesson is
that the start point supplied the **basin**, not the answer — which is why it is checked at
`tol=0.01`, tighter than its siblings: a seeded local polish should land on the answer, not near it.

> An earlier draft used `de` for symmetry with the two siblings. I discarded it after running it: on
> the tiny 8-iteration budget DE converged **at** the seed and returned `(1.35, 0.72)` unchanged,
> which teaches the opposite of the truth — that a start point pins the answer.

## Quickstart

Gains "Picking up where a fit left off", placed immediately after the first successful run, since
that is the moment the need appears: your results are in `sorted_params.txt`, here is how to start
the next run from them, and the bounds you already declared still hold.

## Verification

- Docs gate (`sphinx-build -W --keep-going`) passes.
- All three lesson-44 confs pass the manifest-driven recovery suite (`-m recovery`): 3 passed.