### PR TITLE
docs(gradient): the analytic-sensitivity-RHS measurement is restated on the bngsim CI resolves, and reproduced on the one below it (#606, ADR-0121)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,9 +189,9 @@ All notable changes to PyBNF are documented below. This project adheres to
   artifact — whether it exports the analytic sensitivity RHS symbol, the exact symbol bngsim's
   C++ resolves to choose between the two paths. That matters because bngsim reports a decline
   while *generating* codegen source, and since lanl/bngsim#174 a warm structural cache skips
-  source generation entirely: measured on 0.13.0, the same declining model reports its decline on
-  the first construction and says nothing on the second, while running on the same fallback both
-  times. Since the cache persists on disk, the run that hears nothing is typically the second run
+  source generation entirely: measured on 0.14.0 and 0.13.0 alike, the same declining model
+  reports its decline on the first construction and says nothing on the second, while running on
+  the same fallback both times. Since the cache persists on disk, the run that hears nothing is typically the second run
   of a fit — the one made after the first came back empty. bngsim's reason is still captured and
   reported when it is heard, but only ever as prose; nothing keys off its absence.
   The new `sensitivity_fallback` key chooses what happens next: `warn` (the default — today's

--- a/docs/adr/0121-a-models-analytic-sensitivity-rhs-is-read-off-the-codegen-artifact-rather-than-heard-on-a-log-line-because-a-warm-codegen-cache-says-nothing-about-a-model-that-is-still-on-the-fallback.md
+++ b/docs/adr/0121-a-models-analytic-sensitivity-rhs-is-read-off-the-codegen-artifact-rather-than-heard-on-a-log-line-because-a-warm-codegen-cache-says-nothing-about-a-model-that-is-still-on-the-fallback.md
@@ -40,12 +40,17 @@ works across the whole supported range, which is exactly what recommends it.
 **It does not work, and it fails in the silent direction.** Since lanl/bngsim#174 the codegen
 cache key is *structural*, so a warm cache resolves the `.so` from a handful of C++ reads and
 **generates no source at all** — and source generation is where the decline is derived and
-logged. Measured on bngsim 0.13.0 with an `abs()` rate law, in one process:
+logged. Measured with an `abs()` rate law, in one process, on **bngsim 0.14.0** — the current
+release, and the one CI resolves — and reproduced identically on 0.13.0:
 
 | construction | verdict (artifact) | decline logged |
 |---|---|---|
 | first, cold cache | fallback | yes, with the reason |
 | second, warm cache | fallback | **nothing** |
+
+That the two builds agree is worth more than either measurement alone, because they do not
+agree by taking the same path: 0.14.0 answers through route 2 below and 0.13.0 through route 3,
+so one measurement exercises both rungs of the ladder and shows they return the same verdict.
 
 The cache lives on disk and persists across runs, so the construction that hears nothing is
 typically the *second run of the same fit* — the run a user makes after the first came back

--- a/pybnf/_bngsim_caps.py
+++ b/pybnf/_bngsim_caps.py
@@ -485,9 +485,9 @@ def bngsim_stale_core_report():
 # its own, because the codegen cache short-circuits the step that emits it: since
 # lanl/bngsim#174 the cache key is STRUCTURAL, so a warm cache resolves the ``.so``
 # without generating any source, and source generation is where the decline is
-# derived and logged. Measured on 0.13.0 against an ``abs()`` rate law: first
-# construction reports the decline, a second construction of the same model in the
-# same process reports nothing and is on the same fallback. The cache is on disk
+# derived and logged. Measured against an ``abs()`` rate law on 0.14.0 and 0.13.0
+# alike: first construction reports the decline, a second construction of the same
+# model in the same process reports nothing and is on the same fallback. The cache is on disk
 # and persists across runs, so the run that hears nothing is typically the SECOND
 # run of a fit -- exactly the one made after the first came back empty.
 #


### PR DESCRIPTION
Follow-up to #610 (ADR-0121). **Citations only — no behaviour, test, or interface change.**

## The defect

ADR-0121's central measurement is cited as taken on bngsim **0.13.0**. That is what this
machine's `uv.lock` had resolved. It is not what anything else runs:

- `uv.lock` is **gitignored** (`.gitignore:57`), so it drifts locally and binds nobody;
- CI installs `bngsim[antimony]>=0.11.35,<1` fresh from PyPI, which resolves **0.14.0**.

So the evidence behind a merged ADR came from a build neither CI nor a user has.

## The finding is unchanged, and now rests on both builds

Re-measured on 0.14.0 — same `abs()` rate law, same process:

| construction | verdict (artifact) | decline logged |
|---|---|---|
| first, cold cache | fallback | yes, with the reason |
| second, warm cache | fallback | **nothing** |

Identical to 0.13.0.

The agreement is worth more than either measurement alone, because the two builds don't reach
it the same way. 0.14.0 carries `Simulator._codegen_provides_sens_rhs()`, so the probe answers
on **route 2**; 0.13.0 doesn't, so it answers on **route 3** by reading the artifact directly.
One measurement exercises both rungs and shows they agree — which is the property route 3
exists to have, and which #610 never actually demonstrated.

## Also confirmed on 0.14.0 — none of it needing a change

- Full suite **4374 passed, 23 skipped**, identical to 0.13.0. (The three `test_job_class.py`
  failures are this machine's BNG2.pl and predate all of this — verified on a clean tree.)
- Every decline cause `docs/gradient_fitting.rst` names still declines — `abs()`, `floor()`,
  `ceil()`, `tgamma()` — and an Elementary rate law still gets the analytic RHS.
- bngsim's decline wording still parses through `_SENS_RHS_DECLINE_RE` (the real-backend test
  asserts it by matching the reason text).
- 0.14.0 publishes no `has_analytic_sens_rhs` and no `capabilities()["build"]`, so route 1 still
  fires on no build and lanl/bngsim#438 stays correctly scoped. lanl/bngsim#431's keys are on
  `main`, unreleased; its `event_sensitivities` probe reads a compiled-core binding, so it
  reports `True` on any current build — ADR-0119's route 1 gains an answer, not a refusal.

## Gates

ruff 0.15.14, the `-W --keep-going` Sphinx build, and `tests/test_gradient_sens_fallback.py`
(42 passed) all green against 0.14.0.
