### PR TITLE
fix(gradient): a model's analytic sensitivity RHS is read off the codegen artifact rather than heard on a log line (#606, ADR-0121)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,6 +169,43 @@ All notable changes to PyBNF are documented below. This project adheres to
   says what it has not bisected.
 
 ### Fixed
+- **A gradient fit says, at job start, when bngsim declined the analytic `∂f/∂θ` for one of its
+  models and CVODES' difference quotient is carrying every sensitivity column instead (#606,
+  ADR-0121).** `CVodeSensInit1` takes one sensitivity-RHS callback for every column, so a single
+  rate law bngsim cannot differentiate — an `abs()`/`floor()`/`erf()` term, a comparison it
+  cannot solve, or a derivation that ran out of its build-time budget — declines the analytic
+  path for the **whole model**. The substitution is correct and costs an extra right-hand-side
+  evaluation per column per step, so an N-parameter fit pays roughly N× the sensitivity cost.
+  On a fit measured in hours that is not a slower answer but no answer: on
+  `Smith_BMCSystBiol2013` all 25 columns fell back, every start timed out to `inf`, and thirteen
+  hours produced nothing. PyBNF surfaced none of it — no console line, no refusal, nothing
+  distinguishing a gradient fit on the analytic path from one on the fallback. The decline did
+  reach `<prefix>.log`, because bngsim's logger propagates to root, but as one line per model
+  written mid-run from N worker processes into a shared, noisy file: discoverable by someone who
+  already suspects the problem, which is the wrong order.
+  PyBNF now checks **once per model at gradient-path setup**, on the head node, before the fit
+  has evaluated anything, and names the model, its column count, the expected cost multiplier and
+  bngsim's own reason. The check is not the log line: the verdict is read off the compiled codegen
+  artifact — whether it exports the analytic sensitivity RHS symbol, the exact symbol bngsim's
+  C++ resolves to choose between the two paths. That matters because bngsim reports a decline
+  while *generating* codegen source, and since lanl/bngsim#174 a warm structural cache skips
+  source generation entirely: measured on 0.13.0, the same declining model reports its decline on
+  the first construction and says nothing on the second, while running on the same fallback both
+  times. Since the cache persists on disk, the run that hears nothing is typically the second run
+  of a fit — the one made after the first came back empty. bngsim's reason is still captured and
+  reported when it is heard, but only ever as prose; nothing keys off its absence.
+  The new `sensitivity_fallback` key chooses what happens next: `warn` (the default — today's
+  behaviour plus the sentence), `error` (refuse the fit, for a long unattended run), or `ignore`
+  (skip the check, including the one simulator construction per model it costs). The policy keys off the verdict rather than the reason, so a
+  fit refuses or does not refuse reproducibly whatever state the codegen cache is in. A model
+  PyBNF cannot read an answer for — a `codegen=False` run has no artifact — reports **no
+  opinion**: logged, never warned about, and never refused, because guessing is wrong in both
+  directions.
+  One decline is worse than slow: a model that also branches at a crossing whose time moves gets
+  a difference quotient that integrates straight through it, so every column is wrong at and
+  after the crossing. bngsim ≥ 0.14.0 refuses such a run rather than return a gradient it has
+  flagged as wrong; on 0.13.0, which PyBNF's floor still admits, the same model only warns and
+  returns it, and PyBNF now says so at verbosity 0 whenever bngsim's reason reaches it.
 - **The discrete-event gradient gate reads a bngsim capability instead of a version floor, so a
   from-source build that merely *declares* a new enough version no longer passes it (#558,
   ADR-0119).** `BNGSIM_HAS_EVENT_SENS` gates forward sensitivities that survive a discrete

