### PR TITLE
docs(tutorial): the lesson index lists every lesson on disk, and a test keeps it that way (#598)

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -92,6 +92,9 @@ Objectives and noise models
   (``noise_model = lognormal, location = mean``).
 - `43. Custom objective <https://github.com/lanl/PyBNF/tree/main/examples/tutorial/43_custom_objective>`__
   — bring your own objective: a custom Python callable (``objective = callable``).
+- `48. State-dependent noise <https://github.com/lanl/PyBNF/tree/main/examples/tutorial/48_state_dependent_noise>`__
+  — a noise scale that depends on the prediction: a combined additive+proportional
+  error model (``sigma = prediction_formula``).
 - `49. Measurement-time uncertainty <https://github.com/lanl/PyBNF/tree/main/examples/tutorial/49_measurement_time_uncertainty>`__
   — when the reported sampling times are uncertain, integrate the latent time out
   of the likelihood (``time_error`` / ``sigma_t``).
@@ -123,6 +126,9 @@ Data, experiments and protocols
 - `30. Data fusion <https://github.com/lanl/PyBNF/tree/main/examples/tutorial/30_data_fusion>`__
   — one fit to time-course, steady-state, and qualitative data at once
   (multi-experiment + ``.prop``).
+- `47. Condition perturbations <https://github.com/lanl/PyBNF/tree/main/examples/tutorial/47_condition_perturbations>`__
+  — one model, many conditions: fit a wildtype and a knockout with one model file
+  (``condition:`` / ``perturbations:``).
 
 Bayesian inference and uncertainty
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/examples/tutorial/README.md
+++ b/examples/tutorial/README.md
@@ -72,6 +72,7 @@ Results land in `output/` inside the lesson folder.
 | 46 | [`46_model_checking`](46_model_checking) | **does the model satisfy the spec?** — check a model against qualitative properties, no fitting | `job_type = check`, BPSL `.prop` (`at`/`once`/`always`/`between`) *(recovery tier)* |
 | 47 | [`47_condition_perturbations`](47_condition_perturbations) | **one model, many conditions** — fit a wildtype AND a knockout with one model file | `condition: … perturbations:` + per-experiment `condition:` *(recovery tier)* |
 | 48 | [`48_state_dependent_noise`](48_state_dependent_noise) | a **noise scale that depends on the prediction** — a combined additive+proportional error model | `noise_model = gaussian, sigma = prediction_formula sd_abs + sd_rel*<obs>` *(recovery tier)* |
+| 49 | [`49_measurement_time_uncertainty`](49_measurement_time_uncertainty) | when the **measurement times** are uncertain — integrate the latent sampling time out of the likelihood (fixed or estimated timing spread; gradient-fittable) | `time_error = truncated_normal\|uniform`, `sigma_t = fix_at\|fit …` *(recovery + slow tiers)* |
 
 ## The edition-2 config surface, in one place
 

--- a/tests/test_tutorial_index.py
+++ b/tests/test_tutorial_index.py
@@ -1,0 +1,50 @@
+"""The tutorial's two indexes list every lesson on disk (#598).
+
+``examples/tutorial/README.md``'s table and ``docs/tutorial.rst``'s catalogue are
+the only places the lesson suite is enumerated, so a lesson missing from either
+one is undiscoverable short of listing the directory -- which is exactly how
+lesson 49 sat unlisted from the day it landed. Both indexes are hand-maintained
+prose, and nothing else re-derives them, so this is the check that notices.
+
+Purely structural: it reads the two files as text and never loads a model or
+touches a backend, so it runs in the default tier.
+"""
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_TUTORIAL_DIR = _REPO_ROOT / 'examples' / 'tutorial'
+_README = _TUTORIAL_DIR / 'README.md'
+_DOCS_PAGE = _REPO_ROOT / 'docs' / 'tutorial.rst'
+
+
+def _lesson_folders():
+    """Every numbered lesson folder, e.g. ``49_measurement_time_uncertainty``."""
+    return sorted(p.name for p in _TUTORIAL_DIR.iterdir()
+                  if p.is_dir() and re.match(r'^\d+_', p.name))
+
+
+def test_lesson_folders_are_found():
+    """Guard the guard: a glob that matched nothing would pass vacuously."""
+    folders = _lesson_folders()
+    assert len(folders) > 40, folders
+
+
+@pytest.mark.parametrize('folder', _lesson_folders())
+def test_readme_index_lists_every_lesson(folder):
+    """The README table's ``# | Folder | You learn... | Feature(s)`` row exists."""
+    number = folder.split('_', 1)[0].lstrip('0')
+    row = re.compile(rf'^\|\s*{number}\s*\|.*\({re.escape(folder)}\)', re.MULTILINE)
+    assert row.search(_README.read_text()), (
+        f'{folder} has no row in examples/tutorial/README.md -- add one in the '
+        f'same shape as its neighbours (see #598)')
+
+
+@pytest.mark.parametrize('folder', _lesson_folders())
+def test_docs_tutorial_page_lists_every_lesson(folder):
+    """The Sphinx tutorial page links the lesson's folder on GitHub."""
+    assert folder in _DOCS_PAGE.read_text(), (
+        f'{folder} is not linked from docs/tutorial.rst -- add it under the '
+        f'topic heading it belongs to (see #598)')


### PR DESCRIPTION
Closes #598.

## The gap

`examples/tutorial/49_measurement_time_uncertainty/` has been on disk since 55f262a9, but the index table in `examples/tutorial/README.md` stopped at lesson 48 — the string `49` did not appear anywhere in the file. That table is where a reader goes to find a worked example, so a lesson missing from it is undiscoverable short of listing the directory, and the one that was missing is the only worked example of `time_error` — the entire point of #587/#588 and ADR-0112/0113.

While checking for the same drift elsewhere, the Sphinx index turned out to have it too: `docs/tutorial.rst` was missing lessons **47** and **48**. (It has 49, which was added with the lesson; 47 and 48 are the ones that slipped.) Both indexes are hand-maintained prose that nothing re-derives, so both go stale the same way and for the same reason.

## What changed

- **`examples/tutorial/README.md`** — row 49, in its neighbours' shape.
- **`docs/tutorial.rst`** — lesson 48 under *Objectives and noise models* (beside the other sigma-source lessons) and lesson 47 under *Data, experiments and protocols* (beside the other protocol lessons).
- **`tests/test_tutorial_index.py`** (new) — asserts that every numbered lesson folder has a row in the README table and a link on the Sphinx page. Pure text: it loads no model and touches no backend, so it runs in the default tier in about a tenth of a second for the whole parametrization. Removing either entry again fails a named test instead of going unnoticed for another five lessons.

The test file is beyond the issue's literal "one row" ask; it is there because the issue's own framing — *"they drift for the same reason"* — turned out to be right twice over, and the check is cheap enough to be worth having permanently. It is trivially droppable if you would rather not carry it.

## The two things the issue asked to check in the same pass

**The tier suffix.** Lesson 49's four confs are the only cases in the whole tutorial suite carrying *both* pytest marks: `tests/test_tutorial_examples.py` is module-marked `recovery`, and its four ConfChecks for lesson 49 are `marker='slow'`. Confirmed by collection:

```
$ pytest tests/test_tutorial_examples.py -m 'recovery and slow' --collect-only -q
tests/test_tutorial_examples.py::test_tutorial_conf_recovers[49_measurement_time_uncertainty/marginal.conf]
tests/test_tutorial_examples.py::test_tutorial_conf_recovers[49_measurement_time_uncertainty/estimate_sigma_t.conf]
tests/test_tutorial_examples.py::test_tutorial_conf_recovers[49_measurement_time_uncertainty/marginal_gradient.conf]
tests/test_tutorial_examples.py::test_tutorial_conf_is_dragged_off_truth[49_measurement_time_uncertainty/standard.conf]

4/61 tests collected (57 deselected)
```

So the row says *(recovery + slow tiers)* rather than borrowing either neighbour's single-tier label, which would understate the gating either way.

**The lesson counts.** Nothing to fix: neither `README.md` nor `_manifest.py`'s docstring states a lesson count anywhere, so there was no stale "45 lesson folders" left in the tree. For the record the set is now `01`–`49` with `04` absent, i.e. 48 lessons — and the README table now has 48 rows to match.

## Verification

- `sphinx-build -W --keep-going -b html docs` — build succeeded, no new warnings.
- `pytest tests/test_tutorial_index.py -q` — 97 passed in 0.14s.
- Negative control: deleting the README row and the `docs/tutorial.rst` entry in turn fails exactly the two corresponding named cases and nothing else.
- `ruff@0.15.14 check` clean on the new file; full default-tier collection unaffected.

Docs and one new test only — no runtime code touched, so no CHANGELOG entry (matching #600–#602).
