### PR TITLE
fix(parse): a comment is never part of a filename, so the shared file tokens stop at the '#' rather than running through it (#599, ADR-0120)

### DIFF
--- a/docs/adr/0120-a-comment-is-never-part-of-a-filename-so-the-shared-file-tokens-stop-at-the-hash-rather-than-running-through-it-to-the-next-extension-they-can-find.md
+++ b/docs/adr/0120-a-comment-is-never-part-of-a-filename-so-the-shared-file-tokens-stop-at-the-hash-rather-than-running-through-it-to-the-next-extension-they-can-find.md
@@ -1,0 +1,172 @@
+# A comment is never part of a filename, so the shared file tokens stop at the `#` rather than running through it to the next extension they can find (issue #599)
+
+**Status: Accepted and implemented (2026-08-20).** Closes the half of the hazard that
+ADR-0116 (#586, PR #596) deliberately left open, and does it at the token rather than at one
+declaration's guard.
+
+`parse.py`'s three file tokens were unanchored, lazy regexes:
+
+```python
+model_file = pp.Regex(r".*?\.(bngl|xml|ant|target)")
+exp_file   = pp.Regex(r".*?\.(exp|con|prop)")
+param_file = pp.Regex(r".*?\.tsv")
+```
+
+Both properties are deliberate and both are kept. **Unanchored** is what lets a path start
+with anything a filesystem allows — `../`, `~`, `/abs`, a drive letter. **Lazy** is what
+makes a comma list stop at the first extension instead of swallowing the rest of the line.
+Neither is the defect.
+
+## The defect
+
+Nothing stopped either property from operating *across a comment*. A `.*?` will start
+mid-line and run through spaces and a `#` to reach the next extension it can find, so a
+stray trailing comma followed by a comment that happens to mention a file became a second
+**file**:
+
+```
+model: a.xml, # note about b.xml            -> models   = {'a.xml', '# note about b.xml'}
+model = a.xml : d.exp, # note about e.exp   -> exp_data = {'d.exp', '# note about e.exp'}
+```
+
+Both spellings of a model-data mapping were affected — the new-era `model:` declaration and
+the legacy `model = … : …` form — and the second invents an **exp** file, not just a model.
+Measuring the reach found three more consumers with the identical defect, which the issue
+had not named: `mutant = … : …`, `experiment: … data:`, and the `data =` key all invent a
+phantom `.exp` the same way.
+
+### The failure is loud, but it is loud about the wrong thing
+
+The issue filed this as non-urgent because the bogus entry dies in the loaders rather than
+being integrated. That is true, and it is the reason this was a defect worth measuring
+rather than an emergency. What measuring found is that "loud" is doing less work than it
+sounds: the message the user actually gets depends on which extension their *comment*
+happened to contain, and none of the five point at the comma.
+
+| invented entry | what the user is told |
+|---|---|
+| `# … b.bngl` | `Model file # note about b.bngl was not found.` |
+| `# … b.xml` | `Failed to load model # … b.xml - There were errors in parsing this SBML file.` |
+| `# … b.ant` | `Antimony model support was requested, but requires optional dependency 'antimony'.` |
+| `# … e.exp` | `Action not specified for '# … e.exp'` — *"your model file needs `suffix=>…`"* |
+| `# … e.con` | `Constraint file # … e.con was not found` |
+
+Only the first is the "confusing message about a file they never wrote" the issue predicted.
+The `.xml` row — which is the form the issue's own repro uses — reports a **parse error in
+the user's SBML**, about a file that does not exist. The `.ant` row tells them to install an
+optional dependency they never asked for. The `.exp` row is reached from `_check_actions`
+*before* `_load_exp_data` can say "not found", so it sends them into their BNGL to add a
+`suffix=>` action for a measurement that is a sentence in English.
+
+This also answers the open question the issue attached to it — whether any `.exp`/`.con`/
+`.prop` consumer would *silently* accept a bogus entry rather than erroring. **None does.**
+Every path errors. The data side is simply the side that misdiagnoses hardest.
+
+### A second failure the fix also closes
+
+Measuring the blast radius turned up a second failure of the same regex that nobody had
+filed, on a different mechanism:
+
+```
+model = a.xml : none # note about e.exp     -> exp_data = {'none # note about e.exp'}
+```
+
+The alternation is `(_DelimitedList(exp_file) ^ nonetoken)`, and `^` is pyparsing's `Or` —
+**longest match wins**. `nonetoken` matches 4 characters; `exp_file`, free to cross the `#`,
+matched all 23 of `none # note about e.exp`. So a trailing comment on a `: none` line
+converted *"this model has no data"* into *"this model has one data file"*. It fails
+downstream like the others, but the declaration it corrupts is the one that says a model is
+deliberately unmeasured, which is the last place a user would look.
+
+## The decision
+
+**A `#` is never part of a filename, because `#` is what ends the part of a line a filename
+could live in.** All three tokens take a `[^#\n]` character class:
+
+```python
+model_file = pp.Regex(r"[^#\n]*?\.(bngl|xml|ant|target)")
+exp_file   = pp.Regex(r"[^#\n]*?\.(exp|con|prop)")
+param_file = pp.Regex(r"[^#\n]*?\.tsv")
+```
+
+`[^#\n]` rather than `[^#]` keeps the historical no-crossing-a-newline behaviour of `.`
+explicit now that the class is spelled out. Unanchored and lazy are untouched.
+
+**It lands on all three at once, and that is the whole reason it is a token change rather
+than a second guard.** ADR-0116 closed the *new* half of this hazard — a comma followed by a
+tolerance field — with a negative lookahead scoped to the `model:` declaration's file token,
+and said why it went no further: the legacy `model = … : …` form still accepted `#`, and two
+spellings of one declaration disagreeing about which files exist would be worse than the
+corner it would close. That reasoning is still right, which is why the narrowing could only
+ever be applied to the shared tokens, where both spellings and every other consumer —
+`mutant`, `data =`, `condition: model:`, and `experiment:`'s `model:` / `data:` /
+`measurement_params:` fields — get it simultaneously.
+
+(The issue also listed `normalization` and the PEtab import lines as running through these
+tokens. They do not: `normalization` takes its own permissive `anything` word and is
+resolved by separate code, and PEtab import does not go through `parse.py` at all. Both are
+unaffected, and the 41-shape sweep below confirms it.)
+
+The `model_decl_file` lookahead from ADR-0116 **stays**. The token now covers the comment
+half of what that guard was built for, but the guard still covers the rest of the line:
+`model: a.xml, atol: 1e-4, b.xml` has no comment in it and still needs refusing.
+
+### The one thing that narrows
+
+A filename containing a literal `#` is no longer expressible. This is a real reduction in
+what the grammar accepts and it is accepted deliberately:
+
+* Nothing in the repository, the tutorial suite, or the `BNGL-Models` corpus has such a
+  filename — checked, zero hits.
+* A `.conf` format that supports `#` comments could not round-trip such a name anyway; the
+  old behaviour did not so much *support* `#` filenames as fail to notice them.
+* The two spellings must agree either way, so this was never a per-form choice.
+
+## The measured blast radius
+
+41 line shapes were run through `ploop` before and after — every construct that reaches one
+of the three tokens, plus the ADR-0116 tolerance fields, plus relative/absolute/`~`/spaced
+paths. **9 changed; the other 32 are byte-identical**, including comment stripping on
+well-formed lines (`model: a.xml # note about b.xml` was never affected — the comma is what
+made the difference).
+
+Six are the defect being fixed. Note that three of the five phantom-file lines are
+consumers the issue did not name: it reported the two `model` spellings, but `mutant`,
+`experiment: … data:` and the `data =` key have the identical defect, which is the
+argument for fixing the token rather than each declaration.
+
+| line | before | after |
+|---|---|---|
+| `model: a.xml, # note about b.xml` | `{'a.xml', '# note about b.xml'}` | parse error + `model` format hint |
+| `model = a.xml : d.exp, # note about e.exp` | `{'d.exp', '# note about e.exp'}` | parse error + `model` format hint |
+| `mutant = a.xml m1 x*2.0 : d.exp, # note about e.exp` | `{'d.exp', '# note about e.exp'}` | parse error + `mutant` format hint |
+| `experiment: e, data: d.exp, # note about f.exp` | `{'d.exp', '# note about f.exp'}` | parse error + `experiment` format hint |
+| `data = d.exp, # note about f.exp` | `['d.exp', '# note about f.exp']` | parse error |
+| `model = a.xml : none # note about e.exp` | `{'none # note about e.exp'}` | `{}` — `none` finally means none |
+
+Three are the narrowing, and they are the evidence that the two spellings now agree:
+
+| line | before | after |
+|---|---|---|
+| `model: a#b.xml` | accepted | parse error |
+| `model = a#b.xml : d#e.exp` | accepted | parse error |
+| `experiment: …, measurement_params: a#b.tsv` | accepted | parse error |
+
+## Consequences
+
+* **A dangling comma before a comment is now a parse error rather than a phantom file.**
+  `model: a.xml, # b.xml` is what a user writes when commenting out the second entry of a
+  list and leaving the comma behind — a plausible editing state, and now a hard refusal.
+  This is the right trade: the refusal carries the `model` format hint, which spells out the
+  line's whole legal shape, and it arrives at parse time pointing at the line the user just
+  edited, instead of arriving from the SBML loader pointing at a file that does not exist.
+  The fix is to delete the comma, which is what they meant.
+* **`: none` means none.** The `Or`-longest-match interaction is closed as a side effect
+  rather than by special-casing `nonetoken`, because the cause was never the alternation.
+* **The invariant is now stated where it is enforced.** Both the token comment and the
+  ADR-0116 guard comment say which half each one closes, so the next person to widen a file
+  token can see that the `#` boundary is load-bearing for two independent failures.
+* **Not addressed here:** a malformed `data = …` line reports *"data is not a valid
+  configuration key"*, which is wrong — `data` is valid, just narrow (ADR-0050, `objective =
+  callable` only). It has no branch in `parse.py`'s per-key format-hint chain. That predates
+  this change and is filed separately rather than folded in.

--- a/pybnf/parse.py
+++ b/pybnf/parse.py
@@ -236,12 +236,32 @@ def parse(s):
     # model-data mapping grammar
     mdmkey = pp.CaselessLiteral("model")
     nonetoken = pp.Suppress(pp.CaselessLiteral("none"))
-    model_file = pp.Regex(r".*?\.(bngl|xml|ant|target)")
-    exp_file = pp.Regex(r".*?\.(exp|con|prop)")
+    # The shared file tokens. Every ``model``, ``mutant``, ``data``, ``condition: model:`` and
+    # ``experiment: model:/data:/measurement_params:`` line runs through one of these three, so
+    # they are the widest-blast-radius tokens in the grammar and are deliberately permissive:
+    # unanchored (a path may start with anything -- ``../``, ``~``, a drive letter) and lazy (so
+    # a comma list stops at the first extension rather than swallowing the whole line).
+    #
+    # The one thing they are NOT permissive about is ``#`` (#599, ADR-0120). Being unanchored,
+    # a ``.*?`` would start mid-line and run across spaces and a ``#`` to reach the next
+    # extension it could find, so a stray trailing comma followed by a COMMENT became a second
+    # file: ``model: a.xml, # note about b.xml`` declared a model named
+    # ``# note about b.xml``, and ``model = a.xml : d.exp, # note about e.exp`` invented an exp
+    # file the same way. ``[^#\n]`` is the fix and it is the only narrowing -- a comment is
+    # never part of a filename, in this format or any other, because ``#`` is what ENDS the
+    # part of the line a filename could live in. The cost is that a filename containing a
+    # literal ``#`` is no longer expressible; nothing in the corpus or the tutorial suite has
+    # one, and a conf file that supports ``#`` comments could not round-trip such a name
+    # anyway. It lands on all three tokens at once so the two spellings of a model-data
+    # mapping (``model:`` and ``model = ... : ...``) can never disagree about which files
+    # exist. ``[^#\n]`` rather than ``[^#]`` keeps the historical no-crossing-a-newline
+    # behaviour of ``.`` explicit now that the class is spelled out.
+    model_file = pp.Regex(r"[^#\n]*?\.(bngl|xml|ant|target)")
+    exp_file = pp.Regex(r"[^#\n]*?\.(exp|con|prop)")
     # A per-measurement binding-table sidecar (ADR-0045): a .tsv referenced by an
     # experiment's ``measurement_params:`` field, carrying a row-varying placeholder's
     # per-row token (an estimated id that cannot ride a float .exp column).
-    param_file = pp.Regex(r".*?\.tsv")
+    param_file = pp.Regex(r"[^#\n]*?\.tsv")
     mdmgram = mdmkey - equals - model_file - colon - (_DelimitedList(exp_file) ^ nonetoken) - comment
 
     # new-era model declaration grammar (ADR-0028):
@@ -284,24 +304,22 @@ def parse(s):
     md_tolerance_fields = (pp.Optional(md_atol_field) & pp.Optional(md_rtol_field)
                            & pp.Optional(md_species_atol_field))
     # The declaration's file token is the shared ``model_file`` regex behind a guard, and the
-    # guard exists because that regex is UNANCHORED and lazy: it will start mid-line and run
-    # across commas, colons, spaces and ``#`` to reach the next extension it can find.
-    # Harmless while a ``model:`` line was files-and-nothing-else, and not harmless once a
-    # comma can be followed by something that is not a file. Without it,
-    # ``model: decay.xml, atol: 1e-10  # tighter for decay.xml`` hands ``_DelimitedList`` the
-    # comma and lets the regex swallow the field, the comment and all, as a second "model
-    # file" named ``atol: 1e-10  # tighter for decay.xml`` -- and
-    # ``model: a.xml, atol: 1e-4, b.xml`` swallows ``b.xml`` the same way, walking straight
-    # past the one-model rule the field list is supposed to obey.
+    # guard exists because that regex is still UNANCHORED and lazy: it will start mid-line and
+    # run across commas, colons and spaces to reach the next extension it can find. (It no
+    # longer runs across ``#`` -- see the token above -- so the comment half of what this
+    # guard was built for in #586 is now closed at the token as well; the guard is what
+    # covers the rest of the line.) Harmless while a ``model:`` line was
+    # files-and-nothing-else, and not harmless once a comma can be followed by something that
+    # is not a file. Without it, ``model: a.xml, atol: 1e-4, b.xml`` hands ``_DelimitedList``
+    # the comma and lets the regex swallow the field as part of a second "model file" named
+    # ``atol: 1e-4, b.xml``, walking straight past the one-model rule the field list is
+    # supposed to obey.
     #
     # A tolerance field label is never a filename, so the file list ends where the fields
     # begin. The lookahead needs the label AND its colon, so a model genuinely named
     # ``rtol.xml`` still parses. A file written *after* a field is then a plain parse error
     # carrying the ``model`` format hint, which is where the line's legal shape is spelled
-    # out. Nothing else about the token is narrowed -- in particular ``#`` stays legal
-    # inside a filename, because the legacy ``model = ... : ...`` form still accepts it and
-    # two spellings of one declaration disagreeing about which files exist would be worse
-    # than the corner it would close.
+    # out.
     md_field_label = _one_of('atol rtol species_atol', caseless=True)
     model_decl_file = ~(md_field_label + pp.Literal(':')) + model_file
     model_decl_gram = (mdmkey + colon - _DelimitedList(model_decl_file)

--- a/tests/test_parse_class.py
+++ b/tests/test_parse_class.py
@@ -352,3 +352,99 @@ class TestParameterRecord:
         # A field missing its value -> the parameter-specific format hint.
         with pytest.raises(PybnfError, match='parameter:'):
             parse.ploop(['parameter: k, prior'])
+
+
+class TestFileTokensStopAtAComment:
+    """The shared ``model_file``/``exp_file``/``param_file`` regexes stop at ``#`` (#599,
+    ADR-0120).
+
+    All three are unanchored and lazy on purpose -- unanchored so a path may start with
+    anything (``../``, ``~``, an absolute root, a directory with a space in it), lazy so a
+    comma list stops at the first extension rather than swallowing the line. Neither
+    property is the defect. The defect was that they also ran straight *through* a comment
+    to reach the next extension they could find, so a stray trailing comma followed by a
+    comment that happened to mention a file declared that comment as a second file.
+
+    ADR-0116 closed one corner of this at the ``model:`` declaration's own guard and
+    deliberately left ``#`` alone, because the legacy ``model = ... : ...`` spelling still
+    accepted it and the two spellings disagreeing would be worse. That is why the fix is on
+    the shared tokens: every consumer gets it at once.
+    """
+
+    # Each line invents a file out of its comment. Four of the five are consumers #599 did
+    # not name -- the defect was in the token, not in any one declaration.
+    @pytest.mark.parametrize('line', [
+        'model: a.xml, # note about b.xml',                      # new-era declaration
+        'model = a.xml : d.exp, # note about e.exp',             # legacy mapping (invents an .exp)
+        'mutant = a.xml m1 x*2.0 : d.exp, # note about e.exp',   # mutant's data list
+        'experiment: e, data: d.exp, # note about f.exp',        # experiment's data: field
+        'data = d.exp, # note about f.exp',                      # the callable-objective data key
+    ])
+    def test_a_comment_after_a_trailing_comma_is_not_a_file(self, line):
+        # A dangling comma is malformed, and refusing it is the point: before this, the
+        # comment reached the loaders and died there with a message about a file the user
+        # never wrote -- and *which* message depended on the extension the comment happened
+        # to contain (a bogus `.xml` reported an SBML parse error, a bogus `.ant` demanded
+        # an optional dependency). The parse error names the line instead.
+        with pytest.raises(PybnfError):
+            parse.ploop([line + '\n'])
+
+    def test_none_with_a_trailing_comment_still_means_none(self):
+        # `(_DelimitedList(exp_file) ^ nonetoken)` is an Or -- LONGEST match wins. While
+        # exp_file could cross the '#', it matched all of `none # note about e.exp` (23
+        # chars) and beat `nonetoken` (4), silently turning "this model has no data" into
+        # "this model has one data file". Nothing special-cases the alternation; the token
+        # narrowing is what lets `none` win.
+        d = parse.ploop(['model = a.xml : none # note about e.exp\n'])
+        assert d['models'] == {'a.xml'}
+        assert d['exp_data'] == set()
+        assert d['a.xml'] == []
+
+    # Well-formed lines are untouched: a comment with no dangling comma before it was never
+    # the problem, and is still stripped.
+    @pytest.mark.parametrize('line, models, exp_data', [
+        ('model: a.xml # note about b.xml', {'a.xml'}, set()),
+        ('model: a.xml, b.xml # note about c.xml', {'a.xml', 'b.xml'}, set()),
+        ('model = a.xml : d.exp # note about e.exp', {'a.xml'}, {'d.exp'}),
+        ('model = a.xml : d.exp, e.exp # trailing note', {'a.xml'}, {'d.exp', 'e.exp'}),
+    ])
+    def test_a_comment_without_a_dangling_comma_is_still_stripped(self, line, models, exp_data):
+        d = parse.ploop([line + '\n'])
+        assert d['models'] == models
+        assert d['exp_data'] == exp_data
+
+    # Unanchored is preserved: `[^#\n]` still admits every path shape `.` did.
+    @pytest.mark.parametrize('path', [
+        '../models/a.xml', './sub dir/a.xml', '/abs/path/a.xml', '~/a.xml', 'sub dir/a.xml',
+    ])
+    def test_a_path_may_still_start_with_anything(self, path):
+        assert parse.ploop(['model: %s\n' % path])['models'] == {path}
+
+    def test_the_narrowing_is_a_literal_hash_in_a_filename(self):
+        # The one thing given up, stated so it is a decision rather than a surprise: a
+        # filename containing '#' no longer parses. Nothing in the repo, the tutorial suite
+        # or the BNGL-Models corpus has one, and a format with '#' comments could not
+        # round-trip such a name anyway.
+        for line in ('model: a#b.xml',
+                     'model = a#b.xml : d#e.exp',
+                     'experiment: e, data: d.exp, measurement_params: a#b.tsv'):
+            with pytest.raises(PybnfError):
+                parse.ploop([line + '\n'])
+
+    def test_both_spellings_of_a_model_mapping_agree_about_which_files_exist(self):
+        # The reason the fix had to land on the shared tokens rather than on one
+        # declaration's guard (ADR-0116's stated objection). Whatever the rule is, the
+        # new-era and legacy forms must reach the same verdict on the same filename.
+        for name in ('a#b.xml', 'a.xml'):
+            decl = legacy = None
+            try:
+                parse.ploop(['model: %s\n' % name])
+                decl = 'accepted'
+            except PybnfError:
+                decl = 'refused'
+            try:
+                parse.ploop(['model = %s : none\n' % name])
+                legacy = 'accepted'
+            except PybnfError:
+                legacy = 'refused'
+            assert decl == legacy, name


### PR DESCRIPTION
Closes #599.

`parse.py`'s three file tokens were unanchored, lazy regexes. Both properties are deliberate
and both are kept — unanchored is what lets a path start with anything a filesystem allows
(`../`, `~`, an absolute root, a directory with a space in it), lazy is what makes a comma
list stop at the first extension instead of swallowing the line.

Neither is the defect. The defect was that nothing stopped either property from operating
**across a comment**, so a stray trailing comma followed by a comment that happened to
mention a file declared that comment as a second file.

The fix is a `[^#\n]` character class on all three tokens at once:

```python
model_file = pp.Regex(r"[^#\n]*?\.(bngl|xml|ant|target)")
exp_file   = pp.Regex(r"[^#\n]*?\.(exp|con|prop)")
param_file = pp.Regex(r"[^#\n]*?\.tsv")
```

`#` is what *ends* the part of a line a filename could live in, so a comment is never part of
one. `[^#\n]` rather than `[^#]` keeps the historical no-crossing-a-newline behaviour of `.`
explicit now that the class is spelled out.

## What measuring changed about the issue's picture

The issue asked for the blast radius to be measured rather than guessed at. Three things came
back different from the filed description:

**1. Three more consumers had the identical defect.** The issue named the two `model`
spellings. `mutant = … : …`, `experiment: … data:` and the `data =` key invent a phantom
`.exp` the same way. That is the argument for fixing the token rather than each declaration.

**2. "Loud but confusing" was doing less work than it sounds.** *Which* message the user gets
depends on the extension their **comment** happened to contain, and none of them points at
the comma:

| invented entry | what the user is told |
|---|---|
| `# … b.bngl` | `Model file # note about b.bngl was not found.` |
| `# … b.xml` | `Failed to load model … There were errors in parsing this SBML file.` |
| `# … b.ant` | `Antimony model support was requested, but requires optional dependency 'antimony'.` |
| `# … e.exp` | `Action not specified for '# … e.exp'` — *"your model file needs `suffix=>…`"* |
| `# … e.con` | `Constraint file # … e.con was not found` |

Only the first is the message the issue predicted. The `.xml` row — the form the issue's own
repro uses — reports a parse error in the user's **SBML**, about a file that does not exist.
The `.ant` row demands an optional dependency they never asked for. On the data side,
`_check_actions` (config.py:292) runs before `_load_exp_data` (:294), so a bogus `.exp` sends
them into their BNGL to add a `suffix=>` action for a measurement that is a sentence in
English.

This also answers the open question the issue attached: **no `.exp`/`.con`/`.prop` consumer
silently accepts a bogus entry.** Every path errors. The data side is simply the side that
misdiagnoses hardest.

**3. A second failure nobody had filed, on a different mechanism:**

```
model = a.xml : none # note about e.exp   ->  exp_data = {'none # note about e.exp'}
```

`(_DelimitedList(exp_file) ^ nonetoken)` is an `Or` — longest match wins. `nonetoken` matches
4 characters; `exp_file`, free to cross the `#`, matched all 23 of `none # note about e.exp`
and won. A trailing comment on a `: none` line therefore converted *"this model has no data"*
into *"this model has one data file"* — and that is the declaration that says a model is
deliberately unmeasured, which is the last place anyone would look. Nothing here special-cases
the alternation; narrowing the token is what lets `none` win.

The issue also listed `normalization` and the PEtab import lines as running through these
tokens. They do not — `normalization` takes its own permissive `anything` word and is resolved
by separate code, and PEtab import does not go through `parse.py` at all. Both are unaffected.

## Why all three tokens at once

This is exactly the objection ADR-0116 (#586, PR #596) raised when it closed the *new* half of
the hazard with a lookahead scoped to the `model:` declaration's own file token: the legacy
`model = … : …` form still accepted `#`, and two spellings of one declaration disagreeing about
which files exist would be worse than the corner it would close. That reasoning is still right,
which is why the narrowing could only be applied at the **shared** tokens.

The ADR-0116 lookahead **stays** — the token now covers the comment half of what it was built
for, but `model: a.xml, atol: 1e-4, b.xml` has no comment in it and still needs refusing. Both
comments now say which half each one closes.

## The one thing that narrows

A filename containing a literal `#` no longer parses. Nothing in the repository, the tutorial
suite, or the BNGL-Models corpus has one (checked, zero hits), and a format with `#` comments
could not round-trip such a name anyway. It lands on both spellings simultaneously, so they
cannot disagree.

## Measured blast radius

41 line shapes run through `ploop` before and after — every construct reaching one of the three
tokens, plus the ADR-0116 tolerance fields, plus relative/absolute/`~`/spaced paths.
**9 changed, 32 byte-identical.** Comment stripping on well-formed lines is untouched:
`model: a.xml # note about b.xml` was never affected — the comma is what made the difference.

Six are the defect:

| line | before | after |
|---|---|---|
| `model: a.xml, # note about b.xml` | `{'a.xml', '# note about b.xml'}` | parse error + `model` hint |
| `model = a.xml : d.exp, # note about e.exp` | `{'d.exp', '# note about e.exp'}` | parse error + `model` hint |
| `mutant = a.xml m1 x*2.0 : d.exp, # note …` | `{'d.exp', '# note about e.exp'}` | parse error + `mutant` hint |
| `experiment: e, data: d.exp, # note …` | `{'d.exp', '# note about f.exp'}` | parse error + `experiment` hint |
| `data = d.exp, # note about f.exp` | `['d.exp', '# note about f.exp']` | parse error |
| `model = a.xml : none # note about e.exp` | `{'none # note about e.exp'}` | `{}` — `none` finally means none |

Three are the narrowing, and are the evidence the two forms now agree: `model: a#b.xml`,
`model = a#b.xml : d#e.exp`, and `measurement_params: a#b.tsv` all go from accepted to refused.

## A consequence worth naming

**A dangling comma before a comment is now a parse error rather than a phantom file.**
`model: a.xml, # b.xml` is what a user writes when commenting out the second entry of a list
and leaving the comma behind — a plausible editing state, and now a hard refusal. This is the
right trade: the refusal carries the `model` format hint, which spells out the line's whole
legal shape, and it arrives at parse time pointing at the line they just edited, instead of
arriving from the SBML loader pointing at a file that does not exist. The fix is to delete the
comma, which is what they meant.

## Tests

`TestFileTokensStopAtAComment` in `tests/test_parse_class.py` (the shared-token home, rather
than the tolerance file, since this is not a tolerance defect). 17 cases covering the five
phantom-file lines, the `: none` case, comment stripping on well-formed lines, every path shape
the unanchored token must still admit, the `#`-in-filename narrowing on all three tokens, and
an explicit assertion that **both spellings reach the same verdict on the same filename** —
the invariant ADR-0116 declined to break.

Verified they fail without the parser change: 7 fail on the current `main` parse.py, all pass
with it. The other 10 are invariance assertions that hold in both worlds, which is the point.

## Not addressed here

A malformed `data = …` line reports *"data is not a valid configuration key"*, which is wrong —
`data` is valid, just narrow (ADR-0050, `objective = callable` only). It has no branch in
`parse.py`'s per-key format-hint chain. That predates this change and is left for a separate
PR rather than folded in.