--- a/docs/adr/0121-a-models-analytic-sensitivity-rhs-is-read-off-the-codegen-artifact-rather-than-heard-on-a-log-line-because-a-warm-codegen-cache-says-nothing-about-a-model-that-is-still-on-the-fallback.md
+++ b/docs/adr/0121-a-models-analytic-sensitivity-rhs-is-read-off-the-codegen-artifact-rather-than-heard-on-a-log-line-because-a-warm-codegen-cache-says-nothing-about-a-model-that-is-still-on-the-fallback.md
@@ -1,0 +1,215 @@
+# A model's analytic sensitivity RHS is read off the codegen artifact rather than heard on a log line, because a warm codegen cache says nothing about a model that is still on the fallback (issue #606)
+
+**Status: Accepted and implemented (2026-08-20).** Answers the question ADR-0119's
+consequences section deferred: where a worker-side `∂f/∂p` decline reaches the user.
+
+`CVodeSensInit1` takes **one** sensitivity-RHS callback for every column, so a single rate
+law bngsim cannot differentiate declines the analytic `∂f/∂p` for the *whole* model — there
+is no per-reaction fallback to mix in. CVODES' internal difference quotient then carries
+every column. That substitution preserves correctness and multiplies cost: one extra RHS
+evaluation per column per step, so an N-column request pays roughly N times the sensitivity
+cost.
+
+On a fit measured in hours the cost is what ends runs. On `Smith_BMCSystBiol2013` all 25
+columns fell back, every start timed out to `inf`, and thirteen hours produced nothing. The
+only signal was a bngsim log line nobody had a reason to look for.
+
+## The gap
+
+bngsim says so, on the `bngsim` logger, at codegen time:
+
+> Forward sensitivity: *&lt;reason&gt;*, so the analytic sensitivity RHS is declined for this
+> model and CVODES' internal difference quotient is used instead (correct, but slower).
+
+PyBNF converted that into nothing a user of a fit would see. No console line, no entry in
+the run's own reporting, no refusal, and nothing distinguishing a gradient fit on the
+analytic path from one on the fallback.
+
+The line was not *lost*. `bngsim`'s logger propagates to root, PyBNF's `init_logging` puts a
+`FileHandler` there, and `Cluster` runs `init_logging` on every worker, so it lands in
+`<prefix>.log`. But that is a shared, noisy file written from N worker processes, and the
+line arrives once per model at first codegen, mid-run. It is discoverable by someone who
+already suspects the problem, which is the wrong order.
+
+## The finding that decided the design
+
+Issue #606's first suggested direction was to capture the `bngsim` logger during the
+gradient path and re-emit a decline as a PyBNF-level warning. It needs no new bngsim API and
+works across the whole supported range, which is exactly what recommends it.
+
+**It does not work, and it fails in the silent direction.** Since lanl/bngsim#174 the codegen
+cache key is *structural*, so a warm cache resolves the `.so` from a handful of C++ reads and
+**generates no source at all** — and source generation is where the decline is derived and
+logged. Measured on bngsim 0.13.0 with an `abs()` rate law, in one process:
+
+| construction | verdict (artifact) | decline logged |
+|---|---|---|
+| first, cold cache | fallback | yes, with the reason |
+| second, warm cache | fallback | **nothing** |
+
+The cache lives on disk and persists across runs, so the construction that hears nothing is
+typically the *second run of the same fit* — the run a user makes after the first came back
+empty. A design that took its verdict from the log line would report that run as fine.
+
+It is not even bngsim's cache alone. PyBNF's own `_ENGINE_TEMPLATE_CACHE` holds one engine
+model per SBML text per process, and a template that has been through a sensitivity
+construction carries its `_codegen_so_path` — so the *second model in a worker* skips codegen
+for the same reason, with no disk cache involved at all. Two independent caches, one shared
+consequence, which is what makes this a property of the channel rather than a bug in either.
+
+So silence on that logger means "declined, or served from cache". It can support a statement
+that a model **is** on the fallback, and never one that it is not.
+
+## The decision
+
+**Read the verdict off the codegen artifact; keep the log line for the reason.** The two
+channels answer different halves of the report, and the split is the whole ADR:
+
+| | channel | reliability | may be acted on |
+|---|---|---|---|
+| **verdict** | does the artifact export `bngsim_codegen_sens_rhs`? | exact, cache-hit or not | yes — policy keys off it |
+| **reason** | bngsim's own decline line, captured during construction | present on a cold cache only | prose only |
+
+`bngsim_codegen_sens_rhs` is the exact symbol bngsim's C++ resolves with `try_symbol` to
+choose the analytic RHS over the difference quotient, so reading it back off the artifact
+answers the question for the run that is actually about to happen. `analytic_sens_rhs_probe`
+resolves it through four routes, first match wins, and reports which one answered — the same
+ladder, and the same "prefer what the build publishes" rule, as ADR-0119's
+`_resolve_event_sens`:
+
+| # | route | when it answers |
+|---|---|---|
+| 1 | `Simulator.has_analytic_sens_rhs` | if bngsim ever publishes a per-run answer — **both** directions, ahead of everything else |
+| 2 | `Simulator._codegen_provides_sens_rhs()` | bngsim's own ground truth; private, ≥ 0.14.0 |
+| 3 | the symbol in `_codegen_c_source` / the `.so` at `_codegen_so_path` | today, on every build in the pin |
+| 4 | no artifact to read | **no opinion** |
+
+Route 1 fires on no build that exists. Naming it costs nothing and means PyBNF starts reading
+the real answer on the first build that grows one, with no PyBNF release in between; that is
+issue #606's "related upstream", lanl/bngsim#431. Route 2 is preferred over route 3 wherever
+it exists because it is upstream's answer to upstream's question — if the symbol ever stops
+being where route 3 looks, a build carrying the method keeps answering correctly. Route 3 is
+the load-bearing one: the floor admits 0.13.0, where route 2 does not exist, and a feature
+that only works on the newest build would not have caught the failure that motivated it.
+
+**Route 4 is a real answer and is reported as one.** A `codegen=False` run integrates the
+interpreted RHS and has no artifact; an unreadable `.so` is a different unknown. Guessing is
+wrong in both directions — a false *present* hides the cost this whole probe exists to
+surface, and a false *absent* warns about a fit that is fine — so no opinion is logged and
+never warned about. That is a departure from ADR-0119's fail-closed rule, and deliberately:
+there the wrong guess buys a converged wrong answer, here it buys a wrong sentence.
+
+### Where it runs: the head node, at gradient-path setup
+
+Issue #606 named the placement problem precisely — the fact is decided at codegen, which
+happens on a **worker** at the first sensitivity-bearing `simulate()`, not on the head node
+at `_setup_gradient_path()`. The natural reading is that the answer has to be found on a
+worker and carried back on a result.
+
+It does not. Reading the artifact needs a Simulator, and `_setup_gradient_path()` can build
+one: the models are constructed, the sensitivity request is applied, and it is the head node.
+So `_report_sensitivity_rhs()` builds **one sensitivity-bearing Simulator per model** there
+and probes it. That buys three things a worker-side capture could not:
+
+* the answer arrives **before the fit has spent anything**, which is the whole complaint the
+  log line could not answer — thirteen hours is not the cost of learning this too late, it is
+  the cost of learning it at all;
+* no worker→head plumbing, no per-model de-duplication across N processes, and no decision
+  about whether a decline rides back on a `Result` or is logged in place;
+* a `sensitivity_fallback = error` policy becomes possible, because there is a point in the
+  run at which refusing is still free.
+
+The cost is one codegen per model at job start. It is close to free where it matters: the
+codegen cache is content-addressed and shared, so on a local run every worker then gets a
+cache hit and the compile has been *moved* rather than added. On a cluster with no shared
+cache directory it is one extra compile per model, against a fit measured in hours — the same
+trade `_report_bngsim_build()` already makes ("a fit is hours; the warning is worth one line
+at job start").
+
+`probe_sens_rhs` **never raises**. A model that cannot be prepared for a sensitivity run
+reports no opinion, because a diagnostic that can end a fit is worse than no diagnostic;
+whatever is genuinely wrong surfaces at the first simulation with its own message.
+
+### The policy knob
+
+`sensitivity_fallback` takes `warn` (default), `error`, or `ignore`.
+
+`warn` names the model, its column count, the cost multiplier, and bngsim's reason when it
+gave one — to the log, and to the console, which is the point. `error` refuses instead, for a
+long unattended run. `ignore` skips the check entirely, including the one Simulator
+construction it costs, which is the reason to have an `ignore` at all.
+
+**The policy keys off the verdict, never off the reason.** That is not a detail. The verdict
+is stable across a cold or warm cache; the reason is not, so a policy that keyed off it would
+refuse a fit on its first run and accept the same fit on its second. Reproducible refusal is
+worth more than a more informative one.
+
+`error` also does not refuse a model that reported **no opinion**. The knob refuses a *known*
+fallback; it cannot promise to detect one it could not read, and refusing an unreadable build
+would take down a `codegen=False` run that is perfectly fine.
+
+### The half where "correct, but slower" is false
+
+There is a decline whose difference quotient does not answer the same question: the model
+branches at a crossing whose time moves, and the fallback integrates the variational equation
+straight through it, dropping the saltation jump `(f⁻−f⁺)·dt*/dθ`. Every column is then wrong
+at and after that crossing.
+
+From 0.14.0 bngsim **refuses** such a run — `SensitivityUnsupportedError`,
+lanl/bngsim#414/#416 — rather than return a gradient it has flagged as wrong, so there it
+reaches PyBNF as an ordinary error and needs nothing new. On 0.13.0, which the floor still
+admits, the same model only warns and returns the wrong gradient.
+
+Worth noting *how* 0.14.0 decides it, because it is this ADR's argument arrived at
+independently: `Simulator._raise_if_uncompensated_crossing_sensitivities` opens with `if
+self._codegen_provides_sens_rhs(): return` and then re-scans the model for the crossing. It
+does not consult the codegen warning at all — so its refusal survives a warm cache, and the
+comment beside it reaches the same conclusion, that the artifact is the ground truth and a
+re-derivation is not.
+
+PyBNF reports the case as a statement about the **numbers** rather than the cost: a `print0`,
+past the verbosity the cost line respects, saying the columns are wrong at and after the
+crossing. The wording has to hold on both sides of the 0.14.0 line — on a carrying build the
+fit is about to stop at the first simulation, on an older one it is about to run — so it says
+bngsim refuses the case from 0.14.0 and asks for a finite-difference check *if this fit
+proceeds*.
+
+It is **not** made a PyBNF refusal, and the reason is the cache again. Being carried on the
+reason channel, it can only fire when the reason was heard — so a refusal here would fire on a
+fit's first run and not on its second. A non-reproducible refusal is worse than a consistent
+warning. This is the same rule as the policy knob, applied to the case where it costs the most
+to obey.
+
+## What this does not claim
+
+* **It is not a statement about the whole fit.** One verdict in bngsim's codegen pipeline
+  reads parameter values and species initials (the switch gate), so a model branching on a
+  fitted threshold can in principle cross the line mid-search. The probe describes the model
+  at the fit's start point. Probing every evaluation is not a trade worth making; the caveat
+  is written down instead.
+* **It is not a per-condition statement.** A `condition:` perturbs parameter *values*, not
+  the rate-law expressions that decide differentiability, so the wildtype probe stands for
+  the model — subject to the same start-point caveat.
+* **It does not make PyBNF choose the path.** PyBNF cannot supply an analytic `∂f/∂p` bngsim
+  declined; what it can do is stop the user paying for the discovery in wall-clock.
+
+## Consequences
+
+* The rule this adds to the one stated in ADR-0119 — *a capability is decided by what the
+  build says it can do; a version string is at most a veto* — is about **channels**: a
+  diagnostic channel that can be short-circuited by a cache may carry explanation but not
+  verdict. The asymmetry has to be checked before a channel is trusted, and here checking it
+  reversed the issue's own first suggestion.
+* Route 3 replicates a private upstream method for the builds that lack it, and says so.
+  Route 2 exists precisely so that replication retires itself on every build that carries the
+  real thing, and route 1 retires both the day bngsim publishes a per-run key.
+* The probe is a general capability read, so it lives in `_bngsim_caps` beside the others —
+  keeping "one module asks bngsim what it can do" true even for a fact that is about a
+  (build, model) pair rather than a build.
+* The standing ask upstream is unchanged and now has a second consumer: a supported,
+  non-private read of "is this model on the analytic path" (lanl/bngsim#431) would collapse
+  routes 2 and 3 into route 1.
+* Not addressed here: reporting the *measured* cost. The probe says a model is on the
+  fallback and what the column count implies; it does not time a sensitivity solve, so
+  "roughly Nx" stays an estimate from the difference quotient's own arithmetic rather than an
+  observation.

--- a/docs/config_keys.rst
+++ b/docs/config_keys.rst
@@ -1540,6 +1540,48 @@ Algorithm Options
     * ``sbml_atol = auto``
     * ``sbml_atol = tracking 6``
 
+.. _sensitivity_fallback:
+
+**sensitivity_fallback**
+  Relevant only to a gradient-based ``job_type`` (``trf``, ``lbfgs``, ``gntr``, ``ms``,
+  ``profile_likelihood``): what to do when bngsim declines the **analytic sensitivity
+  right-hand side** for one of your models.
+
+  bngsim derives ``∂f/∂θ`` in closed form and compiles it, but CVODES takes one
+  sensitivity-RHS callback for every column, so a single rate law it cannot
+  differentiate — an ``abs()``/``floor()``/``erf()`` term, a comparison in a place it
+  cannot solve, or simply a derivation that ran out of its build-time budget — declines
+  the analytic path for the **whole model**. CVODES' internal difference quotient carries
+  every column instead. That answer is still correct; it costs an extra right-hand-side
+  evaluation per column per step, so an ``N``-parameter fit pays roughly ``N`` times the
+  sensitivity cost. On a fit measured in hours that is often the difference between a
+  result and a run that times out with nothing.
+
+  PyBNF checks once per model at job start, before the fit has spent anything, by
+  building one sensitivity-bearing simulator and reading back whether the compiled
+  artifact carries the analytic RHS. The settings are:
+
+  * ``warn`` (default) — name the model, the number of sensitivity columns, the expected
+    cost multiplier, and bngsim's own reason when it gave one, then run the fit.
+  * ``error`` — refuse the fit instead, for a long unattended run where discovering this
+    from the log afterwards is too late.
+  * ``ignore`` — skip the check entirely, including the one simulator construction per
+    model that it costs.
+
+  Two limits are worth knowing. bngsim reports its *reason* while generating codegen
+  source, which a warm codegen cache skips, so the reason is present the first time a
+  model is built and absent afterwards — the verdict itself is read off the artifact and
+  is unaffected. And the check describes the model at the fit's start point: one step of
+  bngsim's codegen reads parameter values, so a model that branches on a fitted threshold
+  could in principle change its answer mid-search.
+
+  Default: warn
+
+  Examples:
+
+    * ``sensitivity_fallback = error``
+    * ``sensitivity_fallback = ignore``
+
 **smoothing**
   Number of replicate runs to average together for each parameter set (useful for stochastic simulations). This option can be used with
   ``parallelize_models`` to run model partitions independently within each replicate.

--- a/docs/gradient_fitting.rst
+++ b/docs/gradient_fitting.rst
@@ -909,6 +909,61 @@ would need, at comparable cost but with an **exact** derivative and no step-size
 parameters actually free in a given experiment are requested (a condition-pinned parameter is
 dropped), so :math:`P` is the live count, not the total.
 
+That estimate assumes the **analytic** sensitivity right-hand side, which is the next
+section's subject.
+
+
+The analytic sensitivity RHS, and when bngsim declines it
+---------------------------------------------------------
+
+bngsim derives :math:`\partial f/\partial\theta` in closed form and compiles it alongside the
+model's own right-hand side. When it cannot, CVODES falls back to its **internal difference
+quotient**: correct, and considerably more expensive — one extra right-hand-side evaluation per
+sensitivity column per step, so an :math:`N`-column request pays roughly :math:`N` times the
+sensitivity cost rather than the :math:`(1+P)` above.
+
+The fallback is **all or nothing per model**. ``CVodeSensInit1`` takes one sensitivity-RHS
+callback for every column, so a single rate law bngsim cannot differentiate declines the analytic
+path for the whole model; there is no per-reaction mixture. bngsim declines on an underivable
+construct (``abs()``, ``floor()``, ``erf()``, ``tgamma()``), on a comparison in a position it
+cannot solve, and on a derivation that exhausts its own build-time budget — which means the same
+model can decline or not depending on how long the derivation took, with no version difference to
+point at.
+
+On a fit measured in hours this is not "slower", it is often "nothing": on
+``Smith_BMCSystBiol2013`` all 25 columns fell back, every start timed out, and thirteen hours
+produced no result.
+
+PyBNF therefore checks **once per model at job start**, before the fit has spent anything, and
+says what it found::
+
+    WARNING: model 'Smith' has no analytic sensitivity right-hand side, so this gradient fit
+    runs on CVODES' internal difference quotient -- each of this model's 25 sensitivity columns
+    costs an extra right-hand-side evaluation per step, so expect roughly 25x the sensitivity
+    cost of the analytic path. The gradient stays correct. bngsim declined it because ...
+
+The :ref:`sensitivity_fallback <sensitivity_fallback>` key chooses what happens next: ``warn``
+(the default, as above), ``error`` (refuse the fit — for a long unattended run), or ``ignore``
+(skip the check, including the one simulator construction per model it costs).
+
+Two limits are worth knowing:
+
+* The **verdict** is read off the compiled codegen artifact — whether it exports the analytic
+  sensitivity RHS symbol — so it is right whether or not the artifact came from bngsim's codegen
+  cache. bngsim's **reason** is not: it is reported while generating codegen source, and a warm
+  cache skips that step, so the reason appears the first time a model is built and not afterwards.
+  Only the prose varies; the verdict, and therefore ``sensitivity_fallback = error``, does not.
+* The check describes the model **at the fit's start point**. One step of bngsim's codegen reads
+  parameter values, so a model that branches on a fitted threshold could in principle cross the
+  line mid-search.
+
+One further case is worse than slow: a declined model that *also* branches at a crossing whose
+time moves. The difference quotient integrates straight through such a crossing, dropping the
+jump, so every column is wrong at and after it. bngsim 0.14.0 and later **refuse** that run
+rather than return a gradient they have flagged as wrong, and the refusal reaches PyBNF as an
+ordinary error. On an older bngsim the same model only warns and returns the wrong gradient —
+PyBNF says so at verbosity 0 whenever bngsim's reason reaches it.
+
 
 Parameter scales
 ----------------

--- a/pybnf/_bngsim_caps.py
+++ b/pybnf/_bngsim_caps.py
@@ -7,6 +7,9 @@ rather than reach for ``getattr(bngsim, ...)`` or ``hasattr(...)`` probes.
 """
 
 
+import collections
+import contextlib
+import ctypes
 import importlib.metadata
 import logging
 import os
@@ -458,3 +461,265 @@ def bngsim_stale_core_report():
         return module.format_report(prov)
     except Exception:                                  # pragma: no cover - defensive
         return ''
+
+
+# --- the analytic ∂f/∂p, per (build, MODEL) (#606) --------------------------- #
+#
+# Everything above this line is a property of the INSTALL. This is not: whether a
+# gradient runs on bngsim's analytic sensitivity RHS or on CVODES' internal
+# difference quotient is decided per model, at codegen, and two models on one
+# bngsim get different answers.
+#
+# ``CVodeSensInit1`` takes ONE sensitivity-RHS callback for every column, so a
+# single rate law bngsim cannot differentiate declines the analytic ∂f/∂p for the
+# WHOLE model -- there is no per-reaction fallback to mix in. The difference
+# quotient that replaces it costs an extra RHS evaluation per column per step, so
+# an N-parameter fit pays roughly N times the sensitivity cost. That is not an
+# annoyance on a fit measured in hours: on ``Smith_BMCSystBiol2013`` all 25 columns
+# fell back, every start timed out to ``inf``, and thirteen hours produced nothing
+# (#558). The only signal was a bngsim log line nobody had a reason to look for.
+#
+# WHY THE LOG LINE IS NOT THE INSTRUMENT. bngsim reports every decline on the
+# ``bngsim`` logger at codegen time, and PyBNF could listen for it -- that needs no
+# new bngsim API and works across the whole supported range. It is not enough on
+# its own, because the codegen cache short-circuits the step that emits it: since
+# lanl/bngsim#174 the cache key is STRUCTURAL, so a warm cache resolves the ``.so``
+# without generating any source, and source generation is where the decline is
+# derived and logged. Measured on 0.13.0 against an ``abs()`` rate law: first
+# construction reports the decline, a second construction of the same model in the
+# same process reports nothing and is on the same fallback. The cache is on disk
+# and persists across runs, so the run that hears nothing is typically the SECOND
+# run of a fit -- exactly the one made after the first came back empty.
+#
+# Silence on that logger therefore means "declined, or served from cache". It can
+# support a statement that a model IS on the fallback and never one that it is not.
+#
+# WHAT IS. The compiled artifact either exports ``bngsim_codegen_sens_rhs`` or it
+# does not, and that is the exact symbol bngsim's C++ resolves with ``try_symbol``
+# to choose the analytic RHS over the difference quotient. Reading it back off the
+# artifact answers the question for the run that is actually about to happen,
+# cache hit or not, and it is available on every build in the pin.
+#
+# So the two channels are used for different halves of the report, and
+# :func:`analytic_sens_rhs_probe` / :func:`capture_sens_rhs_declines` are that
+# split: the artifact carries the VERDICT (stable, so a policy may key off it), and
+# the logger carries the REASON (best-effort, so only the prose may key off it).
+#
+# The probe resolves through four routes, first match wins, and reports which one
+# answered -- the same ladder, and the same "prefer what the build publishes"
+# rule, as ``_resolve_event_sens`` above.
+_SENS_RHS_SYMBOL = 'bngsim_codegen_sens_rhs'
+# Route 1. A public per-run answer, if bngsim ever publishes one. No build exposes
+# this attribute today, so naming it costs nothing and means PyBNF reads the real
+# answer -- in BOTH directions -- on the first build that grows one, with no PyBNF
+# release in between. lanl/bngsim#431 is the standing ask it would arrive under.
+_SENS_RHS_PUBLIC_ATTR = 'has_analytic_sens_rhs'
+# Route 2. bngsim's own ground truth, private and >= 0.14.0. Preferred over route 3
+# wherever it exists, because it is upstream's answer to upstream's question: if the
+# artifact ever stops being where the symbol lives, a build carrying this method
+# keeps answering correctly while route 3 would not.
+_SENS_RHS_OWNED_METHOD = '_codegen_provides_sens_rhs'
+
+# bngsim phrases every decline as "Forward sensitivity: <reason>, so the analytic
+# sensitivity RHS is declined ..." (or "... <reason>. The analytic sensitivity RHS
+# is declined ..." for the variant that also says the fallback is wrong). Match the
+# clause that is common to both and keep the reason; a message that does not match
+# is kept whole rather than dropped, since an unrecognized decline is still a
+# decline and the wording is not PyBNF's to depend on.
+_SENS_RHS_DECLINE_MARK = 'analytic sensitivity rhs is declined'
+_SENS_RHS_DECLINE_RE = re.compile(
+    r'Forward sensitivity:\s*(?P<reason>.*?)[.,]\s*(?:so\s+)?[Tt]he analytic '
+    r'sensitivity RHS is declined',
+    re.DOTALL,
+)
+# The half of the decline space where "correct, but slower" is FALSE: the model
+# branches at a crossing whose time moves, the difference quotient integrates the
+# variational equation straight through it, and every column is wrong at and after
+# the crossing by the dropped saltation term. From 0.14.0 bngsim REFUSES such a run
+# (``SensitivityUnsupportedError``, lanl/bngsim#414/#416) rather than return a
+# gradient it has flagged as wrong, so there it reaches PyBNF as an ordinary error
+# and needs nothing here; on 0.13.0, which PyBNF's floor still admits, the same model
+# only warns and returns the wrong gradient. This phrase is how the variant
+# identifies itself on the builds where it is still only a warning.
+_SENS_RHS_UNCOMPENSATED_MARK = 'does not recover'
+
+
+class SensRhsStatus(collections.namedtuple(
+        'SensRhsStatus', 'analytic route reasons columns')):
+    """One model's answer to "is this fit's gradient on the analytic ``∂f/∂p``?" (#606).
+
+    ``analytic`` is the tri-state verdict :func:`analytic_sens_rhs_probe` reached
+    (``True`` / ``False`` / ``None`` for no opinion) and ``route`` names the evidence
+    that reached it. ``reasons`` is whatever bngsim said on its own logger while the
+    Simulator was being built -- ``(reason, fallback_is_wrong)`` pairs, and **empty
+    is not an answer**: a warm codegen cache emits nothing for a model that is on the
+    fallback all the same. Only ``analytic`` may be acted on; ``reasons`` only ever
+    adds detail to a verdict already reached.
+
+    ``columns`` is how many sensitivity columns this model was asked for, which is
+    what turns the verdict into a cost: the difference quotient spends one extra RHS
+    evaluation per column per step, so it is the multiplier a reader needs in order
+    to decide whether to wait.
+    """
+
+    __slots__ = ()
+
+    @property
+    def declined(self):
+        """True only for a model KNOWN to be on the difference-quotient fallback."""
+        return self.analytic is False
+
+    @property
+    def fallback_is_wrong(self):
+        """True when a captured reason says the difference quotient answers a
+        different question -- a branch crossing nobody compensates, where every
+        column is wrong at and after it (lanl/bngsim#150/#232).
+
+        Best-effort, like every read of :attr:`reasons`: ``False`` here means "not
+        heard", not "not so". bngsim >= 0.14.0 raises on this case rather than
+        warning, so it is only reachable on a sub-0.14.0 build with a cold cache.
+        """
+        return any(wrong for _, wrong in self.reasons)
+
+
+def probe_sens_rhs(make_simulator, columns=0):
+    """Build one sensitivity-bearing Simulator and report what it will run on (#606).
+
+    ``make_simulator`` is a thunk each backend supplies -- the same construction its
+    own ODE actions make, so the artifact read is about the artifact the fit will
+    actually install; ``columns`` is that model's requested sensitivity width.
+
+    Building the Simulator is the cost of the answer: it is a codegen, which
+    on a cold cache is a compile. That compile is one every worker was going to pay
+    anyway, content-addressed and shared, so paying it once here mostly moves work
+    rather than adding it -- and it buys the answer BEFORE the fit commits hours to
+    a gradient it cannot afford.
+
+    Never raises. A model that cannot be prepared for a sensitivity run reports no
+    opinion: this is a diagnostic, and a diagnostic that can end a fit is worse than
+    no diagnostic. Whatever is genuinely wrong surfaces at the first simulation with
+    its own message.
+    """
+    try:
+        with capture_sens_rhs_declines() as reasons:
+            sim = make_simulator()
+        state, route = analytic_sens_rhs_probe(sim)
+        return SensRhsStatus(state, route, list(reasons), int(columns))
+    except Exception:
+        logger.debug('could not probe the analytic sensitivity RHS', exc_info=True)
+        return SensRhsStatus(
+            None, 'the model could not be prepared for a sensitivity run', [],
+            int(columns))
+
+
+def analytic_sens_rhs_probe(sim):
+    """``(state, route)`` -- is ``sim`` about to run on the analytic ``∂f/∂p``? (#606)
+
+    ``state`` is tri-state on purpose:
+
+    * ``True``  -- the artifact this run installs carries the analytic sensitivity RHS;
+    * ``False`` -- it does not, so CVODES' internal difference quotient is used;
+    * ``None``  -- **no opinion**. There is no artifact to read (an interpreted RHS,
+      ``codegen=False``), or the one there is could not be opened. A caller must
+      report nothing rather than guess, in either direction: a false *present* hides
+      the cost this whole probe exists to surface, and a false *absent* warns about
+      a fit that is fine.
+
+    ``route`` names the evidence that answered, for a message that has to say how it
+    decided. Never raises -- a probe that cannot answer says so.
+    """
+    if sim is None:
+        return None, 'no simulator to read'
+    published = getattr(sim, _SENS_RHS_PUBLIC_ATTR, None)
+    if isinstance(published, bool):
+        return published, 'the bngsim Simulator attribute %r' % _SENS_RHS_PUBLIC_ATTR
+    owned = getattr(sim, _SENS_RHS_OWNED_METHOD, None)
+    if callable(owned):
+        try:
+            return bool(owned()), "bngsim's own Simulator.%s()" % _SENS_RHS_OWNED_METHOD
+        except Exception:                              # pragma: no cover - defensive
+            logger.debug('bngsim Simulator.%s() failed', _SENS_RHS_OWNED_METHOD,
+                         exc_info=True)
+    return _read_sens_rhs_artifact(sim)
+
+
+def _read_sens_rhs_artifact(sim):
+    """Route 3: does the codegen artifact this run installs export the symbol?
+
+    The JIT backends keep the generated C source on the Simulator and compile
+    nothing, so the source is checked first; it names the symbol only where it also
+    defines the function, which is what makes the substring test equivalent to the
+    ``.so`` symbol test. ``ctypes.CDLL`` on the ``.so`` is cheap -- bngsim's core has
+    already ``dlopen``\\ ed it, so this resolves from the loader's own table.
+    """
+    source = getattr(sim, '_codegen_c_source', '') or ''
+    if source:
+        return (_SENS_RHS_SYMBOL in source), 'the generated C source this run installs'
+    path = getattr(sim, '_codegen_so_path', '') or ''
+    if path:
+        try:
+            return (hasattr(ctypes.CDLL(path), _SENS_RHS_SYMBOL),
+                    'the compiled codegen artifact this run installs')
+        except Exception:
+            # Broad on purpose: the usual failure is an OSError from ``dlopen``, but
+            # this is a diagnostic, and no way of failing to read a path is worth
+            # raising out of one. An unreadable artifact is an unknown, not a verdict.
+            logger.debug('could not open the bngsim codegen artifact %s', path,
+                         exc_info=True)
+            return None, 'the compiled codegen artifact could not be opened'
+    return None, 'this run installs no codegen artifact to read'
+
+
+class _SensRhsDeclineHandler(logging.Handler):
+    """Collects bngsim's own decline reasons, and nothing else, off its logger."""
+
+    def __init__(self):
+        super().__init__(level=logging.WARNING)
+        self.reasons = []
+
+    def emit(self, record):
+        try:
+            message = record.getMessage()
+        except Exception:                              # pragma: no cover - defensive
+            return
+        if _SENS_RHS_DECLINE_MARK not in message.lower():
+            return
+        match = _SENS_RHS_DECLINE_RE.search(message)
+        reason = match.group('reason').strip() if match else message.strip()
+        uncompensated = _SENS_RHS_UNCOMPENSATED_MARK in message.lower()
+        if (reason, uncompensated) not in self.reasons:
+            self.reasons.append((reason, uncompensated))
+
+
+@contextlib.contextmanager
+def capture_sens_rhs_declines():
+    """Collect bngsim's decline reasons emitted inside the block (#606).
+
+    Yields the list the handler fills: ``(reason, fallback_is_wrong)`` pairs, in the
+    order bngsim reported them and de-duplicated, where ``fallback_is_wrong`` marks
+    the variant whose difference quotient does NOT answer the same question (a
+    branch crossing nobody compensates -- see :data:`_SENS_RHS_UNCOMPENSATED_MARK`).
+
+    Best-effort **by construction**: the block has to contain the codegen that
+    derives the decline, and a warm structural cache skips that step entirely, so an
+    empty list means "declined, or served from cache" and never "not declined". Use
+    it to explain a verdict :func:`analytic_sens_rhs_probe` has already reached,
+    never to reach one.
+
+    The handler is attached to the ``bngsim`` logger itself rather than to root:
+    PyBNF's own root handlers stay untouched, so a decline still lands in the run's
+    log exactly as it does today.
+    """
+    handler = _SensRhsDeclineHandler()
+    bngsim_logger = logging.getLogger('bngsim')
+    # No level is set here, deliberately. The ``bngsim`` logger is left at NOTSET and
+    # inherits root's, and ``init_logging`` sets root to DEBUG and does its level
+    # filtering on the FileHandler -- so the decline record reaches this handler even
+    # under ``--log_level error``, where it would not reach the log file. Lowering a
+    # level here would instead be a global side effect, and would push records into
+    # PyBNF's own handlers that the user asked not to see.
+    bngsim_logger.addHandler(handler)
+    try:
+        yield handler.reasons
+    finally:
+        bngsim_logger.removeHandler(handler)

--- a/pybnf/algorithms/optimizers/gradient_base.py
+++ b/pybnf/algorithms/optimizers/gradient_base.py
@@ -43,6 +43,8 @@ re-transforms. Leaves own their ``start_run`` / ``got_result`` state machine and
 must be picklable for backup/resume, exactly like Powell and CMA-ES (ADR-0007).
 """
 
+import logging
+
 import numpy as np
 
 from .concurrent_multistart import DONE, ConcurrentMultiStartOptimizer
@@ -55,12 +57,14 @@ from ...gradient import (
     assemble_marginal_time_gradient,
     route_for_model,
 )
-from ...printing import PybnfError, print1, print2
+from ...printing import PybnfError, print0, print1, print2
 
 # ``DONE`` is the shared multi-start sentinel, re-exported here so a gradient leaf's
 # ``from .gradient_base import DONE`` keeps resolving to the one object the base's
 # ``got_result`` identity-checks (#500).
 __all__ = ['DONE', 'GradientRunner', 'GradientOptimizer']
+
+logger = logging.getLogger(__name__)
 
 
 class GradientRunner:
@@ -281,6 +285,11 @@ class GradientOptimizer(ConcurrentMultiStartOptimizer):
         # _setup_gradient_path (needs the initialized models). None until then, and
         # restored as None by reset() so a bootstrap refit rebuilds it.
         self._routings = None
+        # Whether _report_sensitivity_rhs has already spoken. Deliberately NOT reset by
+        # _after_reset: the routings are rebuilt per bootstrap refit, but which
+        # sensitivity RHS each model runs on is not a function of the resampled data
+        # (#606).
+        self._sens_rhs_reported = False
         # Backend gate: every model must expose bngsim's forward-sensitivity hooks
         # (the capability gate itself fires later, at apply_routing).
         self._require_sensitivity_backend()
@@ -364,7 +373,9 @@ class GradientOptimizer(ConcurrentMultiStartOptimizer):
         print2('Current best objective: %f, %s' % (runner.fval, runner.progress_detail()))
 
     # --- gates ------------------------------------------------------------- #
-    # The gradient path is gated in four places, each as early as it can be:
+    # The gradient path is gated in four places, each as early as it can be (a fifth
+    # check, :meth:`_report_sensitivity_rhs`, sits beside them and is a *report* unless
+    # the user asks it to be a gate -- see its own docstring):
     #
     # * **edition** (:meth:`_require_edition_2`, before model build) -- the gradient
     #   consumes the edition-2 surface (bind-by-id routing, the noise-model /
@@ -379,6 +390,14 @@ class GradientOptimizer(ConcurrentMultiStartOptimizer):
     #   than mid-run, and on a current one the model passes straight through;
     # * **capability** (deferred to :meth:`_setup_gradient_path`'s ``apply_routing``,
     #   #447) -- raises if the bngsim build lacks the ``output_sensitivities`` feature.
+    #
+    # Every one of those is a property of the BUILD or of the CONFIG, which is why each
+    # can be decided from a module-level flag or a config read. The fifth is not: whether
+    # bngsim supplies an analytic ``∂f/∂p`` for a given model is a property of the
+    # (build, model) pair, decided at codegen, so :meth:`_report_sensitivity_rhs` has to
+    # build a Simulator to find out (#606, ADR-0121). It warns by default rather than
+    # refusing, because the fallback is correct -- just N times the cost -- and only
+    # refuses under ``sensitivity_fallback = error``.
     #
     # The per-evaluation gate (an unsupported *objective* -- Laplace residual,
     # estimated scale, … raising :class:`GradientNotSupported`) is caught at the first
@@ -545,6 +564,132 @@ class GradientOptimizer(ConcurrentMultiStartOptimizer):
             for suffix, routing in model_routings.items():
                 routings[(model.name, suffix)] = routing
         self._routings = routings
+        self._report_sensitivity_rhs()
+
+    def _report_sensitivity_rhs(self):
+        """Say which sensitivity right-hand side each model's gradient will run on (#606).
+
+        ``CVodeSensInit1`` takes one sensitivity-RHS callback for every column, so a
+        single rate law bngsim cannot differentiate declines the analytic ``∂f/∂p`` for
+        the **whole** model and CVODES' internal difference quotient carries every
+        column instead. That is a correctness-preserving substitution and a
+        cost-multiplying one: an extra RHS evaluation per column per step, so an
+        N-column request pays roughly N times the sensitivity cost. On a fit measured
+        in hours that is not a slower answer, it is no answer -- on
+        ``Smith_BMCSystBiol2013`` all 25 columns fell back, every start timed out to
+        ``inf``, and thirteen hours produced nothing, with the only signal a bngsim log
+        line on a worker that nobody had a reason to look for (#558).
+
+        This is the only pre-flight check here that is a property of the **(build,
+        model)** pair rather than of the build or the config, so unlike the four gates
+        above it cannot be answered from a module-level flag or a config read: it
+        builds one sensitivity-bearing Simulator per model and reads the verdict off
+        the codegen artifact that Simulator installs
+        (:func:`~pybnf._bngsim_caps.probe_sens_rhs`). Running it here rather than on a
+        worker is what makes it useful -- the answer arrives before the fit has spent
+        anything, which is the whole complaint the log line could not answer.
+
+        The verdict is what policy keys off, because the verdict is stable. bngsim's
+        own *reason* for a decline is captured too, but only ever as prose: it is
+        emitted during codegen source generation, which a warm structural cache skips
+        entirely, so it is present on the first run of a fit and absent on the second.
+        A model reporting no opinion (``None`` -- no codegen artifact to read) is
+        logged and not warned about, in either direction.
+
+        Reported **once per run**, not once per pass: ``reset()`` drops the routings so
+        a bootstrap refit rebuilds them, and a model's differentiability does not change
+        with resampled data, so ``bootstrap = 100`` would otherwise print the same
+        warning a hundred times. The refusal is once-only for the same reason -- it has
+        already ended the run the first time.
+
+        Never raises except under ``sensitivity_fallback = error``, which is a user
+        asking to be stopped."""
+        policy = str(self.config.config.get('sensitivity_fallback', 'warn')).lower()
+        if policy == 'ignore' or getattr(self, '_sens_rhs_reported', False):
+            return
+        self._sens_rhs_reported = True
+        declined = []
+        for model in self.model_list:
+            probe = getattr(model, 'analytic_sens_rhs_status', None)
+            if not callable(probe):
+                # A backend with no opinion to give (a test double, a non-bngsim
+                # model). The sensitivity-backend gate above already refused anything
+                # that cannot supply a gradient at all, so this is not a failure.
+                continue
+            status = probe()
+            if status.analytic is None:
+                logger.info(
+                    "Model %s: cannot tell whether the forward sensitivities run on "
+                    "bngsim's analytic df/dp -- %s.", model.name, status.route)
+            elif status.analytic:
+                logger.info(
+                    "Model %s: forward sensitivities run on bngsim's analytic df/dp "
+                    "(read from %s).", model.name, status.route)
+            else:
+                declined.append((model, status))
+                self._warn_sensitivity_fallback(model, status)
+        if declined and policy == 'error':
+            raise PybnfError(
+                "Gradient-based fitting (job_type = %s) was asked to require the "
+                "analytic sensitivity right-hand side (sensitivity_fallback = error), "
+                "and bngsim declined it for %s." % (
+                    self._fit_type_label(),
+                    ', '.join("model '%s'" % m.name for m, _ in declined)),
+                hint=["Re-encode the declined rate law in a form bngsim can "
+                      "differentiate. Its own reason is in the warning above when it "
+                      "gave one -- it reports the reason while generating codegen "
+                      "source, so a warm codegen cache has none to give.",
+                      "Or accept the fallback with 'sensitivity_fallback = warn' (the "
+                      "default) and expect roughly one extra right-hand-side "
+                      "evaluation per sensitivity column per step.",
+                      _FALLBACK_HINT])
+
+    def _warn_sensitivity_fallback(self, model, status):
+        """One model's difference-quotient warning, to the log and to the console.
+
+        Console rather than log-only on purpose, and at verbosity 0 rather than 1. The
+        decline already reaches ``<prefix>.log`` today -- bngsim's logger propagates to
+        root and PyBNF puts a FileHandler there -- and that is exactly the channel that
+        failed: a shared, noisy file written from N worker processes, one line per
+        model, arriving mid-run. It is discoverable by someone who already suspects the
+        problem, which is the wrong order. A reader who turned the verbosity down is
+        still a reader who would rather not spend the next thirteen hours, which is the
+        same call ``_report_bngsim_build`` makes for a stale compiled core (#558).
+        """
+        columns = status.columns or len(self.variables)
+        cost = ("each of this model's %d sensitivity columns costs an extra "
+                "right-hand-side evaluation per step, so expect roughly %dx the "
+                "sensitivity cost of the analytic path" % (columns, columns))
+        reason = '; '.join(reason for reason, _ in status.reasons)
+        detail = (' bngsim declined it because %s.' % reason if reason else
+                  ' bngsim did not say why in this run: it reports the reason while '
+                  'generating the codegen source, which a warm codegen cache skips.')
+        logger.warning(
+            "Model %s: bngsim declined the analytic sensitivity RHS, so CVODES' "
+            "internal difference quotient carries every column (%s; read from %s).%s",
+            model.name, cost, status.route, detail)
+        print0("WARNING: model '%s' has no analytic sensitivity right-hand side, so "
+               "this gradient fit runs on CVODES' internal difference quotient -- %s. "
+               "The gradient stays correct.%s" % (model.name, cost, detail))
+        print1('  -> Read from %s.' % status.route)
+        if status.fallback_is_wrong:
+            # The half of the decline space where "correct, but slower" is FALSE. This
+            # is a statement about the NUMBERS rather than the cost, so it goes to
+            # print0, past the verbosity the cost line respects.
+            #
+            # From 0.14.0 bngsim refuses such a run outright rather than returning the
+            # gradient it has flagged as wrong (lanl/bngsim#414/#416) -- and it decides
+            # that from its own ground truth, re-scanning the model rather than trusting
+            # the codegen warning, so its refusal survives a warm cache where this line
+            # does not. The wording therefore has to be true on both sides of that
+            # line: on a carrying build the fit is about to stop at the first
+            # simulation, and on an older one it is about to run.
+            print0("WARNING: model '%s' also branches at a crossing whose time moves, "
+                   "and the difference quotient integrates straight through it, so "
+                   "every sensitivity column is wrong at and after that crossing by "
+                   "the jump it drops. bngsim refuses this case outright from 0.14.0; "
+                   "if this fit proceeds, validate against a finite difference of the "
+                   "trajectory before relying on it." % model.name)
 
     def _condition_for_suffix(self, model, suffix):
         """Resolve a scored ``suffix`` to the condition (``MutationSet``) it was

--- a/pybnf/bngsim_model/_runtime.py
+++ b/pybnf/bngsim_model/_runtime.py
@@ -25,3 +25,5 @@ BNGSIM_HAS_SS_OUTPUT_SENS = _bngsim_caps.BNGSIM_HAS_SS_OUTPUT_SENS
 BNGSIM_HAS_SCAN_SENS_CARRY = _bngsim_caps.BNGSIM_HAS_SCAN_SENS_CARRY
 BNGSIM_VERSION = _bngsim_caps.BNGSIM_VERSION
 feature_missing_reason = _bngsim_caps.feature_missing_reason
+probe_sens_rhs = _bngsim_caps.probe_sens_rhs
+SensRhsStatus = _bngsim_caps.SensRhsStatus

--- a/pybnf/bngsim_model/net_model.py
+++ b/pybnf/bngsim_model/net_model.py
@@ -306,6 +306,30 @@ class BngsimModel(NetModel):
             params=list(params or []), ic=list(ic or []),
         )
 
+    def analytic_sens_rhs_status(self):
+        """What this model's forward sensitivities will actually run on (#606).
+
+        Returns a :class:`~pybnf._bngsim_caps.SensRhsStatus`: the tri-state verdict,
+        the evidence that reached it, and whatever bngsim said about *why* while the
+        Simulator was being built. ``None`` verdict on the scalar path -- there are no
+        sensitivities to be on either path of.
+
+        The Simulator built here is the same one an ODE action builds
+        (:meth:`_execute_actions`' opening construction, with no action suffix resolved
+        yet, which is the sensitivity-bearing case), so the artifact read is about the
+        artifact this fit installs.
+        """
+        if self._sensitivity_request is None:
+            return _runtime.SensRhsStatus(
+                None, 'this model has no sensitivity request', [], 0)
+        req = self._sensitivity_request
+        self._current_action_suffix = None
+        return _runtime.probe_sens_rhs(
+            lambda: _runtime.bngsim.Simulator(
+                self._engine_model, method='ode',
+                **self._codegen_kwargs(), **self._sensitivity_request_kwargs('ode')),
+            columns=len(req.params or ()) + len(req.ic or ()))
+
     def set_scored_suffixes(self, suffixes):
         """Record which output suffixes are scored gradient targets (#475).
 

--- a/pybnf/bngsim_sbml_model.py
+++ b/pybnf/bngsim_sbml_model.py
@@ -363,8 +363,10 @@ from ._bngsim_caps import (
     BNGSIM_HAS_SBML,
     BNGSIM_HAS_TRACKING_ATOL,
     BNGSIM_SBML_ERROR,
+    SensRhsStatus,
     bngsim,
     feature_missing_reason,
+    probe_sens_rhs,
 )
 
 try:
@@ -1763,6 +1765,29 @@ class BngsimSbmlModelNoTimeout(Model):
         self._sensitivity_request = _SensitivityRequest(
             params=list(params or []), ic=list(ic or []),
         )
+
+    def analytic_sens_rhs_status(self):
+        """What this model's forward sensitivities will actually run on (#606).
+
+        The SBML twin of :meth:`BngsimModel.analytic_sens_rhs_status`. Probes the
+        **wildtype** engine model with no action suffix resolved, which is the
+        sensitivity-bearing construction every scored ODE action makes: a
+        ``condition:`` perturbs parameter values, not the rate-law expressions that
+        decide differentiability, so one probe stands for the model.
+
+        It stands for it *at the start point*, though, not for the whole fit. One
+        verdict in bngsim's codegen pipeline reads parameter values and species
+        initials (the switch gate), so a model that branches on a threshold can in
+        principle cross the line mid-search. Probing every evaluation is not a trade
+        worth making; the caveat is written down instead.
+        """
+        if self._sensitivity_request is None:
+            return SensRhsStatus(None, 'this model has no sensitivity request', [], 0)
+        req = self._sensitivity_request
+        self._current_action_suffix = None
+        return probe_sens_rhs(
+            lambda: self._make_simulator(self._engine_model_for_action(), 'ode'),
+            columns=len(req.params or ()) + len(req.ic or ()))
 
     def set_scored_suffixes(self, suffixes):
         """Record which output suffixes are scored gradient targets (#475/#482).

--- a/pybnf/config_schema.py
+++ b/pybnf/config_schema.py
@@ -250,6 +250,21 @@ class GlobalConfig(PyBNFConfigModel):
     # union report.
     sbml_rtol: Optional[float] = None
     sbml_atol: Any = None
+    # What a gradient fit does when bngsim declines the analytic sensitivity RHS for a
+    # model and CVODES' internal difference quotient carries every column instead
+    # (#606, ADR-0121). The substitution is correctness-preserving and cost-multiplying
+    # -- one extra RHS evaluation per column per step -- so the default says so and
+    # proceeds:
+    #   * 'warn'   (default) -- name the model, the cost, and bngsim's reason when it
+    #              gave one, at job start, before the fit has spent anything.
+    #   * 'error'  -- refuse instead, for a run nobody will be watching. Keys off the
+    #              verdict (read off the codegen artifact), which is stable across a
+    #              warm or cold codegen cache, so a fit refuses or does not refuse
+    #              reproducibly.
+    #   * 'ignore' -- skip the check entirely, including the one Simulator construction
+    #              it costs per model.
+    # bngsim backends only; a gradient fit is bngsim-only anyway (the backend gate).
+    sensitivity_fallback: Literal['warn', 'error', 'ignore'] = 'warn'
     stochastic_seed: str = 'auto'
     parallel_count: Optional[int] = None
     save_best_data: int = 0

--- a/pybnf/parse.py
+++ b/pybnf/parse.py
@@ -156,7 +156,10 @@ strkeylist = ['bng_command', 'output_dir', 'fit_type', 'job_type', 'objfunc', 'o
               'ms_knot_placement',
               # Global qualitative (BPSL) penalty-family override:
               # auto | hinge | probit | logit.
-              'qualitative_loss']
+              'qualitative_loss',
+              # What a gradient fit does when bngsim declines a model's analytic
+              # sensitivity RHS (#606, ADR-0121): warn | error | ignore.
+              'sensitivity_fallback']
 multstrkeys = ['worker_nodes', 'postprocess', 'output_trajectory', 'output_noise_trajectory',
                # profile likelihood (#446/#466): the subset of free parameters to profile
                # (a list of parameter ids; absent -> profile every free parameter).

--- a/tests/golden_configs/effective_config_golden.json
+++ b/tests/golden_configs/effective_config_golden.json
@@ -318,6 +318,10 @@
     null
    ],
    [
+    "sensitivity_fallback",
+    "warn"
+   ],
+   [
     "simulation_dir",
     null
    ],
@@ -770,6 +774,10 @@
    [
     "scheduler_node",
     null
+   ],
+   [
+    "sensitivity_fallback",
+    "warn"
    ],
    [
     "simulation_dir",
@@ -1234,6 +1242,10 @@
     null
    ],
    [
+    "sensitivity_fallback",
+    "warn"
+   ],
+   [
     "simulation_dir",
     null
    ],
@@ -1650,6 +1662,10 @@
    [
     "scheduler_node",
     null
+   ],
+   [
+    "sensitivity_fallback",
+    "warn"
    ],
    [
     "simulation_dir",
@@ -2216,6 +2232,10 @@
    [
     "scheduler_node",
     null
+   ],
+   [
+    "sensitivity_fallback",
+    "warn"
    ],
    [
     "simulation_dir",
@@ -2792,6 +2812,10 @@
     null
    ],
    [
+    "sensitivity_fallback",
+    "warn"
+   ],
+   [
     "simulation_dir",
     null
    ],
@@ -3322,6 +3346,10 @@
     null
    ],
    [
+    "sensitivity_fallback",
+    "warn"
+   ],
+   [
     "simulation_dir",
     null
    ],
@@ -3774,6 +3802,10 @@
    [
     "scheduler_node",
     null
+   ],
+   [
+    "sensitivity_fallback",
+    "warn"
    ],
    [
     "simulation_dir",
@@ -4238,6 +4270,10 @@
     null
    ],
    [
+    "sensitivity_fallback",
+    "warn"
+   ],
+   [
     "simulation_dir",
     null
    ],
@@ -4589,6 +4625,10 @@
    [
     "scheduler_node",
     null
+   ],
+   [
+    "sensitivity_fallback",
+    "warn"
    ],
    [
     "simulation_dir",
@@ -4987,6 +5027,10 @@
     null
    ],
    [
+    "sensitivity_fallback",
+    "warn"
+   ],
+   [
     "simulation_dir",
     null
    ],
@@ -5304,6 +5348,10 @@
     null
    ],
    [
+    "sensitivity_fallback",
+    "warn"
+   ],
+   [
     "simulation_dir",
     null
    ],
@@ -5583,6 +5631,10 @@
    [
     "scheduler_node",
     null
+   ],
+   [
+    "sensitivity_fallback",
+    "warn"
    ],
    [
     "simulation_dir",
@@ -5914,6 +5966,10 @@
    [
     "scheduler_node",
     null
+   ],
+   [
+    "sensitivity_fallback",
+    "warn"
    ],
    [
     "simulation_dir",
@@ -6256,6 +6312,10 @@
    [
     "scheduler_node",
     null
+   ],
+   [
+    "sensitivity_fallback",
+    "warn"
    ],
    [
     "simulation_dir",
@@ -6605,6 +6665,10 @@
    [
     "scheduler_node",
     null
+   ],
+   [
+    "sensitivity_fallback",
+    "warn"
    ],
    [
     "simulation_dir",
@@ -6958,6 +7022,10 @@
    [
     "scheduler_node",
     null
+   ],
+   [
+    "sensitivity_fallback",
+    "warn"
    ],
    [
     "simplex_contraction",
@@ -7365,6 +7433,10 @@
     null
    ],
    [
+    "sensitivity_fallback",
+    "warn"
+   ],
+   [
     "simulation_dir",
     null
    ],
@@ -7728,6 +7800,10 @@
    [
     "scheduler_node",
     null
+   ],
+   [
+    "sensitivity_fallback",
+    "warn"
    ],
    [
     "simulation_dir",
@@ -8122,6 +8198,10 @@
     null
    ],
    [
+    "sensitivity_fallback",
+    "warn"
+   ],
+   [
     "simulation_dir",
     null
    ],
@@ -8473,6 +8553,10 @@
    [
     "scheduler_node",
     null
+   ],
+   [
+    "sensitivity_fallback",
+    "warn"
    ],
    [
     "simulation_dir",
@@ -8828,6 +8912,10 @@
     null
    ],
    [
+    "sensitivity_fallback",
+    "warn"
+   ],
+   [
     "simulation_dir",
     null
    ],
@@ -9179,6 +9267,10 @@
    [
     "scheduler_node",
     null
+   ],
+   [
+    "sensitivity_fallback",
+    "warn"
    ],
    [
     "simulation_dir",
@@ -9534,6 +9626,10 @@
     null
    ],
    [
+    "sensitivity_fallback",
+    "warn"
+   ],
+   [
     "simulation_dir",
     null
    ],
@@ -9871,6 +9967,10 @@
     null
    ],
    [
+    "sensitivity_fallback",
+    "warn"
+   ],
+   [
     "simulation_dir",
     null
    ],
@@ -10199,6 +10299,10 @@
    [
     "scheduler_node",
     null
+   ],
+   [
+    "sensitivity_fallback",
+    "warn"
    ],
    [
     "simulation_dir",
@@ -10547,6 +10651,10 @@
    [
     "scheduler_node",
     null
+   ],
+   [
+    "sensitivity_fallback",
+    "warn"
    ],
    [
     "simulation_dir",
@@ -10943,6 +11051,10 @@
     null
    ],
    [
+    "sensitivity_fallback",
+    "warn"
+   ],
+   [
     "simulation_dir",
     null
    ],
@@ -11327,6 +11439,10 @@
     null
    ],
    [
+    "sensitivity_fallback",
+    "warn"
+   ],
+   [
     "simulation_dir",
     null
    ],
@@ -11662,6 +11778,10 @@
     null
    ],
    [
+    "sensitivity_fallback",
+    "warn"
+   ],
+   [
     "simulation_dir",
     null
    ],
@@ -11985,6 +12105,10 @@
    [
     "scheduler_node",
     null
+   ],
+   [
+    "sensitivity_fallback",
+    "warn"
    ],
    [
     "simplex_contraction",
@@ -12327,6 +12451,10 @@
    [
     "scheduler_node",
     null
+   ],
+   [
+    "sensitivity_fallback",
+    "warn"
    ],
    [
     "simplex_contraction",
@@ -12676,6 +12804,10 @@
    [
     "scheduler_node",
     null
+   ],
+   [
+    "sensitivity_fallback",
+    "warn"
    ],
    [
     "simulation_dir",

--- a/tests/test_benchmark_harness.py
+++ b/tests/test_benchmark_harness.py
@@ -90,6 +90,11 @@ _EXCLUDE = frozenset({
     # each .target names direct_pass or ave_norm_sos, and no information criterion is defined
     # for an objective that is not a proper likelihood, so nothing is computed or written.
     'backup_information_criteria',
+    # Post-freeze gradient key (#606): what to do when bngsim declines a model's analytic
+    # sensitivity RHS. Read only by the gradient optimizers' _setup_gradient_path, and every
+    # benchmark here is a sampler/metaheuristic that never activates the gradient path, so
+    # its value is inert for this oracle.
+    'sensitivity_fallback',
 })
 
 

--- a/tests/test_gradient_sens_fallback.py
+++ b/tests/test_gradient_sens_fallback.py
@@ -1,0 +1,639 @@
+"""bngsim's analytic ``∂f/∂p`` decline, surfaced as something a fit's user sees (#606).
+
+``CVodeSensInit1`` takes ONE sensitivity-RHS callback for every column, so a single
+rate law bngsim cannot differentiate declines the analytic ``∂f/∂p`` for the *whole*
+model and CVODES' internal difference quotient carries every column instead. That
+substitution preserves correctness and multiplies cost -- one extra RHS evaluation per
+column per step -- and on a fit measured in hours the cost is what ends runs: on
+``Smith_BMCSystBiol2013`` all 25 columns fell back, every start timed out to ``inf``,
+and thirteen hours produced nothing (#558). PyBNF said nothing at all; the only signal
+was a bngsim log line on a worker.
+
+These tests pin the two halves of ADR-0121's answer:
+
+* **the verdict comes off the codegen artifact**, not off the log line. The log line is
+  emitted while *generating* codegen source, which a warm structural cache skips
+  entirely (lanl/bngsim#174), so it is present on the first build of a model and absent
+  on every later one -- while the model is on the fallback all the same.
+  ``test_a_declined_model_is_reported_identically_cold_and_warm`` is that measurement,
+  against the real backend: same model, two probes, one verdict, reason only the first
+  time.
+* **the reason is prose only.** It is captured and reported when heard, and nothing --
+  no policy, no refusal -- may key off its absence.
+"""
+
+import logging
+import types
+
+import pytest
+
+from pybnf import _bngsim_caps
+from pybnf.algorithms.optimizers.gradient_base import GradientOptimizer
+from pybnf.printing import PybnfError
+
+
+# --- route ladder: what answers "is this run on the analytic path?" ----------- #
+
+class _FakeSim:
+    """The Simulator surface :func:`analytic_sens_rhs_probe` reads, and nothing else."""
+
+    def __init__(self, *, source='', so_path='', owned=None, published=None):
+        self._codegen_c_source = source
+        self._codegen_so_path = so_path
+        if owned is not None:
+            self._codegen_provides_sens_rhs = lambda: owned
+        if published is not None:
+            self.has_analytic_sens_rhs = published
+
+
+def test_a_published_per_run_attribute_outranks_every_other_route():
+    """Route 1 -- the key bngsim does not publish yet, honoured in BOTH directions.
+
+    It fires on no build that exists, which is the point: naming it costs nothing and
+    means PyBNF reads the real answer on the first build that grows one, without
+    another PyBNF release. Same shape as ADR-0119's route 1."""
+    sim = _FakeSim(published=False, owned=True,
+                   source='bngsim_codegen_sens_rhs(void) {}')
+    state, route = _bngsim_caps.analytic_sens_rhs_probe(sim)
+    assert state is False
+    assert 'has_analytic_sens_rhs' in route
+
+
+def test_bngsims_own_method_outranks_reading_the_artifact_directly():
+    """Route 2 -- upstream's answer to upstream's question, wherever it exists.
+
+    Route 3 replicates it for the sub-0.14.0 builds PyBNF's floor still admits; a build
+    carrying the method keeps answering correctly even if the symbol ever moves."""
+    sim = _FakeSim(owned=True, source='no symbol here')
+    state, route = _bngsim_caps.analytic_sens_rhs_probe(sim)
+    assert state is True
+    assert '_codegen_provides_sens_rhs' in route
+
+
+def test_a_method_that_raises_falls_through_to_the_artifact():
+    sim = _FakeSim(source='bngsim_codegen_sens_rhs(void) {}')
+    sim._codegen_provides_sens_rhs = lambda: 1 / 0
+    state, route = _bngsim_caps.analytic_sens_rhs_probe(sim)
+    assert state is True
+    assert 'C source' in route
+
+
+@pytest.mark.parametrize('source,expected', [
+    ('static void bngsim_codegen_sens_rhs(void) {}', True),
+    ('static void bngsim_codegen_rhs(void) {}', False),
+])
+def test_a_jit_run_is_read_off_its_generated_source(source, expected):
+    """Route 3a. The JIT backends compile no ``.so`` and keep the source on the
+    Simulator; the source names the symbol only where it also defines the function,
+    which is what makes the substring test equal to the ``.so`` symbol test."""
+    state, route = _bngsim_caps.analytic_sens_rhs_probe(_FakeSim(source=source))
+    assert state is expected
+    assert 'C source' in route
+
+
+def test_an_artifact_that_cannot_be_opened_reports_no_opinion():
+    state, route = _bngsim_caps.analytic_sens_rhs_probe(
+        _FakeSim(so_path='/nonexistent/rhs_deadbeef.so'))
+    assert state is None
+    assert 'could not be opened' in route
+
+
+def test_a_run_with_no_codegen_artifact_reports_no_opinion():
+    """``codegen=False`` integrates the interpreted RHS: there is nothing to read, and
+    guessing in either direction is wrong. A false *present* hides the cost this whole
+    probe exists to surface; a false *absent* warns about a fit that is fine."""
+    state, route = _bngsim_caps.analytic_sens_rhs_probe(_FakeSim())
+    assert state is None
+    assert 'no codegen artifact' in route
+
+
+def test_no_simulator_at_all_reports_no_opinion():
+    assert _bngsim_caps.analytic_sens_rhs_probe(None)[0] is None
+
+
+# --- the reason channel: prose only, and best-effort by construction ---------- #
+
+_PLAIN_DECLINE = (
+    "Forward sensitivity: the Functional rate law for reaction 7 "
+    "('per_species_volume_scaling') could not be differentiated, so the analytic "
+    "sensitivity RHS is declined for this model and CVODES' internal difference "
+    "quotient is used instead (correct, but slower)."
+)
+_CROSSING_DECLINE = (
+    "Forward sensitivity: reaction 1 branches on 'Virus<1'. The analytic sensitivity "
+    "RHS is declined for this model, and CVODES' internal difference quotient -- which "
+    "is used instead -- does NOT recover the missing term: it integrates the "
+    "variational equation smoothly through a crossing whose time moves."
+)
+
+
+def _emit(*messages, level=logging.WARNING):
+    for message in messages:
+        logging.getLogger('bngsim').log(level, '%s', message)
+
+
+def test_a_decline_is_captured_with_its_reason_trimmed_out():
+    with _bngsim_caps.capture_sens_rhs_declines() as reasons:
+        _emit(_PLAIN_DECLINE)
+    assert len(reasons) == 1
+    reason, fallback_is_wrong = reasons[0]
+    assert reason.startswith('the Functional rate law for reaction 7')
+    assert 'declined' not in reason          # the clause is the frame, not the reason
+    assert fallback_is_wrong is False
+
+
+def test_the_variant_whose_fallback_is_wrong_is_flagged_as_such():
+    """bngsim >= 0.14.0 raises here rather than warning (lanl/bngsim#414/#416), so this
+    is reachable only on a sub-0.14.0 build -- which PyBNF's floor still admits, and
+    where the returned gradient is wrong rather than merely slow."""
+    with _bngsim_caps.capture_sens_rhs_declines() as reasons:
+        _emit(_CROSSING_DECLINE)
+    assert reasons[0][1] is True
+
+
+def test_unrelated_bngsim_chatter_is_not_mistaken_for_a_decline():
+    with _bngsim_caps.capture_sens_rhs_declines() as reasons:
+        _emit('Compiling codegen RHS (-O2): cc ...',
+              'wall_time_sim=30 exceeded at 30.001s')
+    assert reasons == []
+
+
+def test_the_same_decline_reported_twice_is_recorded_once():
+    with _bngsim_caps.capture_sens_rhs_declines() as reasons:
+        _emit(_PLAIN_DECLINE, _PLAIN_DECLINE)
+    assert len(reasons) == 1
+
+
+def test_an_unrecognised_decline_is_kept_whole_rather_than_dropped():
+    """The wording is not PyBNF's to depend on: a decline it cannot parse is still a
+    decline, and reporting it verbatim beats reporting nothing."""
+    with _bngsim_caps.capture_sens_rhs_declines() as reasons:
+        _emit('the analytic sensitivity RHS is declined because reasons')
+    assert reasons[0][0] == 'the analytic sensitivity RHS is declined because reasons'
+
+
+def test_the_capture_leaves_the_bngsim_logger_as_it_found_it():
+    """PyBNF's own root handlers must keep receiving the decline exactly as today --
+    the line still lands in ``<prefix>.log``; this only adds a listener, briefly."""
+    bngsim_logger = logging.getLogger('bngsim')
+    before = list(bngsim_logger.handlers)
+    with _bngsim_caps.capture_sens_rhs_declines():
+        assert len(bngsim_logger.handlers) == len(before) + 1
+    assert bngsim_logger.handlers == before
+
+
+def test_a_capture_that_hears_nothing_is_not_a_claim_that_nothing_declined():
+    """The whole reason the verdict may not come from this channel. An empty capture is
+    indistinguishable between "analytic" and "served from a warm codegen cache", so
+    :attr:`SensRhsStatus.declined` reads the verdict and never the reasons."""
+    status = _bngsim_caps.SensRhsStatus(False, 'artifact', [], 25)
+    assert status.declined is True
+    assert status.fallback_is_wrong is False
+
+
+# --- probe_sens_rhs: never raises, never takes a fit down --------------------- #
+
+def test_a_model_that_cannot_be_prepared_reports_no_opinion():
+    """A diagnostic that can end a fit is worse than no diagnostic."""
+    def boom():
+        raise RuntimeError('no engine model here')
+
+    status = _bngsim_caps.probe_sens_rhs(boom, columns=4)
+    assert status.analytic is None
+    assert status.columns == 4
+    assert 'could not be prepared' in status.route
+
+
+def test_the_probe_reports_the_verdict_and_whatever_bngsim_said_building_it():
+    def build():
+        _emit(_PLAIN_DECLINE)
+        return _FakeSim(source='rhs only')
+
+    status = _bngsim_caps.probe_sens_rhs(build, columns=25)
+    assert status.declined
+    assert status.columns == 25
+    assert status.reasons[0][0].startswith('the Functional rate law')
+
+
+# --- what the fit does with the verdict --------------------------------------- #
+
+def _model(name, status):
+    return types.SimpleNamespace(name=name, analytic_sens_rhs_status=lambda: status)
+
+
+def _report(models, policy='warn', n_variables=3):
+    """Drive the real reporting code over a stand-in carrying only what it reads.
+
+    ``_report_sensitivity_rhs`` touches ``model_list``, ``variables``, the config and
+    ``_fit_type_label`` -- so binding the two real methods onto a namespace exercises
+    them exactly, with none of the model building an ``Algorithm`` construction needs.
+    """
+    opt = types.SimpleNamespace(
+        model_list=models,
+        variables=[types.SimpleNamespace(name='p%d' % i) for i in range(n_variables)],
+        config=types.SimpleNamespace(config={'sensitivity_fallback': policy}),
+        _fit_type_label=lambda: 'trf',
+    )
+    opt._warn_sensitivity_fallback = types.MethodType(
+        GradientOptimizer._warn_sensitivity_fallback, opt)
+    return GradientOptimizer._report_sensitivity_rhs(opt)
+
+
+def test_a_declined_model_is_named_on_the_console_with_its_cost(capsys):
+    """Console, not log-only. The decline already reaches ``<prefix>.log`` today --
+    bngsim's logger propagates to root -- and that is the channel that failed: a shared,
+    noisy file written from N worker processes, one line per model, mid-run."""
+    status = _bngsim_caps.SensRhsStatus(
+        False, 'the compiled codegen artifact this run installs',
+        [('reaction 7 could not be differentiated', False)], 25)
+    _report([_model('Smith', status)])
+    out = capsys.readouterr().out
+    assert "model 'Smith'" in out
+    assert '25 sensitivity columns' in out
+    assert '25x' in out
+    assert 'reaction 7 could not be differentiated' in out
+    assert 'gradient stays correct' in out
+    assert 'the compiled codegen artifact' in out    # how it decided
+
+
+def test_the_fallback_warning_survives_verbosity_zero(capsys, monkeypatch):
+    """A reader who turned the verbosity down is still a reader who would rather not
+    spend the next thirteen hours -- the call ``_report_bngsim_build`` already makes for
+    a stale compiled core. Only the how-it-decided line is verbosity-gated."""
+    from pybnf import printing
+
+    monkeypatch.setattr(printing, 'verbosity', 0)
+    _report([_model('Smith', _bngsim_caps.SensRhsStatus(False, 'artifact', [], 25))])
+    out = capsys.readouterr().out
+    assert 'difference quotient' in out
+    assert 'Read from' not in out
+
+
+def test_a_decline_with_no_reason_says_why_there_is_no_reason(capsys):
+    """The warm-cache case. Reporting the verdict with a shrug would read as a PyBNF
+    defect; naming the cache tells the reader the verdict is still sound."""
+    status = _bngsim_caps.SensRhsStatus(False, 'the compiled codegen artifact', [], 25)
+    _report([_model('Smith', status)])
+    out = capsys.readouterr().out
+    assert 'warm codegen cache' in out
+
+
+def test_the_wrong_gradient_variant_says_the_columns_are_wrong_not_merely_slow(capsys):
+    status = _bngsim_caps.SensRhsStatus(
+        False, 'artifact', [('it branches on Virus<1', True)], 4)
+    _report([_model('Virus', status)])
+    out = capsys.readouterr().out
+    assert 'wrong at and after that crossing' in out
+    assert '0.14.0' in out
+
+
+def test_a_model_on_the_analytic_path_says_nothing_to_the_console(capsys):
+    _report([_model('fine', _bngsim_caps.SensRhsStatus(True, 'artifact', [], 4))])
+    assert capsys.readouterr().out == ''
+
+
+def test_a_model_with_no_opinion_says_nothing_to_the_console(capsys):
+    """No artifact to read is not evidence in either direction, so it is logged and
+    never warned about."""
+    _report([_model('quiet', _bngsim_caps.SensRhsStatus(None, 'no artifact', [], 4))])
+    assert capsys.readouterr().out == ''
+
+
+def test_a_backend_with_no_opinion_to_give_is_skipped(capsys):
+    """A test double or a backend without the hook. The sensitivity-backend gate has
+    already refused anything that cannot supply a gradient at all."""
+    _report([types.SimpleNamespace(name='stub')])
+    assert capsys.readouterr().out == ''
+
+
+def test_error_refuses_the_fit_and_names_every_declined_model():
+    declined = _bngsim_caps.SensRhsStatus(False, 'artifact', [], 25)
+    with pytest.raises(PybnfError) as exc:
+        _report([_model('a', declined),
+                 _model('b', _bngsim_caps.SensRhsStatus(True, 'artifact', [], 25)),
+                 _model('c', declined)], policy='error')
+    assert "model 'a'" in exc.value.message and "model 'c'" in exc.value.message
+    assert "model 'b'" not in exc.value.message
+    assert 'sensitivity_fallback' in exc.value.message
+
+
+def test_error_keys_off_the_verdict_so_a_reasonless_decline_still_refuses():
+    """The reason is absent on a warm codegen cache, and a policy that keyed off it
+    would refuse a fit on its first run and accept the same fit on its second."""
+    with pytest.raises(PybnfError):
+        _report([_model('a', _bngsim_caps.SensRhsStatus(False, 'artifact', [], 25))],
+                policy='error')
+
+
+def test_error_does_not_refuse_a_model_that_reported_no_opinion():
+    """The knob refuses a KNOWN fallback; it cannot promise to detect one it could not
+    read, and refusing an unreadable build would take down e.g. a ``codegen=False`` run
+    that is perfectly fine."""
+    _report([_model('a', _bngsim_caps.SensRhsStatus(None, 'no artifact', [], 25))],
+            policy='error')
+
+
+def test_ignore_skips_the_check_entirely(capsys):
+    """Including the one Simulator construction per model it costs -- which is the
+    reason to have an ``ignore`` at all."""
+    def explode():
+        raise AssertionError('the probe must not run under ignore')
+
+    _report([types.SimpleNamespace(name='m', analytic_sens_rhs_status=explode)],
+            policy='ignore')
+    assert capsys.readouterr().out == ''
+
+
+def test_the_warning_is_spoken_once_per_run_not_once_per_bootstrap_refit(capsys):
+    """``reset()`` drops the routings so a bootstrap refit rebuilds them, but a model's
+    differentiability is not a function of the resampled data -- so ``bootstrap = 100``
+    must not print the same warning a hundred times."""
+    models = [_model('m', _bngsim_caps.SensRhsStatus(False, 'artifact', [], 25))]
+    opt = types.SimpleNamespace(
+        model_list=models,
+        variables=[types.SimpleNamespace(name='p0')],
+        config=types.SimpleNamespace(config={'sensitivity_fallback': 'warn'}),
+        _fit_type_label=lambda: 'trf',
+        _sens_rhs_reported=False,
+    )
+    opt._warn_sensitivity_fallback = types.MethodType(
+        GradientOptimizer._warn_sensitivity_fallback, opt)
+    GradientOptimizer._report_sensitivity_rhs(opt)
+    assert 'difference quotient' in capsys.readouterr().out
+    GradientOptimizer._report_sensitivity_rhs(opt)
+    assert capsys.readouterr().out == ''
+
+
+def test_a_declined_model_with_no_column_count_falls_back_to_the_fit_width(capsys):
+    """A backend that cannot say how wide its request is still gets a cost sentence;
+    the fit's own free-parameter count is the right order of magnitude."""
+    _report([_model('m', _bngsim_caps.SensRhsStatus(False, 'artifact', [], 0))],
+            n_variables=7)
+    assert '7 sensitivity columns' in capsys.readouterr().out
+
+
+# --- the real backend: the measurement ADR-0121 is built on ------------------- #
+
+_SBML = """<?xml version="1.0" encoding="UTF-8"?>
+<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" level="3" version="1">
+  <model id="sens_rhs_fixture">
+    <listOfCompartments><compartment id="c" size="1" constant="true"/></listOfCompartments>
+    <listOfSpecies>
+      <species id="S" compartment="c" initialConcentration="100" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false"/>
+    </listOfSpecies>
+    <listOfParameters>
+      <parameter id="k" value="0.3" constant="true"/>
+      <parameter id="Km" value="10" constant="true"/>
+    </listOfParameters>
+    <listOfReactions>
+      <reaction id="deg" reversible="false" fast="false">
+        <listOfReactants><speciesReference species="S" stoichiometry="1" constant="true"/></listOfReactants>
+        <kineticLaw><math xmlns="http://www.w3.org/1998/Math/MathML">%s</math></kineticLaw>
+      </reaction>
+    </listOfReactions>
+  </model>
+</sbml>"""
+
+# ``k*S`` -- Elementary, differentiated in closed form.
+_ANALYTIC_LAW = '<apply><times/><ci>k</ci><ci>S</ci></apply>'
+# ``k*S*|S-Km|`` -- Functional, and ``abs()`` is on bngsim's underivable list, so the
+# whole model declines. Smooth away from S=Km and cheap to build, which is all this
+# fixture needs: nothing here integrates it.
+_DECLINED_LAW = ('<apply><times/><ci>k</ci><ci>S</ci>'
+                 '<apply><abs/><apply><minus/><ci>S</ci><ci>Km</ci></apply></apply>'
+                 '</apply>')
+
+
+@pytest.fixture
+def cold_codegen_cache(tmp_path, monkeypatch):
+    """Make this test's first codegen genuinely the first one.
+
+    A test that means to observe the COLD half has to defeat both of the caches that
+    otherwise serve an artifact somebody else built: bngsim's on-disk codegen cache
+    (moved to an empty directory -- bngsim documents patching the module attribute as
+    the supported way), and PyBNF's own process-wide engine-template cache, whose
+    templates carry the ``_codegen_so_path`` a previous test compiled. Without both,
+    the test silently stops testing what it says it tests.
+    """
+    from pybnf import bngsim_sbml_model
+
+    bngsim_codegen = pytest.importorskip('bngsim._codegen')
+    cache = tmp_path / 'codegen_cache'
+    cache.mkdir()
+    monkeypatch.setattr(bngsim_codegen, 'CACHE_DIR', cache)
+    bngsim_sbml_model._ENGINE_TEMPLATE_CACHE.clear()
+    bngsim_sbml_model._ENGINE_TEMPLATE_WARM_ATTEMPTED.clear()
+    yield cache
+    bngsim_sbml_model._ENGINE_TEMPLATE_CACHE.clear()
+    bngsim_sbml_model._ENGINE_TEMPLATE_WARM_ATTEMPTED.clear()
+
+
+def _sbml_model(tmp_path, law, name):
+    from pybnf.bngsim_sbml_model import BngsimSbmlModelNoTimeout
+    from pybnf.pset import FreeParameter, PSet, TimeCourse
+
+    path = tmp_path / ('%s.xml' % name)
+    path.write_text(_SBML % law)
+    pset = PSet([FreeParameter('k', 'uniform_var', 0.0, 1e6, value=0.3),
+                 FreeParameter('S', 'uniform_var', 0.0, 1e6, value=100.0)])
+    model = BngsimSbmlModelNoTimeout(
+        str(path), str(path), pset=pset,
+        actions=(TimeCourse({'time': '10', 'step': '1'}),))
+    model.enable_output_sensitivities(params=['k'], ic=['S'])
+    return model
+
+
+@pytest.mark.bngsim_sbml
+@pytest.mark.skipif(not _bngsim_caps.BNGSIM_HAS_OUTPUT_SENS,
+                    reason='needs a bngsim build with the output_sensitivities feature')
+def test_the_scalar_path_has_no_sensitivity_rhs_to_be_on_either_side_of(tmp_path):
+    model = _sbml_model(tmp_path, _ANALYTIC_LAW, 'scalar')
+    model._sensitivity_request = None
+    status = model.analytic_sens_rhs_status()
+    assert status.analytic is None
+    assert status.columns == 0
+
+
+@pytest.mark.bngsim_sbml
+@pytest.mark.skipif(not _bngsim_caps.BNGSIM_HAS_OUTPUT_SENS,
+                    reason='needs a bngsim build with the output_sensitivities feature')
+def test_a_differentiable_model_reports_the_analytic_path(tmp_path, cold_codegen_cache):
+    status = _sbml_model(tmp_path, _ANALYTIC_LAW, 'analytic').analytic_sens_rhs_status()
+    assert status.analytic is True
+    assert status.columns == 2               # one parameter axis + one IC axis
+    assert status.reasons == []
+
+
+@pytest.mark.bngsim_sbml
+@pytest.mark.skipif(not _bngsim_caps.BNGSIM_HAS_OUTPUT_SENS,
+                    reason='needs a bngsim build with the output_sensitivities feature')
+def test_a_declined_model_is_reported_identically_cold_and_warm(tmp_path,
+                                                                cold_codegen_cache):
+    """ADR-0121's measurement, and the reason the verdict is not the log line.
+
+    Two probes of the same model. The first generates codegen source and hears bngsim
+    decline; the second resolves the artifact straight out of the (now warm) cache,
+    generates nothing, and hears nothing at all -- while running on exactly the same
+    difference-quotient fallback. A design that took its verdict from the log line
+    would report this model as fine on the second run of the fit, which is the run a
+    user makes after the first came back empty.
+    """
+    cold = _sbml_model(tmp_path, _DECLINED_LAW, 'declined').analytic_sens_rhs_status()
+    assert cold.analytic is False
+    assert cold.columns == 2
+    assert cold.reasons, 'a cold codegen cache must surface bngsim\'s own reason'
+    assert 'abs' in cold.reasons[0][0]
+    assert cold.fallback_is_wrong is False   # smooth: correct, just slower
+
+    from pybnf import bngsim_sbml_model
+    # A genuinely separate run of the same fit: drop the process-wide engine template
+    # so nothing is inherited in memory, and leave ONLY bngsim's on-disk codegen cache
+    # warm. That is the state a user's second `pybnf` invocation is in.
+    bngsim_sbml_model._ENGINE_TEMPLATE_CACHE.clear()
+    bngsim_sbml_model._ENGINE_TEMPLATE_WARM_ATTEMPTED.clear()
+    warm = _sbml_model(tmp_path, _DECLINED_LAW, 'declined2').analytic_sens_rhs_status()
+    assert warm.analytic is False, 'the verdict must not depend on the codegen cache'
+    assert warm.reasons == [], 'a warm cache generates no source, so it says nothing'
+
+
+# --- the config surface ------------------------------------------------------- #
+
+def _load(tmp_path, monkeypatch, extra_lines=()):
+    """A minimal, simulator-free edition-2 config, plus whatever lines are under test."""
+    import json
+
+    from pybnf import config, parse
+
+    (tmp_path / 'gaussian.target').write_text(
+        json.dumps({'type': 'gaussian', 'mean': [0.0], 'variance': [1.0]}))
+    (tmp_path / 'target.exp').write_text('# index\tscore\n0\t0\n')
+    monkeypatch.chdir(tmp_path)
+    conf = ('edition = 2\njob_type = de\nobjective = sos\n'
+            'model = gaussian.target : target.exp\n'
+            'uniform_var = k__FREE 0 10\n'
+            'population_size = 5\nmax_iterations = 5\nwall_time_sim = 0\n'
+            + ''.join(line + '\n' for line in extra_lines))
+    return config.Configuration(parse.ploop(conf.splitlines(keepends=True)))
+
+
+def test_sensitivity_fallback_defaults_to_warn(tmp_path, monkeypatch):
+    """The default must not change any run that works today: it adds a sentence."""
+    assert _load(tmp_path, monkeypatch).config['sensitivity_fallback'] == 'warn'
+
+
+@pytest.mark.parametrize('value', ['warn', 'error', 'ignore'])
+def test_sensitivity_fallback_round_trips_through_the_parser(value, tmp_path,
+                                                             monkeypatch):
+    cfg = _load(tmp_path, monkeypatch, ['sensitivity_fallback = %s' % value])
+    assert cfg.config['sensitivity_fallback'] == value
+
+
+def test_an_unknown_sensitivity_fallback_is_refused_at_config_load(tmp_path,
+                                                                   monkeypatch):
+    with pytest.raises(PybnfError):
+        _load(tmp_path, monkeypatch, ['sensitivity_fallback = maybe'])
+
+
+# --- the wiring: a real gradient fit's setup reports before it spends anything -- #
+
+def _declined_fit_config(tmp_path, **overrides):
+    """A real edition-2 ``trf`` config over the declining SBML fixture.
+
+    The data grid only has to parse -- nothing here simulates the model, and
+    ``_setup_gradient_path`` is reached before the first evaluation, which is the whole
+    point of checking there.
+    """
+    from . import recovery_harness as H
+
+    xml = tmp_path / 'declined.xml'
+    xml.write_text(_SBML % _DECLINED_LAW)
+    exp = tmp_path / 'tc.exp'
+    exp.write_text('# time\tS\tS_SD\n'
+                   + '\n'.join('%d\t%g\t1' % (t, 100.0 - t) for t in range(4)) + '\n')
+    return H.make_newera_config(
+        tmp_path, str(xml), str(exp),
+        {'k': ('uniform_var', 1e-2, 3.0), 'S': ('uniform_var', 10.0, 300.0)},
+        'tc', 'trf', objective='chi_sq', random_seed=1234, population_size=1,
+        max_iterations=1, sbml_backend='bngsim', **overrides)
+
+
+@pytest.mark.bngsim_sbml
+@pytest.mark.skipif(not _bngsim_caps.BNGSIM_HAS_OUTPUT_SENS,
+                    reason='needs a bngsim build with the output_sensitivities feature')
+def test_a_real_gradient_setup_warns_before_the_fit_evaluates_anything(
+        tmp_path, capsys, cold_codegen_cache):
+    """The end the issue is about: a real ``trf`` fit over a model bngsim cannot
+    differentiate says so at setup, on the console, on the head node -- not as a log
+    line on a worker after the first evaluation, and not never."""
+    from . import recovery_harness as H
+
+    alg = H.build(_declined_fit_config(tmp_path), 'trf')
+    capsys.readouterr()                      # discard construction chatter
+    alg._setup_gradient_path()
+
+    out = capsys.readouterr().out
+    assert 'difference quotient' in out
+    assert 'sensitivity columns' in out
+    assert 'abs' in out                      # bngsim's own reason, cold cache
+
+
+@pytest.mark.bngsim_sbml
+@pytest.mark.skipif(not _bngsim_caps.BNGSIM_HAS_OUTPUT_SENS,
+                    reason='needs a bngsim build with the output_sensitivities feature')
+def test_sensitivity_fallback_error_refuses_the_real_fit_at_setup(tmp_path):
+    from . import recovery_harness as H
+
+    alg = H.build(_declined_fit_config(tmp_path, sensitivity_fallback='error'), 'trf')
+    with pytest.raises(PybnfError, match='sensitivity_fallback'):
+        alg._setup_gradient_path()
+
+
+@pytest.mark.bngsim_sbml
+@pytest.mark.skipif(not _bngsim_caps.BNGSIM_HAS_OUTPUT_SENS,
+                    reason='needs a bngsim build with the output_sensitivities feature')
+def test_a_differentiable_real_fit_setup_says_nothing(tmp_path, capsys,
+                                                      cold_codegen_cache):
+    """No new noise for the fits that were already fine -- the default has to be a
+    sentence for the models that need it and silence for everything else."""
+    from . import recovery_harness as H
+
+    xml = tmp_path / 'fine.xml'
+    xml.write_text(_SBML % _ANALYTIC_LAW)
+    exp = tmp_path / 'tc.exp'
+    exp.write_text('# time\tS\tS_SD\n'
+                   + '\n'.join('%d\t%g\t1' % (t, 100.0 - t) for t in range(4)) + '\n')
+    conf = H.make_newera_config(
+        tmp_path, str(xml), str(exp),
+        {'k': ('uniform_var', 1e-2, 3.0), 'S': ('uniform_var', 10.0, 300.0)},
+        'tc', 'trf', objective='chi_sq', random_seed=1234, population_size=1,
+        max_iterations=1, sbml_backend='bngsim')
+    alg = H.build(conf, 'trf')
+    capsys.readouterr()
+    alg._setup_gradient_path()
+    assert 'difference quotient' not in capsys.readouterr().out
+
+
+@pytest.mark.bngsim
+@pytest.mark.skipif(not _bngsim_caps.BNGSIM_HAS_OUTPUT_SENS,
+                    reason='needs a bngsim build with the output_sensitivities feature')
+def test_the_net_backend_answers_through_its_own_simulator_construction():
+    """The BNGL/``.net`` twin of the SBML hook -- a different Simulator construction
+    (``_codegen_kwargs`` plus the request), so it is worth exercising rather than
+    assuming the two share a path. ``e2e_ode_decay.net`` is Elementary throughout, so
+    the answer is the analytic one."""
+    from pathlib import Path
+
+    from pybnf import bngsim_model, pset
+
+    net_path = Path(__file__).resolve().parent / 'bngl_files' / 'e2e_ode_decay.net'
+    model = bngsim_model.BngsimModel(
+        net_path.stem,
+        ['simulate({method=>"ode",t_start=>0,t_end=>10,n_steps=>20,suffix=>"tc"})'],
+        [('simulate', 'tc')], [], nf=str(net_path))
+    model.param_set = pset.PSet([])
+
+    assert model.analytic_sens_rhs_status().analytic is None   # scalar path
+    model.enable_output_sensitivities(params=['k'], ic=[])
+    status = model.analytic_sens_rhs_status()
+    assert status.analytic is True
+    assert status.columns == 1


### PR DESCRIPTION
Closes #606.

`CVodeSensInit1` takes **one** sensitivity-RHS callback for every column, so a single rate law
bngsim cannot differentiate declines the analytic `∂f/∂θ` for the **whole** model, and CVODES'
internal difference quotient carries every column instead. Correct, and N× the cost — which on
a fit measured in hours is not a slower answer but no answer. On `Smith_BMCSystBiol2013` all 25
columns fell back, every start timed out to `inf`, and thirteen hours produced nothing. PyBNF
surfaced none of it.

## The finding that changed the design

The issue's first suggested direction — capture the `bngsim` logger and re-emit the decline —
**does not work, and it fails in the silent direction.**

Since lanl/bngsim#174 the codegen cache key is *structural*, so a warm cache resolves the `.so`
without generating any source — and source generation is where the decline is derived and
logged. Measured on 0.13.0 against an `abs()` rate law:

| construction | verdict | decline logged |
|---|---|---|
| first, cold cache | fallback | yes, with the reason |
| second, warm cache | fallback | **nothing** |

The cache persists on disk, so the construction that hears nothing is typically the **second run
of a fit** — the one made after the first came back empty. PyBNF's own `_ENGINE_TEMPLATE_CACHE`
reproduces the same blindness in-process, with no disk cache involved.

So silence on that logger means "declined, *or* served from cache". It can support a statement
that a model **is** on the fallback, never one that it is not.

## What this does instead

**The verdict comes off the codegen artifact; the log line supplies only the reason.**

The compiled artifact either exports `bngsim_codegen_sens_rhs` or it does not, and that is the
exact symbol bngsim's C++ resolves with `try_symbol` to choose between the two paths. Four
routes, first match wins, each reported so a message can say how it decided — the same ladder as
ADR-0119's `_resolve_event_sens`:

1. `Simulator.has_analytic_sens_rhs` — a public per-run key, if bngsim ever grows one
   (lanl/bngsim#431). Fires on no build today; costs nothing to name.
2. `Simulator._codegen_provides_sens_rhs()` — bngsim's own ground truth; private, ≥ 0.14.0.
3. the symbol in the JIT source or the `.so`. Load-bearing: the floor admits 0.13.0.
4. no artifact — **no opinion**, reported as one.

|  | channel | reliability | may be acted on |
|---|---|---|---|
| **verdict** | the artifact | exact, cache-hit or not | yes — policy keys off it |
| **reason** | bngsim's decline line | cold cache only | prose only |

**Where it runs.** The issue expected this to need worker→head plumbing, since codegen happens
on a worker at the first sensitivity-bearing `simulate()`. It does not: reading the artifact
needs a Simulator, and `_setup_gradient_path()` can build one. So the check runs on the **head
node, before the fit evaluates anything** — which is the whole complaint the log line could not
answer — with no cross-process de-duplication and no decision about whether a decline rides back
on a `Result`. The cost is one codegen per model at job start; the cache is content-addressed
and shared, so on a local run the compile is *moved* rather than added.

## New config key

`sensitivity_fallback = warn | error | ignore` (default `warn`, so no run that works today
changes except by gaining a sentence). `error` refuses, for a long unattended run; `ignore`
skips the check including the Simulator construction it costs.

The policy keys off the **verdict**, never the reason — a policy keyed off the reason would
refuse a fit on its first run and accept the same fit on its second. `error` also does not
refuse a model that reported *no opinion*: the knob refuses a *known* fallback and cannot
promise to detect one it could not read.

## The half where "correct, but slower" is false

A declined model that also branches at a crossing whose time moves gets a difference quotient
that integrates straight through it, dropping the saltation jump, so every column is wrong at
and after the crossing. bngsim ≥ 0.14.0 refuses such a run rather than return a gradient it has
flagged as wrong (lanl/bngsim#414/#416) — and it decides that from `_codegen_provides_sens_rhs()`
plus its own re-scan rather than from the codegen warning, which is this PR's argument arrived at
independently. On 0.13.0, which the floor still admits, the same model only warns and returns the
wrong gradient; PyBNF now says so at verbosity 0 whenever bngsim's reason reaches it. Deliberately
*not* a PyBNF refusal: riding the reason channel it could only fire on a fit's first run, and a
non-reproducible refusal is worse than a consistent warning.

## Deliberately not done

* **The probe describes each model at the fit's start point.** One step of bngsim's codegen reads
  parameter values, so a model branching on a fitted threshold could in principle change its
  answer mid-search. Probing every evaluation is not a trade worth making; the caveat is
  documented.
* **No `Results/` artifact.** Console plus log is the channel `_report_bngsim_build()` already
  established for a job-start warning of this kind (#605).

## Verification

* `tests/test_gradient_sens_fallback.py` — 42 tests: the route ladder in both directions, the
  reason parser (including the wrong-gradient variant and an unparseable decline kept whole),
  `probe_sens_rhs` never raising, all three policies, once-per-run reporting, the config surface,
  and two real-backend tests. `test_a_declined_model_is_reported_identically_cold_and_warm` is the
  measurement above, pinned: same model, two probes, one verdict, reason only the first time.
* Full suite **4374 passed, 23 skipped**. The 3 `test_job_class.py` failures are pre-existing on
  a clean tree here (a local BNG2.pl `run_network` that does not run on this machine).
* ruff 0.15.14 and the `-W --keep-going` Sphinx build both pass. Both frozen config snapshots
  regenerated/excluded per their own rules; the golden diff is purely additive.
* No measurable cost to existing gradient tests (5.0s vs 5.3s baseline over
  `test_gradient_sbml.py` + `test_shooting_sbml.py`) — the probe hits the warm cache.

ADR-0121 records the decision.
