### PR TITLE
fix(config): hold a parameter: record to the same declaration rules as the equivalent *_var line (#603)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,6 +169,34 @@ All notable changes to PyBNF are documented below. This project adheres to
   says what it has not bisected.
 
 ### Fixed
+- **A `parameter:` record is now held to the same declaration rules as the equivalent `*_var`
+  line (#603, ADR-0118).** `_check_variable_keyword_combination` refuses an incoherent pairing
+  of free-parameter declarations and `job_type` — an unbounded prior handed to a box-mode
+  optimizer, `var`/`logvar` handed to a method that draws a population, a mix of point starts
+  and boxes. It decided what it was looking at by pattern-matching **config key names** with
+  `re.search('var$', k[0])`, which a `('parameter', <id>)` key never matches, so the whole rule
+  was silently bypassed by the edition-2 syntax:
+
+      legacy  normal_var = p1 0 1          -> refused: Box-mode optimizer requires a bounded prior
+      record  parameter: p1, prior: normal -> ACCEPTED
+
+  That matters more than an ordinary validation gap, because the record syntax is the *only*
+  one that can express `initial_value` — so the surface most likely to be used for careful,
+  seeded work was the one with no coherence checking at all.
+  The rule now keys on the **built `FreeParameter`** rather than on the key that declared it,
+  and runs after the variables exist rather than before. Both syntaxes produce the same
+  `FreeParameter`, so both now get the same answer. The obvious repair — re-deriving the
+  keyword set from `{v.type}` — was tried and rejected: a *truncated* prior carries a real
+  finite box while its family does not, so it would have falsely refused
+  `prior: normal, ..., lower: X, upper: Y` on `job_type = gntr`, which is an entire benchmark
+  corpus. Verified equivalent to the old rule for every untruncated declaration (family-level
+  and parameter-level bounded-support agree across all 48 registered prior keywords), and run
+  against **1049 real `.conf` files** with zero refusals.
+  The dead branch for ADR-0015's third fit_type category is deleted: every registered refiner
+  now also carries `start_from_box`, so the "point-only start optimizer" category is empty and
+  its code was unreachable. Error messages now name the offending **parameters** rather than a
+  keyword the record user never wrote, and point at `start_point` for the case they usually
+  mean — a bounded box searched from a chosen point.
 - **`starting_params` is now a configuration error on a `job_type` that has never read it
   (#559, ADR-0117).** It has exactly one read site — the Bayesian sampler base — so on the
   other fourteen `job_type`s it was accepted, validated against nothing, and then discarded

--- a/docs/adr/0118-a-declarations-coherence-with-the-job-type-is-a-property-of-the-built-free-parameter-not-of-the-config-key-that-declared-it-so-one-rule-now-covers-both-declaration-syntaxes.md
+++ b/docs/adr/0118-a-declarations-coherence-with-the-job-type-is-a-property-of-the-built-free-parameter-not-of-the-config-key-that-declared-it-so-one-rule-now-covers-both-declaration-syntaxes.md
@@ -1,0 +1,110 @@
+# A declaration's coherence with the job_type is a property of the built FreeParameter, not of the config key that declared it — so one rule now covers both declaration syntaxes (issue #603)
+
+**Status: Accepted and implemented (2026-08-19).** Closes a hole opened by ADR-0043 and
+found while implementing ADR-0117.
+
+`Configuration._check_variable_keyword_combination` refuses an incoherent pairing of
+free-parameter declarations and `job_type`: an unbounded prior handed to a box-mode
+optimizer, `var`/`logvar` handed to a method that draws a population, a mix of point
+starts and boxes. It decided what it was looking at by pattern-matching **config key
+names**, and a new-era `parameter:` record does not match that pattern — so the entire
+rule was silently bypassed by the edition-2 syntax.
+
+## The defect
+
+```python
+used = {k[0] for k in self.config.keys()
+        if isinstance(k, tuple) and re.search('var$', k[0])}
+```
+
+A record is stored under `('parameter', <id>)`, and `re.search('var$', 'parameter')` is
+`None`. The same declaration, in the two spellings, on `job_type = sim`:
+
+```
+legacy  normal_var = p1 0 1          -> refused: Box-mode optimizer requires a bounded prior
+record  parameter: p1, prior: normal -> ACCEPTED
+```
+
+This is the ADR-0117 failure class one layer up: a configuration PyBNF considers invalid is
+accepted without comment as long as it is written in the newer syntax. It matters more than
+a normal validation gap because the record syntax is the *only* one that can express
+`initial_value`, so the surface most likely to be used for careful seeded work was the one
+with no coherence checking at all.
+
+## Why the obvious fix is wrong
+
+The natural repair is to re-derive the keyword set from the loaded parameters —
+`{v.type for v in self.variables}`. That is **verified to break working configurations**:
+
+```
+truncated normal  -> type='normal_var'  has_bounded_support=True    (a REAL box, family unbounded)
+no-prior record   -> type='var'         has_bounded_support=False   (same as a legacy var line)
+```
+
+A truncated prior carries a genuine finite box while its *family* does not. Keying on
+`v.type` would look it up in the family-derived `bounded_prior_kws` set, find `normal_var`
+absent, and refuse it on every box-mode optimizer. That shape —
+`prior: normal, ..., lower: X, upper: Y` on `job_type = gntr` — is the entire Grein-2026
+benchmark corpus.
+
+## The decision
+
+**The discriminator is per parameter, and it is read off the built `FreeParameter`.** A new
+`_declaration_kind(v)` returns one of three kinds:
+
+| kind | test | what it is |
+|---|---|---|
+| `point` | `not v.has_prior` | `var` / `logvar` / `lnvar`, or a record with no prior and no bounds |
+| `box` | `v.has_bounded_support` | a uniform box, or **any family truncated to one** |
+| `unbounded` | otherwise | a prior with no box to span |
+
+Both declaration syntaxes produce the same `FreeParameter`, so they now get the same
+answer — which is the whole point. Verified equivalent to the old keyword-derived rule for
+every untruncated declaration: family-level and parameter-level `has_bounded_support` agree
+across all 48 registered prior keywords, so nothing that loaded before is refused now. The
+only divergence is truncation, which the legacy grammar cannot express and which the new
+rule classifies correctly.
+
+**The check moves to after the variables are built.** It previously ran from *inside*
+`_load_variables` before any `FreeParameter` existed, which is why it had to key on config
+keys in the first place. It now runs at the end of the same method, on the list it just
+built — a local change, not a call-order restructure of `Configuration.__init__`.
+
+**The dead branch is deleted.** ADR-0015 anticipated three categories of fit_type, the third
+being a *point-only* start optimizer (`refiner` and not `start_from_box`). That category is
+now empty — every registered refiner also carries `start_from_box`:
+
+```
+start_from_box: ['cmaes', 'gntr', 'lbfgs', 'ms', 'powell', 'sim', 'trf']
+refiner       : ['cmaes', 'gntr', 'lbfgs', 'ms', 'powell', 'sim', 'trf']
+```
+
+so the `fit_type not in box_types` branch was unreachable and its docstring actively
+misleading. Both are gone.
+
+**The messages name parameters rather than keywords.** `"parameter(s) k, m have an unbounded
+prior"` is true whichever syntax declared them, where `"the normal_var keyword"` is a
+sentence a record user never wrote. Each message also names the way out that ADR-0117 added:
+to search a box *and* begin at a chosen point, give every parameter a bounded prior and name
+the point with `start_point`.
+
+## Consequences
+
+* A `parameter:` record is now held to the same rules as the equivalent `*_var` line. Some
+  edition-2 configs that loaded before will now be refused — correctly; they were
+  configurations PyBNF already considered invalid and failed to say so about.
+* Measured blast radius: the rewritten rule was run against **1049 real `.conf` files** (the
+  `pybnf-jobs` corpus plus this tree's `examples/` and `tests/`), rebuilding each one's
+  declarations through the real loader helpers. **Zero refusals.**
+* Two in-tree tests were loading a no-prior record alongside prior-based records under
+  `job_type = de` — a mix that is refused in both directions. They were testing the record
+  *loader*, not the gate, and now load each declaration style under a `job_type` that accepts
+  it. That they passed before is a direct symptom of the bypass.
+* A half-bounded truncation (`lower: 0, upper: inf`) counts as `box`, since
+  `has_bounded_support` is true for any truncated prior. It is accepted by a box optimizer:
+  the 0.5 quantile is finite, and ADR-0117 already made `_box_widths_u` fall back to the
+  family scale where the support is infinite. Refusing it would be a new restriction, which
+  this change deliberately does not introduce.
+* `docs/config_keys.rst`'s account of the rule was stale in two ways and is corrected: it
+  named only Simplex/Powell/CMA-ES as start-point optimizers (the gradient methods and `ms`
+  are too), and said only CMA-ES could take a bounded prior instead (all of them can).

--- a/docs/config_keys.rst
+++ b/docs/config_keys.rst
@@ -827,14 +827,30 @@ Parameter and Model Specification
   ``*_var`` keyword is the legacy shorthand for the one- and two-parameter families.
 
 
-The following two keys (``var`` and ``logvar``) are the single-value start point used by the start-point optimizers —
-:ref:`Simplex <alg-sim>`, :ref:`Powell <alg-powell>`, and :ref:`CMA-ES <alg-cmaes>`. A fit with one of these
-``job_type``\ s must define every free parameter with ``var`` / ``logvar`` and use none of the prior-based
-parameter specifications above — except that CMA-ES may instead take bounded ``uniform_var`` / ``loguniform_var``
-priors to run as a global search over the box (see :ref:`CMA-ES <alg-cmaes>`). For any other algorithm, define
-parameters with the prior-based specifications, not ``var`` / ``logvar``. When refining a result (``refine = 1``),
-the optimizer is chosen by ``refine_method`` (``sim`` (default), ``powell``, or ``cmaes``); it reads that
-optimizer's own settings (e.g. ``simplex_step`` for Simplex), so you do not need to add ``var`` / ``logvar`` lines.
+The following two keys (``var`` and ``logvar``) are the single-value **start point** used by the
+start-point optimizers — :ref:`Simplex <alg-sim>`, :ref:`Powell <alg-powell>`, :ref:`CMA-ES <alg-cmaes>`,
+the gradient methods :ref:`trf / lbfgs / gntr <alg-gradient>`, and multiple shooting (``ms``).
+
+Each of those ``job_type``\ s accepts **either** style, and not a mix:
+
+* every parameter given a single value with ``var`` / ``logvar`` — a purely local search from
+  that point; or
+* every parameter given a **bounded** prior (``uniform_var`` / ``loguniform_var``, or any family
+  truncated to a finite box with ``lower:``/``upper:`` on a ``parameter:`` record) — a search over
+  that box, beginning at its centre unless you name a different start with
+  :ref:`start_point <start_point>`.
+
+An **unbounded** prior (``normal_var``, ``gamma_var``, …) is refused for these ``job_type``\ s:
+a box search needs a box. For any other algorithm, define parameters with the prior-based
+specifications, not ``var`` / ``logvar``.
+
+The rule is about what each parameter *is*, not how it is spelled: a ``parameter:`` record with
+no ``prior:`` and no ``lower:``/``upper:`` is a start point exactly as ``var`` is, and is accepted
+and refused in the same places.
+
+When refining a result (``refine = 1``), the optimizer is chosen by ``refine_method`` (``sim``
+(default), ``powell``, or ``cmaes``); it reads that optimizer's own settings (e.g. ``simplex_step``
+for Simplex), so you do not need to add ``var`` / ``logvar`` lines.
 
 **var**
   The starting point for a free parameter.  It is defined by a 3-tuple, corresponding to the variable's name, its initial

--- a/pybnf/config.py
+++ b/pybnf/config.py
@@ -3173,7 +3173,6 @@ class Configuration:
                              f'free parameter, but {qscale} is not declared. Declare it as a positive '
                              f'(log-scaled) variable, e.g. "loguniform_var = {qscale} <lower> <upper>".')
         fit_type = self.config['fit_type']
-        self._check_variable_keyword_combination(fit_type)
         variables = []
         initialization_distribution = self.config.get('initialization_distribution', 'prior')
         for k in self.config.keys():
@@ -3223,6 +3222,10 @@ class Configuration:
 
             logger.debug(f'Adding parameter {free_param.name} with bounds [{free_param.lower_bound}, {free_param.upper_bound}]')
             variables.append(free_param)
+        # After the loop, not before it: the rule is about what each parameter turned out
+        # to BE (a start point, a box, an unbounded prior), which is a property of the
+        # built FreeParameter rather than of the config key that declared it (#603).
+        self._check_variable_keyword_combination(fit_type, variables)
         logger.info('Loaded variables')
         return variables
 
@@ -3628,75 +3631,95 @@ class Configuration:
             unknown = ', '.join(sorted(leftover))
             raise PybnfError(f"Parameter '{pid}': unknown field(s) for {where}: {unknown}.")
 
-    def _check_variable_keyword_combination(self, fit_type):
-        """Validate that the fit's free-parameter keywords match what the fit_type
+    @staticmethod
+    def _declaration_kind(v):
+        """How ``v`` was declared, for the coherence rules: ``'point'`` (a single start
+        value, no prior), ``'box'`` (a prior with bounded support -- a uniform box, or any
+        family truncated to one), or ``'unbounded'`` (a prior with no box).
+
+        Read off the built :class:`~pybnf.pset.FreeParameter` rather than off the config
+        key that declared it. That is what makes the rules apply to **both** declaration
+        syntaxes: the legacy positional ``*_var`` keywords and the new-era ``parameter:``
+        record produce the same FreeParameter, so they get the same answer here (#603).
+        """
+        if not v.has_prior:
+            return 'point'
+        return 'box' if v.has_bounded_support else 'unbounded'
+
+    def _check_variable_keyword_combination(self, fit_type, variables):
+        """Validate that the fit's free-parameter declarations match what the fit_type
         accepts -- the var/logvar-vs-prior rule, generalized for the box optimizers.
 
-        Three categories of fit_type, derived from two registry flags (ADR-0005):
+        Two categories of fit_type (ADR-0005):
 
-        * **point-only start optimizer** (``refiner`` and not ``start_from_box`` --
-          Simplex, Powell): begins from a single value per parameter, so it takes
-          only the no-prior ``var`` / ``logvar`` keywords.
-        * **box-capable start optimizer** (``refiner`` and ``start_from_box`` --
-          CMA-ES, #404/ADR-0017): runs either from a single ``var`` / ``logvar``
-          point *or* over a bounded-prior box (``uniform_var`` / ``loguniform_var``),
-          but not a mix, and not an unbounded prior (which has no box to span).
+        * **start-point optimizer** (``refiner``): runs either from a single
+          ``var`` / ``logvar`` point *or* over a bounded-prior box, but not a mix, and
+          not an unbounded prior (which has no box to span).
         * **everything else** (samplers, population optimizers): draws every
           variable from a prior, so it never takes ``var`` / ``logvar``.
 
         ADR-0015 derived the var/logvar rule from ``refiner`` alone because "is a
-        refiner" and "takes a var/logvar point" then coincided; box mode is exactly
-        the divergence it flagged, so the capability splits onto ``start_from_box``.
+        refiner" and "takes a var/logvar point" then coincided; #404/ADR-0017 split box
+        mode onto ``start_from_box``. Every registered refiner now also carries
+        ``start_from_box``, so the two sets are identical and the third category ADR-0015
+        anticipated -- a point-only start optimizer -- is empty. The branch that served it
+        was dead code and is gone.
+
+        Takes ``variables`` (the built :class:`~pybnf.pset.FreeParameter` list) rather
+        than reading config keys. The old form pattern-matched key names with
+        ``re.search('var$', k[0])``, which a ``('parameter', id)`` record never matches --
+        so the whole rule was silently bypassed by the edition-2 syntax, and a
+        configuration this refuses when written positionally was accepted when written as
+        a record (#603). Keying on the FreeParameter is also the only correct discriminator:
+        a *truncated* prior carries a real finite box while its family does not, so the
+        family-keyed keyword set called it unbounded.
         """
         start_point_types = {code for code, e in FIT_TYPE_REGISTRY.items() if e.refiner}
-        box_types = {code for code, e in FIT_TYPE_REGISTRY.items() if e.start_from_box}
-        bounded_prior_kws = {kw for kw, (fam, _scale) in PRIOR_KEYWORD_MAP.items()
-                             if fam.has_bounded_support}
+        kinds = {v.name: self._declaration_kind(v) for v in variables}
+        point = sorted(n for n, k in kinds.items() if k == 'point')
+        prior = sorted(n for n, k in kinds.items() if k != 'point')
+        unbounded = sorted(n for n, k in kinds.items() if k == 'unbounded')
 
-        used = {k[0] for k in self.config.keys()
-                if isinstance(k, tuple) and re.search('var$', k[0])}
-        point_kws = used & {'var', 'logvar'}
-        prior_kws = used - {'var', 'logvar'}
-        unbounded_prior_kws = prior_kws - bounded_prior_kws
+        point_names, prior_names = ', '.join(point), ', '.join(prior)
 
         if fit_type not in start_point_types:
-            if point_kws:
-                names = ' / '.join(sorted(start_point_types))
+            if point:
+                methods = ' / '.join(sorted(start_point_types))
                 raise PybnfError(
-                    'Tried to use start-point variable type {} in another algorithm.'.format(' / '.join(sorted(point_kws))),
-                    "You've used the {} keyword, but var / logvar are only for the "
-                    "start-point optimizers (job_type = {}).\nValid keywords for other "
-                    "algorithms are: uniform_var, normal_var, lognormal_var, "
-                    "loguniform_var.".format(' / '.join(sorted(point_kws)), names))
+                    'Tried to use start-point variable type in another algorithm.',
+                    f"Parameter(s) {point_names} are declared as a single start point -- the "
+                    f"var / logvar keyword, or a 'parameter:' record with no prior and no "
+                    f"bounds -- but job_type = {fit_type} draws every parameter from a prior, "
+                    f"so there is nothing for a lone start value to mean.\nA start point is "
+                    f"only a complete declaration for the start-point optimizers "
+                    f"(job_type = {methods}). For any other method give each parameter a prior "
+                    f"(uniform_var / loguniform_var / normal_var / ...), or a 'parameter:' "
+                    f"record with a 'prior:' or a 'lower:'/'upper:' box.")
             return
 
-        # A start-point optimizer (Simplex / Powell / CMA-ES) from here on.
-        if not prior_kws:
+        # A start-point optimizer from here on.
+        if not prior:
             return  # classic single-point start (var / logvar only, or no vars)
 
-        names = ' / '.join(sorted(start_point_types))
-        if fit_type not in box_types:
-            raise PybnfError(
-                'Invalid start-point variable type {}'.format(' / '.join(sorted(prior_kws))),
-                "You've specified a start-point optimizer (job_type = {}; one of {}), "
-                "but defined a variable with the {} keyword.\nFor these optimizers, "
-                "you must instead define a single initial value for each variable\n"
-                "using the var or logvar keyword (e.g. var = p1 42 ).".format(fit_type, names, ' / '.join(sorted(prior_kws))))
-
-        # Box-capable optimizer given priors: must be a clean bounded-prior box.
-        if point_kws:
+        if point:
             raise PybnfError(
                 'Mixed start-point and box variable types',
-                "job_type = {} uses both a single-value start point (var / logvar) and "
-                "a prior-based variable ({}).\nUse one consistent style: var / logvar "
-                "for a point start, or uniform_var / loguniform_var for a global box "
-                "search.".format(fit_type, ' / '.join(sorted(prior_kws))))
-        if unbounded_prior_kws:
+                f"job_type = {fit_type} is given both kinds of declaration at once: "
+                f"{point_names} declared as a single start point (var / logvar, or a "
+                f"'parameter:' record with no prior), and {prior_names} declared with a "
+                f"prior.\nUse one consistent style -- a start point for every parameter, or a "
+                f"bounded prior for every parameter. To search a box *and* begin at a chosen "
+                f"point, give every parameter a bounded prior and name the point with "
+                f"'start_point = <parameter> <value>'.")
+        if unbounded:
+            unbounded_names = ', '.join(unbounded)
             raise PybnfError(
                 'Box-mode optimizer requires a bounded prior',
-                "job_type = {} runs a global box search when given priors, which needs a "
-                "bounded box, but variable type {} is unbounded.\nUse uniform_var / "
-                "loguniform_var for box mode, or var / logvar for a single-point start.".format(fit_type, ' / '.join(sorted(unbounded_prior_kws))))
+                f"job_type = {fit_type} runs a global box search when given priors, which "
+                f"needs a bounded box, but parameter(s) {unbounded_names} have an unbounded "
+                f"prior.\nUse uniform_var / loguniform_var for box mode, add a "
+                f"'lower:'/'upper:' box to the parameter's record to truncate the prior, or "
+                f"use var / logvar for a single-point start.")
 
     def _check_variable_correspondence(self):
         """Verify the config's free parameters and the models' parameters line up.

--- a/tests/test_config_class.py
+++ b/tests/test_config_class.py
@@ -153,56 +153,118 @@ class TestConfig(object):
         assert 'model.bngl' in out                             # model path untouched
         config.Configuration.check_unused_keys(conf)           # must not raise on the tuple key
 
-    # --- _check_variable_keyword_combination (var/logvar-vs-prior rule, #404) ---
-    # Driven directly on a bare instance (no full build): it only reads self.config
-    # keys + the fit_type. All three start-point optimizers are now box-capable
+    # --- _check_variable_keyword_combination (var/logvar-vs-prior rule, #404, #603) ---
+    # Driven directly on a bare instance: it takes the fit_type and the built
+    # FreeParameter list. All three start-point optimizers are box-capable
     # (start_from_box): cmaes (#404) and -- via concurrent multi-start, #498/ADR-0072
     # -- sim and powell. So the box rules below hold for the whole set.
+    #
+    # The rule keys on the built FreeParameter rather than on the config key that
+    # declared it (#603). That is what makes it apply to BOTH declaration syntaxes: the
+    # legacy positional `*_var` keyword and the new-era `parameter:` record produce the
+    # same FreeParameter, so each pair of tests below asserts the two spellings agree.
     _BOX_OPTIMIZERS = ['cmaes', 'sim', 'powell']
 
     @staticmethod
-    def _kw_checker(var_tuples):
+    def _kw_checker():
+        return object.__new__(config.Configuration)
+
+    @staticmethod
+    def _legacy(*specs):
+        """FreeParameters as the legacy positional `*_var` grammar builds them."""
+        out = []
+        for name, kw, p1, p2 in specs:
+            if kw in ('var', 'logvar', 'lnvar'):
+                out.append(pset.FreeParameter(name, kw, p1, p2))
+            else:
+                out.append(pset.FreeParameter(name, kw, p1, p2, bounded=True))
+        return out
+
+    @staticmethod
+    def _record(name, fields):
+        """A FreeParameter as a new-era `parameter:` record builds it -- through the real
+        loader, so the test exercises the same construction a conf would."""
         c = object.__new__(config.Configuration)
-        c.config = dict(var_tuples)
-        return c
+        return c._free_parameter_from_record(name, fields, 'prior')
 
     @pytest.mark.parametrize('fit_type', _BOX_OPTIMIZERS)
     def test_kw_combo_box_optimizer_accepts_bounded_priors(self, fit_type):
         """A box optimizer (start_from_box) accepts a bounded-prior box -> no raise."""
-        c = self._kw_checker({('uniform_var', 'p1'): [-10., 10.],
-                              ('loguniform_var', 'p2'): [0.1, 100.]})
-        c._check_variable_keyword_combination(fit_type)  # must not raise
+        vs = self._legacy(('p1', 'uniform_var', -10., 10.),
+                          ('p2', 'loguniform_var', 0.1, 100.))
+        self._kw_checker()._check_variable_keyword_combination(fit_type, vs)  # must not raise
 
     @pytest.mark.parametrize('fit_type', _BOX_OPTIMIZERS)
     def test_kw_combo_box_optimizer_accepts_point_start(self, fit_type):
         """A box optimizer still accepts a single var/logvar start point -> no raise."""
-        c = self._kw_checker({('var', 'p1'): [1., 0.5], ('logvar', 'p2'): [3.]})
-        c._check_variable_keyword_combination(fit_type)  # must not raise
+        vs = self._legacy(('p1', 'var', 1., 0.5), ('p2', 'logvar', 3., None))
+        self._kw_checker()._check_variable_keyword_combination(fit_type, vs)  # must not raise
 
     @pytest.mark.parametrize('fit_type', _BOX_OPTIMIZERS)
     def test_kw_combo_box_optimizer_rejects_unbounded_prior(self, fit_type):
         """A box search needs a bounded box: normal_var (unbounded) is rejected."""
-        c = self._kw_checker({('normal_var', 'p1'): [0., 1.]})
-        with pytest.raises(printing.PybnfError):
-            c._check_variable_keyword_combination(fit_type)
+        vs = [pset.FreeParameter('p1', 'normal_var', 0., 1.)]
+        with pytest.raises(printing.PybnfError, match='bounded prior'):
+            self._kw_checker()._check_variable_keyword_combination(fit_type, vs)
 
     @pytest.mark.parametrize('fit_type', _BOX_OPTIMIZERS)
     def test_kw_combo_box_optimizer_rejects_mixed_point_and_box(self, fit_type):
         """A var point mixed with a uniform_var box is ambiguous -> rejected."""
-        c = self._kw_checker({('var', 'p1'): [1.], ('uniform_var', 'p2'): [-10., 10.]})
-        with pytest.raises(printing.PybnfError):
-            c._check_variable_keyword_combination(fit_type)
+        vs = self._legacy(('p1', 'var', 1., None), ('p2', 'uniform_var', -10., 10.))
+        with pytest.raises(printing.PybnfError, match='Mixed'):
+            self._kw_checker()._check_variable_keyword_combination(fit_type, vs)
 
     @raises(printing.PybnfError)
     def test_kw_combo_sampler_rejects_var_keyword(self):
         """A non-start-point method (de) rejects the var/logvar start-point keyword."""
-        c = self._kw_checker({('var', 'p1'): [1.]})
-        c._check_variable_keyword_combination('de')
+        vs = self._legacy(('p1', 'var', 1., None))
+        self._kw_checker()._check_variable_keyword_combination('de', vs)
 
     def test_kw_combo_sampler_accepts_priors(self):
         """Negative control: de with uniform_var priors -> no raise."""
-        c = self._kw_checker({('uniform_var', 'p1'): [-10., 10.]})
-        c._check_variable_keyword_combination('de')  # must not raise
+        vs = self._legacy(('p1', 'uniform_var', -10., 10.))
+        self._kw_checker()._check_variable_keyword_combination('de', vs)  # must not raise
+
+    # --- the same rules, stated as `parameter:` records (#603) -------------------- #
+    # Before #603 the rule matched config keys with `re.search('var$', k[0])`, which a
+    # ('parameter', id) key never matches -- so every refusal below was silently skipped
+    # and the record syntax accepted configurations the legacy syntax rejects.
+
+    @pytest.mark.parametrize('fit_type', _BOX_OPTIMIZERS)
+    def test_kw_combo_record_unbounded_prior_is_rejected_like_the_keyword(self, fit_type):
+        vs = [self._record('p1', {'prior': 'normal', 'mean': '0', 'sd': '1'})]
+        with pytest.raises(printing.PybnfError, match='bounded prior'):
+            self._kw_checker()._check_variable_keyword_combination(fit_type, vs)
+
+    @raises(printing.PybnfError)
+    def test_kw_combo_record_point_start_is_rejected_by_a_sampler(self):
+        """A record with no prior and no bounds is a point start, whatever it is spelled."""
+        vs = [self._record('p1', {'initial_value': '1.0'})]
+        self._kw_checker()._check_variable_keyword_combination('de', vs)
+
+    @pytest.mark.parametrize('fit_type', _BOX_OPTIMIZERS)
+    def test_kw_combo_record_mixed_point_and_box_is_rejected(self, fit_type):
+        vs = [self._record('p1', {'initial_value': '1.0'}),
+              self._record('p2', {'prior': 'uniform', 'lower': '-10', 'upper': '10'})]
+        with pytest.raises(printing.PybnfError, match='Mixed'):
+            self._kw_checker()._check_variable_keyword_combination(fit_type, vs)
+
+    @pytest.mark.parametrize('fit_type', _BOX_OPTIMIZERS)
+    def test_kw_combo_truncated_prior_is_a_box_not_an_unbounded_prior(self, fit_type):
+        """The case that makes the keyword-keyed rule unfixable in place, and the reason
+        the discriminator must be per-parameter: a truncated normal carries a real finite
+        box (`has_bounded_support` True) while its FAMILY is unbounded, so a rule keyed on
+        the family would refuse it. This shape is the whole Grein-2026 benchmark corpus --
+        `prior: normal, ..., lower: X, upper: Y` on `job_type = gntr`."""
+        vs = [self._record('p1', {'prior': 'normal', 'mean': '0', 'sd': '1',
+                                  'lower': '-5', 'upper': '5'})]
+        self._kw_checker()._check_variable_keyword_combination(fit_type, vs)  # must not raise
+
+    def test_kw_combo_truncated_prior_is_still_a_prior_for_a_sampler(self, ):
+        """Negative control for the above: it is a prior, so a sampler takes it too."""
+        vs = [self._record('p1', {'prior': 'normal', 'mean': '0', 'sd': '1',
+                                  'lower': '-5', 'upper': '5'})]
+        self._kw_checker()._check_variable_keyword_combination('de', vs)  # must not raise
 
     # --- _check_variable_correspondence (the config-level free-parameter guard) ---
     # Tricky.bngl declares __FREE params: koff__FREE, __koff2__FREE, kase__FREE, pase__FREE.
@@ -436,11 +498,18 @@ class TestParameterRecordConfig:
     _GAUSS_TARGET = json.dumps({'type': 'gaussian', 'mean': [0.0], 'variance': [1.0]})
     _TARGET_EXP = '# index\tscore\n0\t0\n'
 
-    def _build_vars(self, tmp_path, monkeypatch, param_lines):
+    def _build_vars(self, tmp_path, monkeypatch, param_lines, job_type='de'):
+        """Load ``param_lines`` and return the built FreeParameters by name.
+
+        ``job_type`` defaults to ``de``, which takes prior-based declarations. A record
+        with no prior and no bounds is a *point start*, which only a start-point optimizer
+        accepts and which may not be mixed with prior-based parameters -- so a no-prior
+        record needs its own call with ``job_type='sim'`` (#603 made that rule apply to
+        the record syntax, which had been bypassing it)."""
         (tmp_path / 'gaussian.target').write_text(self._GAUSS_TARGET)
         (tmp_path / 'target.exp').write_text(self._TARGET_EXP)
         monkeypatch.chdir(tmp_path)
-        conf = ('edition = 2\njob_type = de\nobjective = sos\n'
+        conf = (f'edition = 2\njob_type = {job_type}\nobjective = sos\n'
                 'model = gaussian.target : target.exp\n'
                 'population_size = 5\nmax_iterations = 5\nwall_time_sim = 0\n'
                 + ''.join(line + '\n' for line in param_lines))
@@ -557,11 +626,15 @@ class TestParameterRecordConfig:
     def test_initial_value_routing(self, tmp_path, monkeypatch):
         # A prior parameter carries initial_value as its theta-space .value (read by the
         # population seed); a no-prior start point carries it as the first slot (Simplex reads p1).
+        # Loaded separately because the two are different KINDS of declaration -- a box and a
+        # point start -- and mixing them in one fit is refused (#603).
         got = self._build_vars(tmp_path, monkeypatch, [
             'parameter: p, prior: normal, mean: 0, sd: 1, lower: -5, upper: 5, initial_value: 2',
-            'parameter: s, initial_value: 3',
         ])
         assert got['p'].value == 2.0
+        got = self._build_vars(tmp_path, monkeypatch, [
+            'parameter: s, initial_value: 3',
+        ], job_type='sim')
         assert got['s'].type == 'var' and got['s'].p1 == 3.0
 
     def test_parameter_scale_linear_log10_ln(self, tmp_path, monkeypatch):
@@ -574,8 +647,12 @@ class TestParameterRecordConfig:
             'parameter: b, prior: normal, parameter_scale: log10, mean: 1, sd: 0.5',
             'parameter: c, prior: normal, parameter_scale: ln, mean: 1, sd: 0.5',
             'parameter: u, prior: uniform, parameter_scale: ln, lower: 0.1, upper: 100',
-            'parameter: s, parameter_scale: ln, initial_value: 2',                 # no-prior ln start point
         ])
+        # The no-prior ln start point is a point-start declaration, so it loads under a
+        # start-point optimizer and not alongside the priors above (#603).
+        got['s'] = self._build_vars(tmp_path, monkeypatch, [
+            'parameter: s, parameter_scale: ln, initial_value: 2',
+        ], job_type='sim')['s']
         ref = stats.norm(1, 0.5)
         assert got['a'].scale_name == 'linear' and not got['a'].log_space
         assert got['b'].type == 'lognormal_var' and got['b'].scale_name == 'log10'

--- a/tests/test_noise_model_config.py
+++ b/tests/test_noise_model_config.py
@@ -303,7 +303,7 @@ def test_declared_noise_free_param_passes_check():
         _is_free_param_key=Configuration._is_free_param_key,
         # ... and stub the downstream keyword-combination check (separate concern); the
         # point here is that the noise-param check does not raise for a declared param.
-        _check_variable_keyword_combination=lambda fit_type: None,
+        _check_variable_keyword_combination=lambda fit_type, variables: None,
         # ... and the qualitative-scale free-param check, unused here.
         _qualitative_scale_param=lambda: None)
     variables = Configuration._load_variables(ns)


### PR DESCRIPTION
Closes #603.

## The defect

`_check_variable_keyword_combination` refuses an incoherent pairing of free-parameter declarations
and `job_type`. It decided what it was looking at by pattern-matching **config key names**:

```python
used = {k[0] for k in self.config.keys()
        if isinstance(k, tuple) and re.search('var$', k[0])}
```

A `parameter:` record lives under `('parameter', <id>)`, and `re.search('var$', 'parameter')` is
`None` — so the whole rule was silently bypassed by the edition-2 syntax. The same declaration in
the two spellings, on `job_type = sim`:

```
legacy  normal_var = p1 0 1          -> refused: Box-mode optimizer requires a bounded prior
record  parameter: p1, prior: normal -> ACCEPTED
```

This is #583/#559's failure class one layer up, and it matters more than an ordinary validation
gap: the record syntax is the **only** one that can express `initial_value`, so the surface most
likely to be used for careful, seeded work was the one with no coherence checking at all.

## The fix

The rule now keys on the **built `FreeParameter`** and runs after the variables exist — which is
why it had to key on config keys in the first place. Both syntaxes produce the same
`FreeParameter`, so both now get the same answer. Three kinds, per parameter:

| kind | test | what it is |
|---|---|---|
| `point` | `not v.has_prior` | `var` / `logvar` / `lnvar`, or a record with no prior and no bounds |
| `box` | `v.has_bounded_support` | a uniform box, or **any family truncated to one** |
| `unbounded` | otherwise | a prior with no box to span |

**The obvious repair was tried and rejected.** Re-deriving from `{v.type}` looks right and is
wrong: a truncated prior carries a real finite box while its *family* does not, so `normal_var`
would be looked up in the family-derived bounded set, not found, and
`prior: normal, ..., lower: X, upper: Y` refused on `job_type = gntr` — which is the entire
Grein-2026 benchmark corpus.

## Blast radius, measured

- **Equivalent to the old rule for every untruncated declaration.** Family-level and
  parameter-level `has_bounded_support` agree across all 48 registered prior keywords, so nothing
  that loaded before is refused now. The only divergence is truncation, which the legacy grammar
  cannot express and which the new rule classifies correctly.
- **1049 real `.conf` files** — the `pybnf-jobs` corpus plus this tree's `examples/` and `tests/` —
  each one's declarations rebuilt through the real loader helpers and run through the new rule.
  **Zero refusals.**

## Also in scope

- **The dead branch is deleted.** ADR-0015 anticipated a third fit_type category, a *point-only*
  start optimizer (`refiner` and not `start_from_box`). It is empty — every registered refiner now
  also carries `start_from_box` — so that branch was unreachable and its docstring actively
  misleading.
- **Messages name parameters, not keywords.** `"parameter(s) k, m have an unbounded prior"` is true
  whichever syntax declared them; `"the normal_var keyword"` is a sentence a record user never
  wrote. Each also points at the way out #597 added: for a bounded box searched from a chosen
  point, give every parameter a bounded prior and name the point with `start_point`.
- **`docs/config_keys.rst` was stale two ways** and is corrected: it named only
  Simplex/Powell/CMA-ES as start-point optimizers (the gradient methods and `ms` are too), and said
  only CMA-ES could take a bounded prior instead of a point (all of them can).

## A note on two changed tests

Two in-tree tests were loading a no-prior record *alongside* prior-based records under
`job_type = de` — a mix that is refused in both directions. They test the record **loader**, not
the gate, and now load each declaration style under a `job_type` that accepts it. That they passed
before is a direct symptom of the bypass.

## Verification

- Full default suite: **4205 passed, 23 skipped**.
- Docs gate (`sphinx-build -W --keep-going`) and `ruff@0.15.14`: pass.
- New tests assert each rule under **both** spellings, plus the truncated-prior case that makes the
  keyword-keyed version unfixable in place.