### PR TITLE
A behavioural capability is read from a published key that only a carrying build publishes, not from a version string (#558, ADR-0119)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,6 +169,45 @@ All notable changes to PyBNF are documented below. This project adheres to
   says what it has not bisected.
 
 ### Fixed
+- **The discrete-event gradient gate reads a bngsim capability instead of a version floor, so a
+  from-source build that merely *declares* a new enough version no longer passes it (#558,
+  ADR-0119).** `BNGSIM_HAS_EVENT_SENS` gates forward sensitivities that survive a discrete
+  event, and it does not gate a missing feature — it gates **silent wrongness**: a build below
+  the line does not refuse an event it cannot differentiate, it returns a finite tensor with the
+  event's contribution missing. It decided by comparing `bngsim.__version__` against exactly
+  `0.12.2`. bngsim bumps its version at the *start* of a release cycle, so every from-source
+  build made between that bump and the fixes that set the line (lanl/bngsim#144, #146) declares
+  the same string as the release that carries them, clears the floor, and is reported as
+  carrying them. The two failure directions are not symmetric — a false *absent* is a refusal
+  and a metaheuristic fit; a false *present* is a gradient fit that runs to completion and
+  reports a converged wrong number — and a version compare could only ever be wrong the second
+  way. The neighbouring `BNGSIM_HAS_PER_SPECIES_ATOL` already carried the argument, for the same
+  version string, in a comment on the wrong flag.
+  The gate now resolves through published capabilities: `features['event_sensitivities']` if
+  bngsim ever publishes a dedicated key (both directions, so the flag starts reading the real
+  answer on the first build that grows one, with no PyBNF release), otherwise
+  `features['effective_ic_sensitivity']` — a **witness**, usable because lanl/bngsim#155 added it
+  three commits after #146 inside the same release window, so a build that publishes it
+  necessarily carries the fixes. The version survives only as a veto: it can no longer report the
+  capability present on its own, because the witness shipped *in* 0.12.2 and a build claiming
+  0.12.2-or-newer without it is exactly the pre-release build at issue. **No install that works
+  today is refused** — every released bngsim at or above the floor publishes the witness — and a
+  refusal now names the route that decided (`event_sens_probe()`) rather than telling a reader
+  who already has 0.12.2 to upgrade to 0.12.2.
+- **A fit whose bngsim loaded a compiled core older than its own C++ says so at job start, not in
+  import noise (#558, ADR-0119).** An editable bngsim serves live Python from the source tree
+  while loading `_bngsim_core*.so` from a separately built artifact with auto-rebuild off, so the
+  two halves drift — one install reporting `0.12.2` was found with a core binary three days older
+  than the `.cpp` beside it. Every version, metadata and feature-key check passes there, because
+  nothing in the Python layer moved. bngsim detects it by mtime and warns, but it warns at
+  *import*, which for PyBNF is while the `pybnf` package loads: before `init_logging`, before the
+  config is read, and before the user has committed to anything. PyBNF now repeats it at job
+  start — the core's identity line (path, build commit, mtime) to the log unconditionally, the
+  staleness report promoted to a console warning at verbosity 0 — where a reader can still stop a
+  run that would otherwise spend hours producing statements about code that is no longer in the
+  tree. `bngsim_build_id()` exposes the commit the core was built from, which is the only thing
+  on hand that tells two installs declaring one version apart. Every read is guarded and
+  memoized; an install that cannot answer reports no opinion rather than taking the fit down.
 - **A `parameter:` record is now held to the same declaration rules as the equivalent `*_var`
   line (#603, ADR-0118).** `_check_variable_keyword_combination` refuses an incoherent pairing
   of free-parameter declarations and `job_type` — an unbounded prior handed to a box-mode

--- a/docs/adr/0119-a-behavioural-capability-is-read-from-a-published-key-that-only-a-carrying-build-publishes-because-a-version-string-is-a-claim-a-from-source-build-does-not-have-to-honour.md
+++ b/docs/adr/0119-a-behavioural-capability-is-read-from-a-published-key-that-only-a-carrying-build-publishes-because-a-version-string-is-a-claim-a-from-source-build-does-not-have-to-honour.md
@@ -1,0 +1,164 @@
+# A behavioural capability is read from a published key that only a carrying build publishes, because a version string is a claim a from-source build does not have to honour (issue #558)
+
+**Status: Accepted and implemented (2026-08-20).** Revises how one flag introduced by #536
+is decided; the flag's meaning, and everything gated on it, are unchanged.
+
+`pybnf/_bngsim_caps.py` is the one module allowed to ask what the installed bngsim can do.
+It gated two capabilities two different ways, and the file itself explained why one of them
+was unsafe — on the *other* flag:
+
+| flag | how it decided |
+|---|---|
+| `BNGSIM_HAS_PER_SPECIES_ATOL` | a **name** probe: `hasattr(bngsim, 'AUTO')` |
+| `BNGSIM_HAS_EVENT_SENS` | a **version floor** at exactly `(0, 12, 2)` |
+
+> The probe is a name, not a version. The build that first carried #196 still declares
+> 0.12.2 — the same string as the released wheel 25 commits behind it — so a version floor
+> here would report *present* on an install that does not have it, and that is the expensive
+> direction.
+
+That is the whole argument, it is correct, and it applied verbatim to the flag next to it.
+
+## The defect
+
+bngsim bumps `__version__` at the **start** of a release cycle, not at the end. So the
+version string identifies a *cycle*, not a build, and every from-source build made between
+the bump and a given fix declares the same string as the release that carries it. For
+`BNGSIM_HAS_EVENT_SENS` the fixes that set the line — lanl/bngsim#144 (an event assignment
+reading the state lost its carried term `∂h/∂x·s⁻`) and lanl/bngsim#146 (a solver root
+firing nothing rewound the state but not the sensitivity history) — landed inside the
+0.12.1 → 0.12.2 window. A build from anywhere in that window before them declares `0.12.2`,
+clears a `>= (0, 12, 2)` floor, and is reported as carrying them.
+
+What that costs is asymmetric, and the asymmetry is the point. The flag does not gate a
+*feature*; it gates **silent wrongness**. A build below the line does not refuse an event it
+cannot differentiate — it returns a finite tensor with the event's contribution missing. So a
+false *absent* is a refusal and a metaheuristic fit, while a false *present* is a gradient
+fit that runs to completion, converges, and reports a number. The floor could only ever be
+wrong in the second direction.
+
+This is not hypothetical. Its sibling failure cost a real fit: on `Smith_BMCSystBiol2013`,
+reaction 7 is `per_species_volume_scaling`, and without lanl/bngsim#160/#161 the whole model
+declines the analytic `∂f/∂p`, all 25 columns fall back to CVODES difference quotients, and
+every start times out to `inf`. The released 0.12.2 wheel lacks those commits and clears the
+same floor. Thirteen hours produced nothing, and the capability layer could not tell the two
+installs apart. The corpus note written up from that run reached the conclusion
+independently: *probe capability, never version.*
+
+## Why the obvious fixes are wrong
+
+**Raise the floor.** To what? There is no released version that separates a build carrying
+the fixes from a build declaring the same number and not carrying them — that is what "the
+same number" means. Raising the floor to 0.13.0 would refuse the released 0.12.2, which is
+correct, while still admitting a from-source 0.13.0 built before whatever the *next* fix is.
+The instrument is wrong, not its setting.
+
+**Probe a name.** This is what the neighbouring flags do, and it is unavailable here. What
+separates these builds is behaviour, not API surface: `event_sensitivity_unsupported_reason`
+has existed since bngsim's initial public release, and nothing in the Python namespace
+appears or disappears at #144 or #146.
+
+**Read a feature key.** `capabilities()` reports compiled backends and build options. It has
+no key for "carries the event-sensitivity fixes", and it is not PyBNF's to add. This is the
+honest reason the floor was written in the first place, and #558 states it as a defect
+upstream of PyBNF rather than a PyBNF bug.
+
+**Probe behaviour numerically.** Build a model with a state-reading event assignment, run it
+with sensitivities, compare against a central difference — this is the measurement that
+found the bug (`-10.96` where the model's own central difference says `-311.20`). It is the
+only *direct* answer, and it costs a codegen and a compile at job start, needs the codegen
+capability to be present at all in order to answer a question about a different capability,
+and introduces a numerical tolerance that can itself be wrong. Rejected as the default; it
+remains the right instrument for a capability with no witness at all.
+
+## The decision
+
+**Decide from a published capability key that only a carrying build publishes, and demote
+the version to a veto.** `BNGSIM_HAS_EVENT_SENS` now resolves through three routes, first
+match wins:
+
+| # | route | when it answers |
+|---|---|---|
+| 1 | `features['event_sensitivities']` | if bngsim ever publishes a dedicated key — **both** directions, ahead of everything else |
+| 2 | `features['effective_ic_sensitivity']` **and** version ≥ 0.12.2 | today |
+| 3 | neither key published | absent |
+
+Route 1 is issue #558's first ask and fires on no build that exists: naming the key costs
+nothing and means the flag starts reading the real answer on the first bngsim that grows one,
+without another PyBNF release. A published `False` there outranks route 2, or the key would
+be decoration.
+
+Route 2 is the load-bearing one, and it is a **witness**, not the capability.
+`effective_ic_sensitivity` reports `Model.effective_ic_sensitivity` — the `∂x(0)/∂θ` reader
+ADR-0100 consumes, which has nothing to do with events. It is usable as evidence because of
+*where it landed*: lanl/bngsim#155 added it three commits after #146 and seven after #144,
+inside the same release window, so a build that publishes it necessarily carries both. The
+implication runs one way only:
+
+```
+publishes effective_ic_sensitivity  ⟹  carries #144 and #146
+```
+
+and the converse failure — a build from the handful of commits between #146 and #155, which
+has the fixes and not the witness — reads as *absent* and is refused. That is the direction
+the flag is allowed to be wrong in.
+
+Route 3 is where the old floor used to live, and the change is that **the version can no
+longer carry the answer on its own.** The witness shipped *in* 0.12.2, so a build claiming
+0.12.2-or-newer that does not publish it is precisely the lying pre-release build. The floor
+survives only as a conjunct on route 2, where it vetoes an incoherent build and preserves the
+deliberate fail-closed reading of an unparseable version.
+
+**No install that works today is refused.** Every released bngsim at or above the floor
+publishes the witness; every one below fails both the witness and the floor, exactly as
+before. The only installs whose answer changes are from-source builds inside the window —
+which is the entire purpose.
+
+**A refusal names the route, not the version.** `event_sens_probe()` returns the phrase that
+answered, and `_require_differentiable_dynamics` prints it. Without that, a reader whose
+bngsim already reports 0.12.2 is told to upgrade to 0.12.2.
+
+### The trap one level down: a stale compiled core
+
+An editable bngsim serves live Python from the source tree while loading `_bngsim_core*.so`
+from a separately built artifact, with auto-rebuild deliberately off (lanl/bngsim#23). The
+two halves drift, and during unrelated work an install reporting `0.12.2` was found with a
+core binary three days older than the `.cpp` beside it. **Every check in this ADR passes
+there** — the version, the feature keys, the witness — because nothing in the Python layer
+moved. Only bngsim's own mtime comparison sees it.
+
+bngsim already does that comparison and warns. The problem is *when*: PyBNF imports bngsim
+while loading its own package, which is before `init_logging`, before the config is read, and
+before the user has committed to anything, so the warning lands in import noise on a terminal
+nobody is reading yet. `_report_bngsim_build()` repeats it at job start — the identity line
+to the log unconditionally, the staleness report promoted to a console warning at verbosity 0
+— where a reader can still stop a run that would otherwise spend hours producing statements
+about code that is no longer in the tree. The identity line carries the build commit, which
+is the only thing on hand that tells two installs declaring one version apart.
+
+Reads of `bngsim._build_provenance` are guarded and memoized, and every failure is silent: it
+is a private module, `gather()` walks the whole C++ source tree, and an install that cannot
+answer must report no opinion rather than take a fit down.
+
+## Consequences
+
+* The general shape is reusable and is stated as the rule for this module: **a capability is
+  decided by what the build says it can do; a version string is at most a veto.** The two
+  neighbouring `hasattr` flags already followed it; this one now does too, and it does it
+  through a published key rather than a name, which bngsim's "existing names will not be
+  renamed or removed" contract covers.
+* A witness is a proxy and its justification is a fact about *history*, not about semantics.
+  It has to be written down at the probe, and it is. If bngsim publishes a dedicated key,
+  route 1 retires the witness with no further change here.
+* Fail-closed is now the behaviour on ambiguity in both places: an unpublished witness and an
+  unparseable version both read absent. The cost of the wrong guess is a metaheuristic fit;
+  the cost of the other wrong guess is a converged wrong answer.
+* Not addressed here: surfacing bngsim's *analytic `∂f/∂p` decline* — the `Smith` failure —
+  as a PyBNF-level warning. That is a different capability (lanl/bngsim#160/#161), it is
+  reported by bngsim on the `bngsim` logger at codegen time rather than by `capabilities()`,
+  and codegen happens on a worker at the first simulation rather than at setup, so it needs
+  its own decision about where a worker-side decline reaches the user.
+* The standing ask upstream is unchanged: behaviour-level feature keys in `capabilities()`,
+  plus a resolved build identifier. Route 1 exists so that PyBNF consumes the first of those
+  the day it appears; `bngsim_build_id()` consumes the second, which `_build_provenance`
+  already computes.

--- a/docs/gradient_fitting.rst
+++ b/docs/gradient_fitting.rst
@@ -777,9 +777,9 @@ right only if the solver applies the event's own jump to it at each fire,
          + \frac{\partial h}{\partial p}
          - f^+\frac{\partial t^*}{\partial p}
 
-for a state assignment :math:`x^+ = h(x^-, p)` firing at :math:`t^*`. On a bngsim **newer than
-0.12.1** it does, so an event-bearing model fits on ``trf`` / ``lbfgs`` / ``gntr`` like any
-other. The event shapes it covers are:
+for a state assignment :math:`x^+ = h(x^-, p)` firing at :math:`t^*`. A bngsim that applies it
+— every release from **0.12.2** — lets an event-bearing model fit on ``trf`` / ``lbfgs`` /
+``gntr`` like any other. The event shapes it covers are:
 
 * a **fixed trigger time** (``time >= 5``), where the crossing does not move with the parameters
   (:math:`\partial t^*/\partial p = 0`) and the jump is the assignment Jacobian alone;
@@ -794,16 +794,35 @@ one differentiable surface — is refused per simulation with a message naming t
 fit stops with an actionable error rather than a wrong gradient. Use a metaheuristic ``job_type``
 for those.
 
-**On bngsim 0.12.1 or older** the refusal is instead *blanket* and arrives up front, at
-construction. The floor is set by silent wrongness, not by a missing feature: such a build can
-answer an event it cannot actually differentiate without saying so. A trigger reading the state
-came back as a finite tensor with the event's contribution missing rather than being refused
-(lanl/bngsim#52, through 0.11.x); an assignment reading the state — ``A := A + dose``, the
-repeat-dosing idiom — dropped the carried term and restarted the assigned row from zero
-(lanl/bngsim#144, through 0.12.1); and a solver root that fires nothing rewound the state but not
-the sensitivity history (lanl/bngsim#146, through 0.12.1). PyBNF declines the whole class on
-those builds rather than run a fit to completion on a wrong gradient, and the message names the
-upgrade.
+**On an older bngsim** the refusal is instead *blanket* and arrives up front, at construction.
+The line is drawn by silent wrongness, not by a missing feature: such a build can answer an event
+it cannot actually differentiate without saying so. A trigger reading the state came back as a
+finite tensor with the event's contribution missing rather than being refused (lanl/bngsim#52,
+through 0.11.x); an assignment reading the state — ``A := A + dose``, the repeat-dosing idiom —
+dropped the carried term and restarted the assigned row from zero (lanl/bngsim#144, through
+0.12.1); and a solver root that fires nothing rewound the state but not the sensitivity history
+(lanl/bngsim#146, through 0.12.1). PyBNF declines the whole class on those builds rather than run
+a fit to completion on a wrong gradient, and the message names what to install.
+
+**PyBNF decides this from a capability, not from a version string** (ADR-0119). It reads
+``bngsim.capabilities()`` and asks whether the build publishes the feature key that only a build
+carrying those fixes publishes; the version is a veto on the answer, never the answer itself.
+The distinction matters for anyone running bngsim from source: bngsim bumps its version at the
+*start* of a release cycle, so a from-source build made between that bump and the fixes declares
+the same string as the release that carries them — and a version compare reports the capability
+present on it, which is the direction that costs a wrong gradient rather than a refusal. If you
+are refused on a build whose version already looks new enough, that is what happened; the
+refusal names the key it looked for. Install a released bngsim ≥ 0.12.2, or a source build at or
+past lanl/bngsim#155.
+
+**A compiled core older than its own C++ is the same trap one level down.** An editable bngsim
+serves live Python from the source tree while loading its compiled extension from a separately
+built artifact, with auto-rebuild deliberately off, so the two halves drift — and a version, a
+feature key and every other metadata check pass regardless, because nothing in the Python layer
+moved. bngsim detects this by comparing mtimes and warns at import, which for PyBNF is while the
+package is loading, before logging is configured. PyBNF repeats that warning **at job start**,
+together with the commit the loaded core was built from, where a reader can still stop the run;
+if you see it, rebuild bngsim before trusting any number the fit produces.
 
 **Discontinuity triggers are not events.** A forcing pulse or a piecewise-time schedule written
 as ``if(t >= tau)`` in a rate law breaks the integrator step but never jumps the state, so it

--- a/pybnf/_bngsim_caps.py
+++ b/pybnf/_bngsim_caps.py
@@ -158,9 +158,9 @@ BNGSIM_HAS_SCAN_SENS_CARRY = bool(
 #     s+ = dh/dx . (s- + f-.dt*/dp) + dh/dp - f+.dt*/dp
 #
 # bngsim applies at each fire, for the event subclasses it can classify (#536).
-# The floor is set by the last build that could return a wrong jump *without
-# saying so*, because that -- not a missing feature -- is what this flag guards
-# against. Three separate silent derivatives had to go first:
+# The line this flag draws is set by the last build that could return a wrong
+# jump *without saying so*, because that -- not a missing feature -- is what it
+# guards against. Three separate silent derivatives had to go first:
 #
 # * a trigger that reads the state through an SBML document (``S < 30``) was
 #   neither refused nor differentiated, returning a finite tensor missing the
@@ -176,26 +176,107 @@ BNGSIM_HAS_SCAN_SENS_CARRY = bool(
 #   history, injecting a spurious step into every column (lanl/bngsim#146),
 #   also after 0.12.1.
 #
-# So the floor is "newer than 0.12.1", which every later release satisfies
-# whether the next one bumps the minor or the major. What the qualifying build
-# then *supports* is a separate, wider question -- a fixed trigger time
-# (bngsim GH #212), a threshold that is a fitted constant (lanl/bngsim#49), a
-# state-dependent trigger differentiated in flight (lanl/bngsim#144) -- and it
-# refuses the rest per simulation rather than guessing, which is exactly why
-# PyBNF can stop classifying events itself.
+# What a qualifying build then *supports* is a separate, wider question -- a
+# fixed trigger time (bngsim GH #212), a threshold that is a fitted constant
+# (lanl/bngsim#49), a state-dependent trigger differentiated in flight
+# (lanl/bngsim#144) -- and it refuses the rest per simulation rather than
+# guessing, which is exactly why PyBNF can stop classifying events itself.
 #
-# ``capabilities()`` has no feature key to read here -- it reports compiled
-# backends and build options, and what separates these builds is a set of bug
-# fixes -- so this is a version floor rather than a probe. An unparseable
-# version reads as *absent* (fail closed): elsewhere in this module an
-# unparseable version is accepted, because rejecting it would brick an
+# HOW THE LINE IS DRAWN (#558). It used to be drawn by a version floor at
+# exactly 0.12.2, and a version floor is the wrong instrument for it: the three
+# fixes above are behaviour, and a build's version string is a claim about
+# behaviour that a from-source build does not have to honour. bngsim bumps
+# ``__version__`` at the start of a release cycle, so every dev build between
+# that bump and the fixes *also* declares 0.12.2 -- and a floor reports the
+# capability PRESENT on one, which is the expensive direction: a gradient that
+# is wrong rather than a refusal. The neighbouring ``BNGSIM_HAS_PER_SPECIES_ATOL``
+# comment states the same hazard for the same version string, and it cost a real
+# fit (#558). "Probe capability, never version."
+#
+# So the flag resolves through three routes, first match wins, and each is
+# reported by :func:`event_sens_probe` so a refusal can say how it decided:
+#
+# 1. ``features['event_sensitivities']`` -- a dedicated key. bngsim publishes no
+#    such key today; naming it here costs nothing and means the flag starts
+#    reading the real answer, in BOTH directions, on the first build that grows
+#    one. That is #558's ask 1, and it is why this route is checked first even
+#    though it never fires yet.
+#
+# 2. ``features['effective_ic_sensitivity']`` -- a WITNESS. This key is not the
+#    capability; it reports ``Model.effective_ic_sensitivity``, the dx(0)/dtheta
+#    reader ADR-0100 consumes. It is usable here because of WHERE it landed:
+#    lanl/bngsim#155 added it three commits after #146 and seven after #144, inside
+#    the same 0.12.1 -> 0.12.2 window, so a build that publishes it necessarily
+#    carries every fix above. The implication runs one way only, and that is the
+#    safe way -- a build from the handful of commits between #146 and #155 has
+#    the fixes and lacks the witness, and is refused. A refusal on a build that
+#    would have been right is a metaheuristic fit; the converse is a wrong
+#    gradient nobody sees. Being a published ``capabilities()`` key rather than a
+#    ``hasattr`` also means bngsim's own "existing names will not be renamed or
+#    removed" contract covers it.
+#
+# 3. Neither key published -- absent. The version floor survives ONLY as a
+#    conjunct on route 2, where it vetoes an incoherent build; it can no longer
+#    report *present* on its own. The witness shipped IN 0.12.2, so a build
+#    claiming 0.12.2-or-newer that does not publish it is precisely the lying
+#    pre-release build, and a build below 0.12.2 was refused before this change
+#    too. Every released bngsim at or above the floor publishes the witness, so
+#    no install that works today is refused by this change.
+#
+# An unparseable version reads as *absent* (fail closed): elsewhere in this
+# module an unparseable version is accepted, because rejecting it would brick an
 # otherwise-working install, but here the cost of guessing wrong is a wrong
 # gradient rather than a refusal.
 _BNGSIM_EVENT_SENS_VERSION = (0, 12, 2)
-BNGSIM_HAS_EVENT_SENS = bool(
-    BNGSIM_AVAILABLE
-    and (_parse_version(BNGSIM_VERSION) or ()) >= _BNGSIM_EVENT_SENS_VERSION
-)
+_BNGSIM_EVENT_SENS_FEATURE = 'event_sensitivities'
+_BNGSIM_EVENT_SENS_WITNESS = 'effective_ic_sensitivity'
+
+
+def _feature_key(name):
+    """Tri-state read of a bngsim feature key: the flag, or ``None`` if unpublished.
+
+    ``BNGSIM_FEATURES.get(name, False)`` cannot tell a build that says "no" from a
+    build too old to have been asked, and that distinction is the whole of #558:
+    an unpublished key must fall through to the next route, while a published
+    ``False`` is an answer and must be honoured.
+    """
+    if not BNGSIM_AVAILABLE or name not in BNGSIM_FEATURES:
+        return None
+    return bool(BNGSIM_FEATURES[name])
+
+
+def _resolve_event_sens():
+    """``(present, route)`` for :data:`BNGSIM_HAS_EVENT_SENS` -- see the block above."""
+    if not BNGSIM_AVAILABLE:
+        return False, 'bngsim is not available'
+    declared = _feature_key(_BNGSIM_EVENT_SENS_FEATURE)
+    if declared is not None:
+        return declared, "bngsim feature key %r" % _BNGSIM_EVENT_SENS_FEATURE
+    floor_ok = (_parse_version(BNGSIM_VERSION) or ()) >= _BNGSIM_EVENT_SENS_VERSION
+    witness = _feature_key(_BNGSIM_EVENT_SENS_WITNESS)
+    if witness is not None:
+        if witness and not floor_ok:
+            # The witness says yes and the version cannot corroborate it. Not a
+            # coherent build; the veto stands, and the message has to name the
+            # veto rather than the witness or it describes the wrong evidence.
+            return False, (
+                "bngsim feature key %r is published, but the reported version (%s) "
+                "is below %s, so the build contradicts itself"
+                % (_BNGSIM_EVENT_SENS_WITNESS, BNGSIM_VERSION or 'unparseable',
+                   '%d.%d.%d' % _BNGSIM_EVENT_SENS_VERSION)
+            )
+        return bool(witness), (
+            "bngsim feature key %r, which is published only by a build that also "
+            "carries the event-sensitivity fixes" % _BNGSIM_EVENT_SENS_WITNESS
+        )
+    return False, (
+        "no bngsim feature key to read (%r is unpublished by this build), and a "
+        "version floor alone is not evidence of a behavioural fix"
+        % _BNGSIM_EVENT_SENS_WITNESS
+    )
+
+
+BNGSIM_HAS_EVENT_SENS, _BNGSIM_EVENT_SENS_ROUTE = _resolve_event_sens()
 
 
 # A **per-species** absolute tolerance: ``Simulator.run(atol=...)`` accepts a vector and
@@ -237,8 +318,26 @@ BNGSIM_HAS_TRACKING_ATOL = bool(
 
 
 def event_sens_min_version():
-    """The bngsim version whose forward sensitivities survive a discrete event (#536)."""
+    """The first bngsim RELEASE whose forward sensitivities survive a discrete event (#536).
+
+    A release number is the actionable half of the refusal -- it is what a reader
+    installs -- but it is no longer what :data:`BNGSIM_HAS_EVENT_SENS` decides on,
+    because a from-source build can declare it without carrying it (#558). Pair it
+    with :func:`event_sens_probe` when a message has to explain a *refusal*, so a
+    reader who already has this version learns why it did not count.
+    """
     return '%d.%d.%d' % _BNGSIM_EVENT_SENS_VERSION
+
+
+def event_sens_probe():
+    """How :data:`BNGSIM_HAS_EVENT_SENS` was decided, as a phrase for a message (#558).
+
+    Names the route that actually answered -- a dedicated feature key, the
+    ``effective_ic_sensitivity`` witness, or neither -- so a refusal on a build
+    whose version *looks* new enough says which evidence it was missing instead of
+    reading as a version complaint the reader has already satisfied.
+    """
+    return _BNGSIM_EVENT_SENS_ROUTE
 
 
 def feature_missing_reason(name):
@@ -260,3 +359,102 @@ BNGSIM_SBML_ERROR = feature_missing_reason('sbml_import') if BNGSIM_AVAILABLE el
 BNGSIM_ANTIMONY_ERROR = (
     feature_missing_reason('antimony_import') if BNGSIM_AVAILABLE else BNGSIM_ERROR
 )
+
+
+# --- compiled-core provenance (#558) ---------------------------------------- #
+#
+# A version floor is blind to two different things, and the section above deals
+# with only the first. Which COMMITS the Python layer carries is one; whether the
+# COMPILED layer matches its own C++ sources is the other, and it is worse,
+# because nothing in the Python layer moves at all. An editable bngsim serves live
+# Python from the source tree but loads ``_bngsim_core*.so`` from a separately
+# built artifact with auto-rebuild deliberately off (lanl/bngsim#23), so the two
+# halves drift: an install reporting a perfectly good version has been observed
+# with a core binary three days older than the ``.cpp`` next to it. Every
+# version-, metadata- and feature-key-based check passes there.
+#
+# bngsim already detects this and warns at import. The problem is WHEN: PyBNF
+# imports bngsim while loading its own package, which is before ``init_logging``
+# has run and long before a fit is a commitment, so the warning lands in import
+# noise on a terminal nobody is reading yet. A fit is hours; the warning is worth
+# one line at job start, where it is still cheap to abort.
+#
+# ``bngsim._build_provenance`` is a private module, so every read here is guarded
+# and every failure is silent -- an install that cannot answer is reported as "no
+# opinion", never as an error. This is the module that owns such shims. The reads
+# are also LAZY and memoized: ``gather()`` walks the whole C++ source tree
+# (src/, include/, third_party/, cmake/), which is not a cost to pay at import on
+# behalf of callers who never ask.
+
+_provenance = None
+
+
+def _bngsim_provenance():
+    """bngsim's own build-provenance snapshot, or ``None`` when it cannot say.
+
+    Memoized, including the negative answer: a wheel install has no ``src/`` to
+    walk, and re-deciding that per call would still pay for the import attempt.
+    """
+    global _provenance
+    if _provenance is None:
+        _provenance = (False, None, None)
+        if BNGSIM_AVAILABLE:
+            try:
+                from bngsim import _build_provenance
+                _provenance = (True, _build_provenance,
+                               _build_provenance.gather(include_head=False))
+            except Exception:
+                # Private module, absent on some installs, and a filesystem walk:
+                # three independent ways to fail, none of them worth a traceback
+                # in front of a user who asked for a fit.
+                logger.debug('bngsim build provenance is unavailable', exc_info=True)
+    ok, module, prov = _provenance
+    return (module, prov) if ok else (None, None)
+
+
+def bngsim_build_id():
+    """The commit the loaded ``_bngsim_core`` was BUILT from, or ``''``.
+
+    The identifier #558 asks for: two installs can declare the same version and
+    be different builds, and this is the only thing on hand that tells them apart.
+    Baked into the extension by bngsim's CMake, so it describes the binary rather
+    than the package metadata -- which is exactly the distinction a version string
+    cannot make. ``''`` for a wheel built without it.
+    """
+    _, prov = _bngsim_provenance()
+    return getattr(prov, 'build_commit', None) or ''
+
+
+def bngsim_identity_line():
+    """One line naming the loaded compiled core -- path, build commit, mtime, state.
+
+    For the job-start log. ``''`` when bngsim cannot say, so a caller can simply
+    skip the line rather than print a placeholder.
+    """
+    module, prov = _bngsim_provenance()
+    if module is None:
+        return ''
+    try:
+        return module.identity_line(prov)
+    except Exception:                                  # pragma: no cover - defensive
+        return ''
+
+
+def bngsim_stale_core_report():
+    """bngsim's multi-line staleness report, or ``''`` when the core is not stale.
+
+    Truthy exactly when the loaded binary predates its own C++ sources -- i.e.
+    when every capability answer this module gives, and every number the fit is
+    about to produce, describes code that is no longer in the tree. Honours
+    bngsim's own ``BNGSIM_NO_BUILD_CHECK`` opt-out, since that is the user saying
+    the heuristic misfires here.
+    """
+    module, prov = _bngsim_provenance()
+    if module is None or prov is None:
+        return ''
+    try:
+        if module._checks_disabled() or not prov.is_stale:
+            return ''
+        return module.format_report(prov)
+    except Exception:                                  # pragma: no cover - defensive
+        return ''

--- a/pybnf/algorithms/optimizers/gradient_base.py
+++ b/pybnf/algorithms/optimizers/gradient_base.py
@@ -444,8 +444,8 @@ class GradientOptimizer(ConcurrentMultiStartOptimizer):
         pre-flight gate, rather than let it surface mid-run at the first
         sensitivity-bearing ``simulate()``.
 
-        bngsim applies the jump now. From the version
-        :data:`~pybnf._bngsim_caps.BNGSIM_HAS_EVENT_SENS` reads it also *classifies*
+        bngsim applies the jump now. On a build
+        :data:`~pybnf._bngsim_caps.BNGSIM_HAS_EVENT_SENS` reports it also *classifies*
         each event honestly -- differentiating the subclasses it covers (a fixed
         trigger time; a trigger thresholding a fitted constant, lanl/bngsim#49; a
         state-dependent trigger whose crossing it differentiates in flight,
@@ -458,13 +458,20 @@ class GradientOptimizer(ConcurrentMultiStartOptimizer):
         only one an event can reach PyBNF through, since a ``.net`` model cannot
         author one.
 
-        Below that floor the refusal stays, and stays blanket, because an older
-        build does not merely lack a subclass -- it answers one *wrongly and
-        quietly*: a trigger reading the state came back as a finite tensor missing
-        the event's contribution instead of being refused (lanl/bngsim#52), and an
-        event assignment that reads the state dropped its carried term altogether
-        (lanl/bngsim#144). Refusing up front, with a message naming the upgrade,
-        beats a fit that runs to completion on a wrong gradient.
+        Otherwise the refusal stays, and stays blanket, because such a build does
+        not merely lack a subclass -- it answers one *wrongly and quietly*: a
+        trigger reading the state came back as a finite tensor missing the event's
+        contribution instead of being refused (lanl/bngsim#52), and an event
+        assignment that reads the state dropped its carried term altogether
+        (lanl/bngsim#144). Refusing up front beats a fit that runs to completion on
+        a wrong gradient.
+
+        The message says both what to install and *how the flag decided*
+        (:func:`~pybnf._bngsim_caps.event_sens_probe`), because since #558 the two
+        can disagree: the flag reads a capability rather than a version, so a
+        reader whose bngsim already reports a new enough number needs to be told
+        that the number was not the evidence -- otherwise the refusal reads as a
+        version complaint they have already answered.
 
         Models whose backend exposes no event count (``has_discrete_events``
         absent) pass through untouched."""
@@ -481,9 +488,15 @@ class GradientOptimizer(ConcurrentMultiStartOptimizer):
                     "-- so the gradient there would be silently wrong." % (
                         self._fit_type_label(), getattr(model, 'name', '?'),
                         _bngsim_caps.BNGSIM_VERSION or 'version unknown'),
-                    hint=["Upgrade to bngsim >= %s, which differentiates the event "
-                          "subclasses it supports and refuses the rest."
-                          % _bngsim_caps.event_sens_min_version(),
+                    hint=["Install bngsim >= %s, which differentiates the event "
+                          "subclasses it supports and refuses the rest. This gate "
+                          "reads a capability, not a version -- it decided from: %s "
+                          "-- so a build whose version already reads new enough is "
+                          "one that does not publish the capability, which a "
+                          "from-source build ahead of (or behind) its own release "
+                          "number can be."
+                          % (_bngsim_caps.event_sens_min_version(),
+                             _bngsim_caps.event_sens_probe()),
                           _FALLBACK_HINT])
 
     def _fit_type_label(self):

--- a/pybnf/bngsim_model/net_model.py
+++ b/pybnf/bngsim_model/net_model.py
@@ -360,8 +360,9 @@ class BngsimModel(NetModel):
         arrives **up front**, with an actionable "use a metaheuristic job_type"
         message, instead of at the first sensitivity-bearing ``simulate()``. bngsim
         now applies the jump and refuses only the subclasses it cannot cross, so on a
-        build at or above :data:`~pybnf._bngsim_caps.BNGSIM_HAS_EVENT_SENS`'s floor
-        the gate no longer fires and this property only documents the structure.
+        build :data:`~pybnf._bngsim_caps.BNGSIM_HAS_EVENT_SENS` reports (a published
+        capability since #558, not a version compare) the gate no longer fires and
+        this property only documents the structure.
 
         Only true state-jumping events are counted (the engine core's ``n_events``).
         Discontinuity triggers -- forcing pulses / piecewise-time dosing schedules --

--- a/pybnf/bngsim_sbml_model.py
+++ b/pybnf/bngsim_sbml_model.py
@@ -1817,8 +1817,8 @@ class BngsimSbmlModelNoTimeout(Model):
         arrives **up front**, with an actionable "use a metaheuristic job_type"
         message, instead of at the first sensitivity-bearing ``simulate()``. bngsim
         now applies the jump and refuses only the subclasses it cannot cross, so on a
-        build at or above :data:`~pybnf._bngsim_caps.BNGSIM_HAS_EVENT_SENS`'s floor
-        the gate no longer fires. The net backend's property documents the same
+        build :data:`~pybnf._bngsim_caps.BNGSIM_HAS_EVENT_SENS` reports (a published
+        capability since #558, not a version compare) the gate no longer fires. The net backend's property documents the same
         contract; this is its SBML twin -- and, since a ``.net`` model cannot author
         events, the one that is reachable in practice.
 

--- a/pybnf/pybnf.py
+++ b/pybnf/pybnf.py
@@ -2,6 +2,7 @@
 
 
 from . import __version__
+from . import _bngsim_caps
 from . import method_chain
 from .budget import FitBudget, format_duration, spend_reserve
 from .parse import load_config
@@ -25,6 +26,42 @@ import time
 import traceback
 import pickle
 from pathlib import Path
+
+
+def _report_bngsim_build():
+    """Name the compiled bngsim core this run loaded, and warn if it is stale (#558).
+
+    An editable/from-source bngsim serves live Python from the source tree while
+    loading its compiled core from a separately-built ``.so``, with auto-rebuild
+    deliberately off, so the two halves drift. bngsim detects that and warns -- but
+    it warns at *import*, which for PyBNF is while the ``pybnf`` package is loading:
+    before ``init_logging``, before the config is read, and long before the user has
+    decided anything. The warning scrolls past in import noise and the fit proceeds
+    on numbers produced by C++ that is no longer in the tree.
+
+    Repeating it here puts it at the top of the run's own log and console output,
+    where a reader still has the option to stop. The identity line goes to the log
+    unconditionally -- it carries the build commit, which is the only thing that
+    tells two installs declaring the same version apart -- and the staleness report
+    is promoted to a warning at verbosity 0, because it invalidates every capability
+    answer and every number that follows it.
+
+    Never raises: every read is guarded inside ``_bngsim_caps``, so an install
+    that cannot answer reports no opinion rather than taking the fit down.
+    """
+    logger = logging.getLogger(__name__)
+    identity = _bngsim_caps.bngsim_identity_line()
+    if identity:
+        logger.info(identity)
+    stale = _bngsim_caps.bngsim_stale_core_report()
+    if stale:
+        logger.warning('The installed bngsim\'s compiled core is older than its own '
+                       'C++ sources; every number this fit produces describes that '
+                       'older code.\n%s', stale)
+        print0("WARNING: the installed bngsim's compiled core is older than its own C++ "
+               "sources, so every number this fit produces describes that older code. "
+               "Rebuild bngsim before trusting this run.")
+        print1(stale)
 
 
 def _initialize_random_seed(config):
@@ -609,6 +646,7 @@ def main():
 
     print0(f"PyBNF v{__version__}")
     logger.info(f'Running PyBNF v{__version__}')
+    _report_bngsim_build()
 
     try:
         # Load the conf file and create the algorithm

--- a/tests/test_bngsim_capabilities.py
+++ b/tests/test_bngsim_capabilities.py
@@ -5,6 +5,7 @@ and feature gating) against the issue #378 acceptance criteria:
 too-old BNGsim, PYBNF_NO_BNGSIM-disabled, and missing-capability cases.
 """
 
+import contextlib
 import importlib
 import logging
 import os
@@ -308,3 +309,331 @@ def test_unparseable_version_warns_and_accepts(version, caplog):
     with caplog.at_level(logging.WARNING, logger='pybnf._bngsim_caps'):
         assert _bngsim_caps._version_compatible(version) is True
     assert any('Could not parse bngsim version' in r.message for r in caplog.records)
+
+
+# --------------------------------------------------------------------------- #
+# BNGSIM_HAS_EVENT_SENS — a capability probe, not a version compare (#558)
+# --------------------------------------------------------------------------- #
+#
+# The flag guards against a bngsim that answers a discrete event's forward
+# sensitivity *wrongly and quietly*. It used to be a version floor at exactly
+# 0.12.2, and the hazard with that is not hypothetical: bngsim bumps
+# ``__version__`` at the start of a release cycle, so every from-source build
+# between that bump and the fixes declares the same string as the release that
+# carries them. A floor reports the capability PRESENT on such a build, and the
+# symptom is not a refusal but a fit that runs to completion on a wrong gradient.
+#
+# The resolution order under test: a dedicated feature key first (bngsim
+# publishes none yet -- this is the hook that starts working on the first build
+# that grows one), then the ``effective_ic_sensitivity`` witness, and the version
+# floor only as a conjunct that can veto but never carry.
+
+_WITNESS = 'effective_ic_sensitivity'
+_DEDICATED = 'event_sensitivities'
+
+
+def _event_sens(monkeypatch, *, version, features):
+    """Reload the capability module against a fake bngsim; return (flag, route)."""
+    fake = _make_fake_bngsim(version=version, features=features)
+    try:
+        caps = _reload_caps_with(monkeypatch, fake)
+        return caps.BNGSIM_HAS_EVENT_SENS, caps.event_sens_probe()
+    finally:
+        _restore_caps()
+
+
+def test_event_sens_reads_a_dedicated_feature_key_when_one_exists(monkeypatch):
+    """Ask 1 of #558: the moment bngsim publishes a key for this, the flag reads it.
+
+    In BOTH directions, and ahead of everything else -- a published ``False`` on a
+    version that clears the floor must report absent, or the key is decoration.
+    """
+    present, route = _event_sens(
+        monkeypatch, version='0.9.0',
+        features={_DEDICATED: True})
+    assert present is True                     # ... even below the old floor
+    assert _DEDICATED in route
+
+    absent, route = _event_sens(
+        monkeypatch, version='0.13.0',
+        features={_DEDICATED: False, _WITNESS: True})
+    assert absent is False                     # ... and it outranks the witness
+    assert _DEDICATED in route
+
+
+def test_event_sens_reads_the_witness_key_when_there_is_no_dedicated_one(monkeypatch):
+    """``effective_ic_sensitivity`` stands in for a key bngsim does not publish.
+
+    It is not the capability. It is usable as evidence because of where it landed:
+    lanl/bngsim#155 added it inside the same 0.12.1 -> 0.12.2 window as the fixes
+    (#144, #146) and after both, so a build that publishes it necessarily carries
+    them.
+    """
+    present, route = _event_sens(
+        monkeypatch, version='0.12.2', features={_WITNESS: True})
+    assert present is True
+    assert _WITNESS in route
+
+
+def test_event_sens_refuses_a_prerelease_build_that_only_declares_the_version(monkeypatch):
+    """The #558 defect itself: version says 0.12.2, capabilities say otherwise.
+
+    A from-source bngsim built after the release cycle's version bump but before
+    the fixes declares ``0.12.2`` -- the same string as the release -- and the old
+    floor reported the capability present on it. It publishes no witness key,
+    because the key shipped IN 0.12.2, so reading capabilities instead of the
+    version tells the two apart and fails toward a refusal.
+    """
+    present, route = _event_sens(
+        monkeypatch, version='0.12.2', features={'codegen': True})
+    assert present is False
+    assert 'version floor alone is not evidence' in route
+
+
+def test_event_sens_does_not_regress_any_released_bngsim(monkeypatch):
+    """Every released bngsim at or above the floor publishes the witness, so this
+    change refuses nothing that worked before -- and still refuses everything below."""
+    for version in ('0.12.2', '0.13.0', '0.14.0'):
+        present, _ = _event_sens(
+            monkeypatch, version=version, features={_WITNESS: True})
+        assert present is True, version
+    for version in ('0.11.35', '0.12.0', '0.12.1'):
+        present, _ = _event_sens(
+            monkeypatch, version=version, features={'codegen': True})
+        assert present is False, version
+
+
+def test_event_sens_vetoes_a_witness_that_contradicts_the_version_floor(monkeypatch):
+    """The floor survives as a conjunct: it can veto, it can no longer carry.
+
+    A build below the floor that somehow publishes the witness is incoherent, and
+    an unparseable version is no evidence at all. Both read absent -- the
+    deliberate asymmetry with ``_version_compatible``, which accepts an unparseable
+    version rather than brick an install, because the cost of guessing wrong here
+    is a wrong gradient rather than a refusal.
+    """
+    below, route = _event_sens(monkeypatch, version='0.11.0', features={_WITNESS: True})
+    assert below is False
+    assert 'contradicts itself' in route
+    unparseable, _ = _event_sens(monkeypatch, version='unknown', features={_WITNESS: True})
+    assert unparseable is False
+
+
+def test_event_sens_resolves_on_a_first_import_not_only_on_a_reload():
+    """The resolution runs at module scope, and the tests above reach it by RELOAD --
+    which reuses the module dict, so a name the resolver reads before its own
+    definition still resolves to the previous load's copy. Only a fresh interpreter
+    sees the import-time ordering. Every route is exercised there, since the bug
+    class is per-branch."""
+    script = textwrap.dedent('''
+        import sys, types
+        version, features = sys.argv[1], eval(sys.argv[2])
+        fake = types.ModuleType('bngsim')
+        fake.__version__ = version
+        fake.capabilities = lambda: {
+            'version': version, 'features': features, 'missing': {}}
+        sys.modules['bngsim'] = fake
+        from pybnf import _bngsim_caps as caps
+        print('%s|%s' % (caps.BNGSIM_HAS_EVENT_SENS, caps.event_sens_probe()))
+    ''')
+    cases = [
+        ('0.13.0', "{'event_sensitivities': True}", 'True'),
+        ('0.13.0', "{'effective_ic_sensitivity': True}", 'True'),
+        ('0.12.2', "{'codegen': True}", 'False'),
+        ('0.11.0', "{'effective_ic_sensitivity': True}", 'False'),
+    ]
+    env = os.environ.copy()
+    env.pop('PYBNF_NO_BNGSIM', None)
+    for version, features, expected in cases:
+        result = subprocess.run(
+            [sys.executable, '-c', script, version, features],
+            env=env, capture_output=True, text=True, check=False)
+        assert result.returncode == 0, (
+            '%s %s: stdout=%r stderr=%r' % (version, features, result.stdout, result.stderr))
+        assert result.stdout.startswith(expected + '|'), (version, features, result.stdout)
+
+
+def test_event_sens_is_absent_and_says_so_without_bngsim(monkeypatch):
+    monkeypatch.setitem(sys.modules, 'bngsim', None)
+    monkeypatch.setenv('PYBNF_NO_BNGSIM', '1')
+    try:
+        caps = importlib.reload(_bngsim_caps)
+        assert caps.BNGSIM_HAS_EVENT_SENS is False
+        assert 'not available' in caps.event_sens_probe()
+    finally:
+        _restore_caps()
+
+
+def test_event_sens_refusal_names_the_probe_rather_than_the_version(monkeypatch):
+    """The refusal a user reads must not be a version complaint they have answered.
+
+    On a build that declares a new enough version but publishes no capability, the
+    old message said only "upgrade to >= 0.12.2" to someone who already had it.
+    """
+    import types
+
+    from pybnf.algorithms.optimizers.trf import TRFAlgorithm
+    from pybnf.printing import PybnfError
+
+    fake = _make_fake_bngsim(version='0.12.2', features={'codegen': True})
+    try:
+        caps = _reload_caps_with(monkeypatch, fake)
+        assert caps.BNGSIM_HAS_EVENT_SENS is False
+        alg = object.__new__(TRFAlgorithm)
+        alg.fit_type = 'trf'
+        alg.model_list = [types.SimpleNamespace(name='m', has_discrete_events=True)]
+        with pytest.raises(PybnfError) as exc:
+            alg._require_differentiable_dynamics()
+        message = exc.value.message
+        assert 'capability, not a version' in message
+        assert _WITNESS in message
+    finally:
+        _restore_caps()
+
+
+# --------------------------------------------------------------------------- #
+# Compiled-core provenance — the staleness a version cannot see (#558)
+# --------------------------------------------------------------------------- #
+
+
+def _fake_provenance_module(*, stale, build_commit='deadbeef1234', disabled=False):
+    """A stand-in for bngsim's private ``_build_provenance`` module."""
+    prov = types.SimpleNamespace(is_stale=stale, build_commit=build_commit)
+    module = types.ModuleType('bngsim._build_provenance')
+    module.gather = lambda **kwargs: prov
+    module.identity_line = lambda p=None: (
+        '[bngsim] _bngsim_core: /x/_bngsim_core.so | built=%s | mtime=? | %s'
+        % (build_commit, 'STALE' if stale else 'installed'))
+    module.format_report = lambda p=None: (
+        module.identity_line() + '\n[bngsim]   STALE: src/x.cpp is newer than the '
+        'loaded binary.')
+    module._checks_disabled = lambda: disabled
+    return module
+
+
+@contextlib.contextmanager
+def _caps_with_provenance(monkeypatch, provenance_module):
+    """Reload the capability module against a fake bngsim carrying ``provenance_module``.
+
+    A context manager rather than a plain call because of how the absent case has
+    to be spelled. ``from bngsim import _build_provenance`` falls back to importing
+    the *submodule* when the package object has no such attribute, and the real one
+    is already in ``sys.modules`` from this session's own import, so modelling an
+    install without it means putting ``None`` there -- the import system's spelling
+    of "unavailable". That stub must come back out **before** ``_restore_caps()``
+    re-imports the real bngsim, whose own ``__init__`` imports that submodule;
+    leaving it to monkeypatch's teardown (which runs after the ``finally``) would
+    make the restore reload find bngsim unimportable and poison every capability
+    constant for the rest of the session -- the ordering failure ``_restore_caps``
+    documents.
+    """
+    fake = _make_fake_bngsim(version='0.13.0', features={_WITNESS: True})
+    stub = 'bngsim._build_provenance'
+    stubbed = provenance_module is None
+    original = sys.modules.get(stub)
+    if stubbed:
+        sys.modules[stub] = None
+    else:
+        fake._build_provenance = provenance_module
+    try:
+        yield _reload_caps_with(monkeypatch, fake)
+    finally:
+        if stubbed:
+            if original is None:
+                sys.modules.pop(stub, None)
+            else:
+                sys.modules[stub] = original
+        _restore_caps()
+
+
+def test_build_id_distinguishes_two_installs_declaring_one_version(monkeypatch):
+    """The commit baked into the compiled core, which package metadata cannot give.
+
+    Two bngsim installs can report the same ``__version__`` and be different
+    builds; this is the identifier that tells them apart, and it describes the
+    *binary* rather than the package.
+    """
+    with _caps_with_provenance(monkeypatch, _fake_provenance_module(stale=False)) as caps:
+        assert caps.bngsim_build_id() == 'deadbeef1234'
+        assert 'built=deadbeef1234' in caps.bngsim_identity_line()
+        assert caps.bngsim_stale_core_report() == ''
+
+
+def test_stale_compiled_core_is_reported(monkeypatch):
+    """A core older than its own C++ passes every version and feature check.
+
+    Nothing in the Python layer moves, so ``capabilities()`` is as wrong as a
+    version string here -- bngsim's mtime comparison is the only thing that sees
+    it, and PyBNF has to ask.
+    """
+    with _caps_with_provenance(monkeypatch, _fake_provenance_module(stale=True)) as caps:
+        assert 'STALE' in caps.bngsim_stale_core_report()
+        assert caps.BNGSIM_HAS_EVENT_SENS is True   # every other check still passes
+
+
+def test_stale_report_honors_bngsims_own_opt_out(monkeypatch):
+    """``BNGSIM_NO_BUILD_CHECK`` is the user saying the heuristic misfires here;
+    PyBNF does not get a second vote."""
+    stubbed = _fake_provenance_module(stale=True, disabled=True)
+    with _caps_with_provenance(monkeypatch, stubbed) as caps:
+        assert caps.bngsim_stale_core_report() == ''
+
+
+def test_provenance_is_silent_when_bngsim_cannot_answer(monkeypatch):
+    """``_build_provenance`` is private to bngsim: an install without it (or one
+    whose reads raise) reports no opinion rather than taking the run down."""
+    with _caps_with_provenance(monkeypatch, None) as caps:
+        assert caps.bngsim_build_id() == ''
+        assert caps.bngsim_identity_line() == ''
+        assert caps.bngsim_stale_core_report() == ''
+
+    exploding = _fake_provenance_module(stale=True)
+    exploding.gather = lambda **kwargs: (_ for _ in ()).throw(RuntimeError('boom'))
+    with _caps_with_provenance(monkeypatch, exploding) as caps:
+        assert caps.bngsim_identity_line() == ''
+        assert caps.bngsim_stale_core_report() == ''
+
+
+@contextlib.contextmanager
+def _collect_warnings(logger_name):
+    """Collect warning records from one logger.
+
+    Not ``caplog``: these tests reload ``pybnf._bngsim_caps`` against fake modules,
+    and keeping the capture explicit keeps that dance out of the assertion.
+    """
+    records = []
+
+    class _Collect(logging.Handler):
+        def emit(self, record):
+            records.append(record)
+
+    handler = _Collect(level=logging.WARNING)
+    log = logging.getLogger(logger_name)
+    log.addHandler(handler)
+    try:
+        yield records
+    finally:
+        log.removeHandler(handler)
+
+
+def test_job_start_surfaces_a_stale_core_where_the_user_will_see_it(monkeypatch, capsys):
+    """Ask 3 of #558. bngsim warns at *import* -- for PyBNF that is while the
+    ``pybnf`` package loads, before logging is configured and before the user has
+    committed to anything, so the warning scrolls past in import noise. A fit is
+    hours; this repeats it at job start, on the console and in the run's own log."""
+    from pybnf import pybnf as pybnf_main
+
+    monkeypatch.setattr(pybnf_main._bngsim_caps, 'bngsim_identity_line',
+                        lambda: '[bngsim] _bngsim_core: ... | built=abc123 | STALE')
+    monkeypatch.setattr(pybnf_main._bngsim_caps, 'bngsim_stale_core_report',
+                        lambda: '[bngsim]   STALE: src/x.cpp is newer than the binary.')
+    with _collect_warnings('pybnf.pybnf') as records:
+        pybnf_main._report_bngsim_build()
+    out = capsys.readouterr().out
+    assert 'WARNING' in out and 'older than its own C++' in out
+    assert any('older than its own' in r.getMessage() for r in records)
+
+    monkeypatch.setattr(pybnf_main._bngsim_caps, 'bngsim_stale_core_report', lambda: '')
+    pybnf_main._report_bngsim_build()
+    assert 'WARNING' not in capsys.readouterr().out
+


### PR DESCRIPTION
Closes #558.

## The defect

`pybnf/_bngsim_caps.py` gated two bngsim capabilities two different ways, and the file
already explained why one of them was unsafe — in a comment sitting on the *other* flag:

| flag | how it decided |
|---|---|
| `BNGSIM_HAS_PER_SPECIES_ATOL` | a **name** probe |
| `BNGSIM_HAS_EVENT_SENS` | a **version floor** at exactly `(0, 12, 2)` |

> The probe is a name, not a version. The build that first carried #196 still declares
> 0.12.2 — the same string as the released wheel 25 commits behind it — so a version floor
> here would report *present* on an install that does not have it, and that is the expensive
> direction.

That argument is correct and applied verbatim to the flag next to it. bngsim bumps
`__version__` at the **start** of a release cycle, so the string identifies a *cycle*, not a
build: every from-source build made between the bump and the fixes that set the line
(lanl/bngsim#144, #146 — both inside the 0.12.1 → 0.12.2 window) declares the same number as
the release that carries them and clears the floor.

**The two failure directions are not symmetric, and that is the whole point.** The flag does
not gate a missing feature — it gates *silent wrongness*. A build below the line does not
refuse an event it cannot differentiate; it returns a finite tensor with the event's
contribution missing. A false *absent* is a refusal and a metaheuristic fit. A false
*present* is a gradient fit that runs to completion, converges, and reports a number nobody
has reason to doubt. A version compare could only ever be wrong the second way.

## The change

`BNGSIM_HAS_EVENT_SENS` now resolves through three routes, first match wins:

| # | route | when it answers |
|---|---|---|
| 1 | `features['event_sensitivities']` | if bngsim ever publishes a dedicated key — **both** directions, ahead of everything else |
| 2 | `features['effective_ic_sensitivity']` **and** version ≥ 0.12.2 | today |
| 3 | neither key published | absent |

**Route 1** is the issue's first ask and fires on no build that exists. Naming the key costs
nothing and means the flag starts reading the real answer on the first bngsim that grows one,
with no PyBNF release in between.

**Route 2** is load-bearing, and it is a **witness**, not the capability.
`effective_ic_sensitivity` reports `Model.effective_ic_sensitivity`, which has nothing to do
with events; it is evidence because of *where it landed*. lanl/bngsim#155 added it three
commits after #146 and seven after #144, inside the same release window, so

```
publishes effective_ic_sensitivity  ⟹  carries #144 and #146
```

The implication runs one way only, and that is the safe way: a build from the handful of
commits between #146 and #155 has the fixes, lacks the witness, and is refused. A refusal on
a build that would have been right costs a metaheuristic fit; the converse costs a wrong
gradient nobody sees. Being a published `capabilities()` key rather than a `hasattr` also
puts it under bngsim's own "existing names will not be renamed or removed" contract.

**The version floor survives only as a conjunct on route 2**, where it vetoes an incoherent
build and preserves the deliberate fail-closed reading of an unparseable version. It can no
longer report the capability present on its own.

**No install that works today is refused.** Every released bngsim at or above the floor
publishes the witness; every one below fails both tests exactly as before. The only installs
whose answer changes are from-source builds inside the window — which is the entire purpose.

**The refusal names how it decided** (`event_sens_probe()`) rather than telling a reader who
already has 0.12.2 to upgrade to 0.12.2.

## The trap one level down: a stale compiled core

An editable bngsim serves live Python from the source tree while loading `_bngsim_core*.so`
from a separately built artifact with auto-rebuild deliberately off, so the two halves drift
— one install reporting `0.12.2` was found with a core binary three days older than the
`.cpp` beside it. **Every check above passes there**, because nothing in the Python layer
moved.

bngsim detects it by mtime and warns — but at *import*, which for PyBNF is while the `pybnf`
package loads: before `init_logging`, before the config is read, before the user has
committed to anything. `_report_bngsim_build()` repeats it at job start — the identity line
(path, build commit, mtime) to the log unconditionally, the staleness report promoted to a
console warning at verbosity 0 — where a reader can still stop a run that would otherwise
spend hours producing statements about code that is no longer in the tree.
`bngsim_build_id()` exposes the commit the core was built from, which is the only thing on
hand that tells two installs declaring one version apart.

Every provenance read is guarded, lazy and memoized: `bngsim._build_provenance` is a private
module and `gather()` walks the whole C++ source tree, so an install that cannot answer
reports no opinion rather than taking the fit down.

## What this does not do

The issue's ask 2 — a **behavioural** check at setup — is not implemented, deliberately, and
for two different reasons:

* For the **event-sensitivity** case, ask 2's premise ("where a capability cannot be probed at
  all") no longer holds: the witness key *is* a capability probe. A direct numerical probe —
  build a state-reading event assignment, run it with sensitivities, compare against a central
  difference — is the only fully direct answer, but it costs a codegen and a compile at job
  start, needs `codegen` present in order to answer a question about a *different* capability,
  and introduces a tolerance that can itself be wrong. ADR-0119 records it as the right
  instrument for a capability with no witness at all.
* The **`Smith_BMCSystBiol2013`** failure the issue describes — a `per_species_volume_scaling`
  reaction declines the analytic `∂f/∂p`, all 25 columns fall back to CVODES difference
  quotients, every start times out to `inf` — is a **different capability**
  (lanl/bngsim#160/#161). It is reported on the `bngsim` logger at codegen time rather than by
  `capabilities()`, and codegen happens on a worker at the first simulation rather than at
  setup, so it needs its own decision about where a worker-side decline reaches the user.
  Recorded in ADR-0119's consequences.

The upstream ask stated in the issue — behaviour-level feature keys in `capabilities()` plus a
resolved build identifier — is unchanged and not filed here. Route 1 exists so PyBNF consumes
the first of those the day it appears; `bngsim_build_id()` consumes the second, which
`_build_provenance` already computes.

## Verification

* Full default suite: `4215 passed, 23 skipped`. Three `tests/test_job_class.py` failures are
  **pre-existing** — reproduced identically on a clean tree in the same environment (a local
  BNG2.pl failing on `TrickyWP`), unrelated to this change.
* Recovery-tier event gate tests (`-m recovery -k event`) pass with `BNGPATH` set.
* 12 new tests in `tests/test_bngsim_capabilities.py`, including the regression for the
  defect itself (version says 0.12.2, capabilities say otherwise → refused) and a
  **fresh-interpreter** test: the existing reload-based harness reuses the module dict, so a
  name read before its own definition still resolves to the previous load's copy. That masked
  a real import-time ordering bug in the first draft of the resolver, which the new test now
  catches.
* `ruff@0.15.14 check .` clean; `sphinx-build -W --keep-going` clean.
