### PR TITLE
fix(parse): a malformed 'data' line reports what the key takes rather than denying the key exists

### DIFF
--- a/pybnf/parse.py
+++ b/pybnf/parse.py
@@ -1241,6 +1241,15 @@ def ploop(ls):  # parse loop
                       "experiment's time-course endpoint), 't_start: <number>' / 'n_steps: <number>' " \
                       "(a constraint-only experiment's integration start / output resolution), or " \
                       "'measurement_params: file.tsv' in any order (requires edition >= 2)"
+            elif key == 'data':
+                # `data` is a real key (data_gram, above) -- narrow, but real. Without this
+                # branch it fell through to the `fmt == ''` fallback and a malformed line was
+                # told "data is not a valid configuration key", which is simply untrue and
+                # sends the reader looking for a typo in the key rather than in the file list.
+                fmt = "'data = file1.exp[, file2.exp ...]' binding experimental data to a " \
+                      "bring-your-own callable objective -- each file is one experiment, " \
+                      "presented to the callable as a name->Data mapping keyed by file stem " \
+                      "(ADR-0050). Valid only with 'objective = callable'"
             elif key == 'observable':
                 fmt = "'observable: entity, column: header' mapping a model observable/function name to a " \
                       "differently-named data column header (requires edition >= 2)"

--- a/tests/test_parse_class.py
+++ b/tests/test_parse_class.py
@@ -371,7 +371,7 @@ class TestFileTokensStopAtAComment:
     the shared tokens: every consumer gets it at once.
     """
 
-    # Each line invents a file out of its comment. Four of the five are consumers #599 did
+    # Each line invents a file out of its comment. Three of the five are consumers #599 did
     # not name -- the defect was in the token, not in any one declaration.
     @pytest.mark.parametrize('line', [
         'model: a.xml, # note about b.xml',                      # new-era declaration
@@ -448,3 +448,31 @@ class TestFileTokensStopAtAComment:
             except PybnfError:
                 legacy = 'refused'
             assert decl == legacy, name
+
+
+class TestDataKeyFormatHint:
+    """A malformed ``data = ...`` line reports what the key takes, not that it does not exist.
+
+    ``data`` is a real key -- narrow, but real: a comma list of ``.exp`` files bound to a
+    bring-your-own callable objective (ADR-0050), valid only with ``objective = callable``.
+    It had no branch in ploop's per-key format-hint chain, so it fell through to the generic
+    ``'{key} is not a valid configuration key.'`` fallback, which is untrue for this key and
+    sends the reader hunting for a typo in the key rather than in the file list.
+    """
+
+    def test_a_malformed_data_line_reports_the_data_format(self):
+        with pytest.raises(PybnfError) as exc:
+            parse.ploop(['data = d.exp, # note about f.exp\n'])
+        message = str(exc.value)
+        assert 'data = file1.exp' in message
+        assert 'objective = callable' in message
+
+    def test_a_malformed_data_line_no_longer_denies_the_key_exists(self):
+        # The specific regression: the old fallback text must not come back.
+        with pytest.raises(PybnfError) as exc:
+            parse.ploop(['data = not_a_file\n'])
+        assert 'data is not a valid configuration key' not in str(exc.value)
+
+    def test_a_well_formed_data_line_still_parses(self):
+        # The hint is reached only on failure -- the happy path is untouched.
+        assert parse.ploop(['data = d.exp, e.exp\n'])['data'] == ['d.exp', 'e.exp']


### PR DESCRIPTION
Follow-up to #608, which found this but deliberately left it out to keep that PR's scope to the file tokens.

## The defect

`ploop`'s per-key format-hint chain had no branch for `data`, so any malformed `data = …`
line fell through to the generic fallback and was told:

```
data is not a valid configuration key.
```

That is simply untrue. `data` is a real key (`data_gram`) — narrow, but real: a comma list of
`.exp` files bound to a bring-your-own callable objective (ADR-0050), where each file is one
experiment presented to the callable as a `name -> Data` mapping keyed by file stem, valid
only alongside `objective = callable`.

The message sends the reader hunting for a typo in the **key name**, which is fine, rather
than in the **file list**, which is the one place the error actually is.

## The fix

A `data` branch in the chain, in the style of its neighbours:

```
data should be specified in the format 'data = file1.exp[, file2.exp ...]' binding
experimental data to a bring-your-own callable objective -- each file is one experiment,
presented to the callable as a name->Data mapping keyed by file stem (ADR-0050). Valid
only with 'objective = callable'
```

No ADR — this corrects a message, it does not decide anything.

## Why it is a separate PR

Narrowing the shared file tokens in #608 made `data = d.exp, # note about f.exp` a parse
error rather than a phantom `.exp` file, which is correct — but it meant a plausible line now
reached a hint that denied the key existed.

The gap itself **predates** that change: `data = d.exp,` and every other malformed `data` line
already hit the same fallback. So it was not a regression from #608 and did not belong in it.

## Also in here: a one-word correction from #608

`tests/test_parse_class.py:374` said *"Four of the five are consumers #599 did not name"*
where the count is **three**. #599 named the two `model` spellings; the consumers it did not
name are `mutant`, `experiment: … data:` and `data =`.

The count is correct in ADR-0120 and in the #608 commit body — only that comment was stale,
because I amended it locally after pushing and the pre-amend version is what got squashed.

## Tests

`TestDataKeyFormatHint` in `tests/test_parse_class.py`:

- a malformed `data` line reports the real format (checks both `data = file1.exp` and the
  `objective = callable` restriction reach the user)
- the old fallback text specifically does not come back
- a well-formed `data = d.exp, e.exp` still parses — the hint is reached only on failure, so
  the happy path must be untouched

Verified they catch the defect: 2 of the 3 fail against `main`'s `parse.py`, all pass with the
change. The third is the invariance assertion and holds either way.

Nothing asserted the old wrong message, so no existing test needed updating.
