### PR TITLE
fix(shooting): a segment that stopped short of its end knot is a failed segment rather than a state read at the wrong time, and the offline backend can fail on purpose (#584)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,6 +169,44 @@ All notable changes to PyBNF are documented below. This project adheres to
   says what it has not bisected.
 
 ### Fixed
+- **A multiple-shooting segment that comes back short of its end knot is refused instead of
+  being read at the wrong time (#584).** `job_type = ms` builds every continuity row from the
+  **last row** of a segment's trajectory, which is the end knot only if the integration
+  reached it. An integrator that stops early and returns a partial result rather than raising
+  breaks that quietly: the trajectory is finite, in the right columns, and its final state
+  belongs to an earlier instant, so the defect `Phi_j(z_j, θ) − z_{j+1}` becomes a difference
+  of states taken at two different *times* — a different constraint, satisfied by a different
+  trajectory. Nothing downstream could see it, because the symptom is a nonzero defect, which
+  is what an honest stage shows after θ has moved. Measured on the offline fixture: a stage
+  seeded to be feasible at iteration zero, whose defect norm is exactly `0`, reported `0.0399`
+  and would have optimized against it. The segment seam now checks that a span reached the
+  knot it was asked for, and treats one that did not the way it treats any point that did not
+  integrate — the local model goes non-finite and the search backs off, rather than the run
+  dying on a point-specific failure.
+- **A segment simulation that carries no forward sensitivities now names the segment seam
+  (#584).** It stopped on the gradient assembly's own message — *enable the gradient path
+  (apply_routing) on every scored model* — which tells a `job_type = ms` user to enable a path
+  they did enable. A sensitivity request is applied **per action** (#475/#482), so a segment
+  run under a suffix the request never reached comes back with a perfectly good trajectory and
+  no tensor at all; that is an internal wiring error and every point in the fit hits it, so it
+  is now refused where it happens, saying which segment of which experiment returned what.
+- **The shooting suite now tests behaviour at pathological parameter points, not only the
+  arithmetic at well-behaved ones (#584).** The two defects above were found by these tests.
+  The two before them (#578, #581) were not: both reached `main` through a suite of 51 passing
+  offline tests and were caught by pointing `job_type = ms` at a real model. The offline
+  fixtures are a closed-form flow and an exponential decay, deliberately well-behaved so that
+  every derivative is checkable exactly — which is the right design for what they verify, and
+  leaves nothing asking what the method does when a *point* misbehaves. The offline
+  backend's failures are now switchable — a region that does not integrate, a region whose
+  trajectory is finite while its forward sensitivities overflow (#581's exact shape), a span
+  longer than the "model" can carry, a one-off refusal on the n-th call, a missing sensitivity
+  tensor, and a span that stops short of its end knot — and the new tests assert the three
+  properties ADR-0110 states as design and nothing checked: an unusable local model **backs
+  the search off** rather than ending the run; a run that stops early still **reports what it
+  has already earned**; and an unusable point **never becomes a reported fit**, including the
+  corner the method's own advantage creates, where every segment integrates, the whole horizon
+  does not, and the run therefore reports no fit rather than a segmented score no ordinary run
+  could reproduce. Each runs in milliseconds with no simulator.
 - **A gradient fit says, at job start, when bngsim declined the analytic `∂f/∂θ` for one of its
   models and CVODES' difference quotient is carrying every sensitivity column instead (#606,
   ADR-0121).** `CVodeSensInit1` takes one sensitivity-RHS callback for every column, so a single

--- a/pybnf/shooting/backend.py
+++ b/pybnf/shooting/backend.py
@@ -179,7 +179,7 @@ class SegmentBackend(ABC):
         """
 
 
-def trace_from_data(data, state_names, selector_prefix='species'):
+def trace_from_data(data, state_names, selector_prefix='species', end_time=None):
     """Read a :class:`SegmentTrace` off a simulated :class:`~pybnf.data.Data`.
 
     The end-knot state is the last row of the state columns, and its derivatives are the
@@ -189,7 +189,12 @@ def trace_from_data(data, state_names, selector_prefix='species'):
     A ``Data`` with no ``output_sensitivities`` yields a value-only trace, which is what the
     certification path (an ordinary single-shoot score, no derivatives) and a scalar
     evaluation need.
+
+    ``end_time`` is the knot the caller asked this span to reach, and passing it is what
+    turns "the last row" into "the end knot" (#584). See :func:`_require_end_knot`.
     """
+    if end_time is not None:
+        _require_end_knot(data, end_time)
     state_names = tuple(state_names)
     missing = [name for name in state_names if name not in data.cols]
     if missing:
@@ -221,3 +226,33 @@ def trace_from_data(data, state_names, selector_prefix='species'):
         d_end_ic = np.array([sens.slice_for(s, axis='ic')[-1] for s in selectors], dtype=float)
     return SegmentTrace(data, end_state, d_end_param=d_end_param, d_end_ic=d_end_ic,
                         param_axis=tuple(sens.param_names), ic_axis=tuple(sens.ic_species))
+
+
+def _require_end_knot(data, end_time):
+    """Refuse a span that came back short of the knot its end state is read from.
+
+    Everything the continuity block is built from is read off the trajectory's **last
+    row**, which is the end knot only if the integration reached it. An integrator that
+    stops early -- a step limit, a tolerance failure it reports as a partial result rather
+    than as an exception -- returns a trajectory that is perfectly finite and perfectly
+    wrong for this purpose: the defect ``c_j = Phi_j(z_j, theta) - z_{j+1}`` would then be
+    a difference of states taken at two different *instants*. That is not a small error for
+    the penalty term to absorb; it is a different constraint, satisfied by a different
+    trajectory. And nothing downstream can notice -- a stage reports a nonzero defect at a
+    point it was seeded to be feasible at, which is exactly what an honest stage does after
+    ``theta`` has moved.
+
+    So it is refused here, and as a :class:`SegmentSimulationFailed` rather than as an
+    error: a span that did not reach its knot is a point that did not integrate, which
+    every caller already handles -- the local model comes back non-finite and the search
+    backs off. The offline suite makes this switchable
+    (``TwoStateBackend.stop_short``), which is how the class is covered without a simulator
+    that can be asked to stop early (#584).
+    """
+    times = np.asarray(data.data, dtype=float)[:, data.cols[data.indvar]]
+    if times.size and np.isclose(times[-1], end_time, rtol=1e-9, atol=1e-12):
+        return
+    raise SegmentSimulationFailed(
+        'the segment stopped at %s rather than reaching its end knot %s = %g'
+        % ('no output at all' if not times.size else '%s = %g' % (data.indvar, times[-1]),
+           data.indvar, end_time))

--- a/pybnf/shooting/parallel.py
+++ b/pybnf/shooting/parallel.py
@@ -61,6 +61,8 @@ dominant cost. Stated here rather than discovered from a benchmark table.
 import queue
 from concurrent.futures import ThreadPoolExecutor
 
+import numpy as np
+
 from .backend import SegmentSimulationFailed, trace_from_data
 
 
@@ -182,12 +184,19 @@ class SegmentPool:
 
 
 def _integrate(task, pset, lane):
-    """One span, in one lane. ``None`` when it did not integrate."""
+    """One span, in one lane. ``None`` when it did not integrate.
+
+    "Did not integrate" includes coming back **short of the segment's end knot**, which is
+    why the requested knot is handed to
+    :func:`~pybnf.shooting.backend.trace_from_data` rather than the end state being read off
+    whatever last row arrived (#584).
+    """
     try:
         data = task.backend.simulate(pset, task.times, task.initial_state, lane=lane)
+        return trace_from_data(data, task.state_names,
+                               end_time=float(np.asarray(task.times, dtype=float)[-1]))
     except SegmentSimulationFailed:
         return None
-    return trace_from_data(data, task.state_names)
 
 
 def _integrate_in_lane(task, pset, lane_queue):

--- a/pybnf/shooting/problem.py
+++ b/pybnf/shooting/problem.py
@@ -316,9 +316,40 @@ class MultipleShootingProblem(TranscriptionProblem, EqualitySystem):
                                          self._knot_state(u, experiment, segment),
                                          experiment.state_names))
         flat, ok = self._pool.run(pset, tasks)
+        traces = _regroup(flat, shape) if ok else None
+        if traces is not None:
+            self._require_sensitivities(traces)
         self._cache_key = key
-        self._cache = (pset, _regroup(flat, shape)) if ok else None
+        self._cache = (pset, traces) if ok else None
         return self._cache
+
+    def _require_sensitivities(self, traces):
+        """Refuse a segment pass that came back carrying no derivatives at all.
+
+        A pass exists to build a local model, so a sensitivity-free segment is not a
+        property of the point the way a failed integration is -- it is a request that never
+        reached the simulator, and every point in the fit will come back the same way.
+        Saying so here, naming the segment seam, is the difference between a run that stops
+        with an actionable sentence and one that stops on the gradient assembly's own
+        message, which tells a ``job_type = ms`` user to enable a gradient path they did
+        enable: the sensitivity request is applied **per action** (#475/#482), so a segment
+        simulated under a suffix the request never reached carries a perfectly good
+        trajectory and nothing else (#584).
+        """
+        for experiment, per_segment in zip(self.experiments, traces):
+            for segment, trace in enumerate(per_segment):
+                if trace.data.output_sensitivities is None:
+                    raise PybnfError(
+                        "Multiple shooting simulated segment %i of experiment '%s' and got "
+                        "a trajectory carrying no forward sensitivities. A segment run has "
+                        "to return both axes -- d(y)/d(theta) for the data rows and "
+                        "d(end state)/d(start state) for the continuity block -- so there "
+                        "is no local model to assemble from this one."
+                        % (segment, experiment.key[1]),
+                        hint='This is an internal wiring error rather than a property of '
+                             'the fit: a sensitivity request is applied per action, so a '
+                             'segment simulated under a suffix the request never reached '
+                             'comes back bare. Please report it.')
 
     def _free_params(self, u, pset):
         """The augmented free-parameter list, in layout order.

--- a/tests/test_shooting.py
+++ b/tests/test_shooting.py
@@ -20,7 +20,16 @@ claims that matter:
   own;
 * **the load-bearing claim** -- at convergence the transcription is equivalent to the
   uninterrupted fit, measured against a single-shoot optimum computed **independently** by
-  ``scipy.least_squares`` rather than against this package's own arithmetic written twice.
+  ``scipy.least_squares`` rather than against this package's own arithmetic written twice;
+* **behaviour at a point that misbehaves** -- the last section, and the one thing the four
+  above cannot see. A closed-form flow always integrates and its derivatives are finite by
+  construction, so the fixture's failures are made *switchable* instead
+  (:class:`TwoStateBackend`: a region that does not integrate, one whose sensitivities
+  overflow while its trajectory does not, a span the "model" cannot carry, a one-off
+  refusal, a missing tensor, a span that stops short of its knot). What is then asserted is
+  behaviour rather than arithmetic: an unusable local model backs the search off rather than
+  ending the run, a run that stops early still reports what it has already earned, and an
+  unusable point never becomes a reported fit (#584).
 
 The offline problem
 -------------------
@@ -57,6 +66,7 @@ from pybnf.shooting import (
     max_segments,
     run_multiple_shooting,
     seed_stage,
+    trace_from_data,
 )
 from pybnf.shooting.grid import KNOT
 from pybnf.transcription import AugmentedLagrangian, Multipliers, PenaltySchedule
@@ -79,9 +89,26 @@ class TwoStateBackend(SegmentBackend):
     :meth:`simulate` therefore runs unmodified.
     """
 
-    def __init__(self, n_lanes=1):
+    def __init__(self, n_lanes=1, **failures):
         self.n_simulations = 0
-        self.fail_beyond = None    # |k| above which this "model" refuses to integrate
+        # -- the controllable failures (#584). Every one is off by default, so the closed
+        #    form above is what the arithmetic tests see; each is one thing a real model
+        #    does at a pathological parameter point and an exponential never does by
+        #    itself. See the "pathological parameter points" section at the foot of this
+        #    module for what each one is for.
+        self.fail_beyond = None          # |k| above which this "model" refuses to integrate
+        self.overflow_beyond = None      # |k| above which the *sensitivities* go non-finite
+        self.refuse_span_beyond = None   # the longest span this "model" can integrate
+        self.fail_on_call = None         # the n-th call refuses, whatever the point
+        self.drop_sensitivities = False  # a trajectory, and no tensor at all
+        self.stop_short = 0              # come back this many rows short of the end knot
+        #: How many times a switch above refused a call, so a test can assert that the
+        #: pathology it configured actually fired rather than passing vacuously.
+        self.n_refusals = 0
+        for name, value in failures.items():
+            if not hasattr(self, name):
+                raise TypeError('%s has no failure switch %r' % (type(self).__name__, name))
+            setattr(self, name, value)
         self._n_lanes = int(n_lanes)
         #: Lanes currently mid-integration, so a test can assert that a scheduler never puts
         #: two segments in one lane at once -- the invariant a stateful simulator needs and
@@ -123,12 +150,10 @@ class TwoStateBackend(SegmentBackend):
 
     def _simulate(self, pset, sample_times, initial_state=None):
         k = float(pset['k'])
-        if self.fail_beyond is not None and abs(k) > self.fail_beyond:
-            raise SegmentSimulationFailed('the closed-form backend refuses |k| > %g'
-                                          % self.fail_beyond)
+        times = np.asarray(sample_times, dtype=float)
+        self._maybe_refuse(k, times)
         state = ({'y': float(pset['y0']), 'w': W0} if initial_state is None
                  else {name: float(value) for name, value in initial_state.items()})
-        times = np.asarray(sample_times, dtype=float)
         dt = times - times[0]
         grow, decay = np.exp(k * dt), np.exp(-k * dt)
         y, w = state['y'] * grow, state['w'] * decay
@@ -143,7 +168,73 @@ class TwoStateBackend(SegmentBackend):
         data.output_sensitivities = OutputSensitivities(
             selectors=['species:y', 'species:w'], param_names=['k'], ic_species=['y', 'w'],
             d_param=d_param, d_ic=d_ic)
+        return self._maybe_spoil(data, k)
+
+    # -- the failure switches ---------------------------------------------------
+
+    def _maybe_refuse(self, k, times):
+        """The calls this backend declines to integrate at all.
+
+        Three shapes, because a real refusal has three shapes: a *region* of parameter
+        space the model cannot be integrated in (``fail_beyond``); a *span* longer than the
+        integrator can carry, which is the failure multiple shooting exists to work around
+        -- every segment integrates while the whole horizon does not (``refuse_span_beyond``);
+        and a *one-off*, a step limit hit on one trial point and not on its neighbours
+        (``fail_on_call``), which is the only one of the three that can make an individual
+        inner-solver trial unusable without also making the start point unusable.
+        """
+        if self.fail_beyond is not None and abs(k) > self.fail_beyond:
+            self.n_refusals += 1
+            raise SegmentSimulationFailed('the closed-form backend refuses |k| > %g'
+                                          % self.fail_beyond)
+        if self.refuse_span_beyond is not None \
+                and times[-1] - times[0] > self.refuse_span_beyond:
+            self.n_refusals += 1
+            raise SegmentSimulationFailed(
+                'the closed-form backend refuses a span longer than %g'
+                % self.refuse_span_beyond)
+        if self.fail_on_call is not None and self.n_simulations == self.fail_on_call:
+            self.n_refusals += 1
+            raise SegmentSimulationFailed('the closed-form backend refuses call %i'
+                                          % self.fail_on_call)
+
+    def _maybe_spoil(self, data, k):
+        """The calls that come back, carrying something a consumer cannot use.
+
+        ``overflow_beyond`` is #581's exact shape and the reason this section exists: the
+        *trajectory* is finite and correct, and the forward sensitivities are not, which is
+        what a stiff oscillator does long before it stops integrating. ``drop_sensitivities``
+        is the tensor missing altogether, and ``stop_short`` is an integration that returned
+        a partial result rather than raising -- the span comes back finite, in the right
+        columns, and never reaches the knot its end state is read from.
+        """
+        if self.drop_sensitivities:
+            data.output_sensitivities = None
+        elif self.overflow_beyond is not None and abs(k) > self.overflow_beyond:
+            sens = data.output_sensitivities
+            sens.d_param = np.full_like(sens.d_param, np.inf)
+            sens.d_ic = np.full_like(sens.d_ic, np.inf)
+        if self.stop_short:
+            return _truncated(data, self.stop_short)
         return data
+
+
+def _truncated(data, rows):
+    """``data`` with its last ``rows`` output rows dropped, sensitivity tensor included.
+
+    What an integration that stopped early hands back: a shorter trajectory over the same
+    columns, finite everywhere, carrying nothing that says it is short.
+    """
+    keep = len(data.data) - int(rows)
+    out = Data.from_columns(np.asarray(data.data, dtype=float)[:keep, :], ['time', 'y', 'w'])
+    sens = data.output_sensitivities
+    if sens is not None:
+        out.output_sensitivities = OutputSensitivities(
+            selectors=sens.selectors, param_names=sens.param_names,
+            ic_species=sens.ic_species,
+            d_param=None if sens.d_param is None else sens.d_param[:keep],
+            d_ic=None if sens.d_ic is None else sens.d_ic[:keep])
+    return out
 
 
 # ---------------------------------------------------------------------------
@@ -762,3 +853,249 @@ def _stale(problem, u, factor=1.6):
     for block in problem.layout.blocks:
         u[problem.layout.slice_of(block.name)] += np.log10(factor)
     return u
+
+
+# ---------------------------------------------------------------------------
+# Behaviour at pathological parameter points (#584)
+# ---------------------------------------------------------------------------
+#
+# Everything above this line verifies *arithmetic*: derivatives against central
+# differences, the equivalence claim against an independently computed optimum. A
+# closed-form flow is the right fixture for that, and it is exactly the wrong one for
+# asking what the method does when a **point** misbehaves -- it always integrates, it never
+# stiffens, and its sensitivities are finite by construction. Two defects reached ``main``
+# through that gap (#578, #581), both found by pointing ``job_type = ms`` at a real model
+# rather than by the suite above.
+#
+# So the backend's failures are switchable instead (see ``TwoStateBackend``), and the claims
+# below are behavioural rather than numerical -- the three ADR-0110 states as design
+# properties and nothing here checked:
+#
+#   * an unusable local model **backs the search off** rather than ending the run;
+#   * a run that stops early still **reports what it has already earned**;
+#   * an unusable point **never becomes a reported fit**.
+
+
+def run_ladder(backend, start=(0.55, 0.9), seed=4, **kwargs):
+    """One whole ``4-2-1`` run against ``backend``, from ``start`` in sampling space."""
+    times, obs = observations(seed=seed)
+    free = variables()
+    spec = make_spec(times, obs, backend=backend)
+    return run_multiple_shooting([spec], ChiSquareObjective(), free, pset_from_u_for(free),
+                                 np.asarray(start, dtype=float), **kwargs)
+
+
+def single_shoot_score(reported, seed=4):
+    """The ordinary unsegmented objective at ``reported``, computed here rather than by the
+    package under test -- the number ``certify`` has to reproduce."""
+    times, obs = observations(seed=seed)
+    residual = (reported[1] * np.exp(reported[0] * times) - obs) / SIGMA
+    return float(0.5 * residual @ residual)
+
+
+class TestOverflowingSensitivities:
+    """The trajectory integrates and the forward sensitivities do not (#581).
+
+    The shape a stiff oscillator reaches long before it stops integrating, and the one that
+    cost ``job_type = ms`` a whole reported fit: measured on ``Borghans_BiophysChem1997``,
+    1 of 8 oscillating box draws produced a point whose every segment returned ``OK`` and
+    whose every ``SegmentTrace.is_finite()`` was ``False``.
+    """
+
+    def test_the_local_model_is_refused_while_the_certificate_still_stands(self):
+        """Both halves of #581's asymmetry, in one place: the *augmented* model at the point
+        is unusable, and the *reconstruction* of the same point is perfectly good.
+
+        They are different computations -- certification discards every auxiliary state and
+        re-simulates the reported parameters through the ordinary unsegmented path, which
+        needs no forward sensitivities at all -- which is why one can fail while the other
+        succeeds, and why a run that discarded the second reported nothing from a point it
+        could score.
+        """
+        backend = TwoStateBackend(overflow_beyond=0.1)     # every point this stage visits
+        problem, _spec, free = build_stage(4, backend=backend, start_u=(0.5, 0.9))
+        u = problem.layout.initial_point([0.5, 0.9])
+
+        data = backend.simulate(pset_from_u_for(free)(np.array([0.5, 0.9])),
+                                np.linspace(0.0, 3.0, 7), None)
+        assert np.all(np.isfinite(np.asarray(data.data, dtype=float)))   # the trajectory
+        assert not np.all(np.isfinite(data.output_sensitivities.d_param))  # the derivatives
+
+        assert not problem.objective_at(u).is_finite()
+        assert not problem.equality_at(u).is_finite()
+        certificate = problem.certify(np.array([0.5, 0.9]))
+        assert certificate.accepted
+        assert certificate.objective == pytest.approx(single_shoot_score([0.5, 0.9]))
+
+    def test_a_run_that_starts_there_reports_the_certificate_it_already_holds(self):
+        """#581 end to end, offline and in milliseconds: the run stops -- there is no
+        surface at the start point to step from -- but it reports the score of the point it
+        was given rather than "no simulation completed"."""
+        result = run_ladder(TwoStateBackend(overflow_beyond=0.1), start=(0.55, 0.9))
+
+        assert result.stop_reason == 'inner_failed'
+        assert result.best is not None, 'the certificate at the start point was discarded'
+        np.testing.assert_allclose(result.reported, [0.55, 0.9])
+        assert result.best_score == pytest.approx(single_shoot_score([0.55, 0.9]))
+        assert result.certified
+
+    def test_an_overflowing_region_backs_the_search_off_rather_than_ending_the_run(self):
+        """The design property ADR-0110 states and nothing checked: a point whose local
+        model is not finite shrinks the trust region.
+
+        The overflow starts at ``k = 0.62``, between the start (``0.4``) and the optimum
+        (``0.702``), so the search walks up to a wall it cannot evaluate past. It is
+        supposed to stop *at* the wall and report what it earned on the good side of it --
+        not end the fit, and not report the optimum it never got to see.
+        """
+        times, obs = observations()
+        _target, target_objective = single_shoot_optimum(times, obs)
+        result = run_ladder(TwoStateBackend(overflow_beyond=0.62), start=(0.4, 0.8))
+
+        assert result.stop_reason == 'completed'
+        assert [stage.name for stage in result.stages] == ['m=4', 'm=2', 'm=1']
+        assert result.best is not None and np.isfinite(result.best_score)
+        assert result.best_score < single_shoot_score([0.4, 0.8])    # it moved
+        assert result.best_score > target_objective                  # and the wall cost it
+
+    def test_a_parallel_pass_reaches_the_same_verdict_as_a_serial_one(self):
+        """Parallel gives up the serial pass's short-circuit, not its verdict -- and the
+        verdict now has to be reached on a *finite* trajectory's derivatives rather than on
+        a failed integration."""
+        serial = TwoStateBackend(overflow_beyond=0.1)
+        problem, _spec, _free = build_stage(4, backend=serial, start_u=(0.5, 0.9))
+        u = problem.layout.initial_point([0.5, 0.9])
+        assert not problem.objective_at(u).is_finite()
+
+        backend = TwoStateBackend(n_lanes=4, overflow_beyond=0.1)
+        pool = SegmentPool(4)
+        try:
+            parallel, _s, _f = build_stage(4, backend=backend, start_u=(0.5, 0.9),
+                                           pool=pool)
+            model = parallel.objective_at(parallel.layout.initial_point([0.5, 0.9]))
+            assert not model.is_finite()
+        finally:
+            pool.close()
+
+
+class TestOneOffSegmentFailure:
+
+    def test_a_refused_trial_segment_does_not_derail_the_fit(self):
+        """A failure that is neither the start point's nor a whole region's: one call
+        refuses, the way a step limit is hit on one trial point and not on its neighbours.
+
+        Call 6 is a segment of the *second* augmented evaluation -- the first trial step the
+        inner solver takes -- so the trust region has somewhere to back off to, and the run
+        is held to the same optimum the healthy fixture reaches.
+        """
+        times, obs = observations()
+        target, _objective = single_shoot_optimum(times, obs)
+        backend = TwoStateBackend(fail_on_call=6)
+        result = run_ladder(backend, start=(0.55, 0.9))
+
+        assert backend.n_refusals == 1, 'the configured failure never fired'
+        assert result.stop_reason == 'completed'
+        np.testing.assert_allclose(result.reported, target, rtol=1e-3, atol=1e-4)
+
+
+class TestAnUnusablePointIsNeverAFit:
+
+    def test_a_run_whose_points_never_integrate_reports_no_fit(self):
+        """The honest empty answer. Nothing simulated, so nothing certified, so there is no
+        fit -- reported as such rather than as the augmented objective of a point whose
+        trajectories do not exist."""
+        result = run_ladder(TwoStateBackend(fail_beyond=0.0),    # no |k| it can integrate
+                        start=(0.55, 0.9))
+
+        assert result.best is None
+        assert result.reported is None
+        assert not np.isfinite(result.best_score)
+        assert 'best certified objective none' in result.summary()
+
+    def test_a_segmented_score_is_never_reported_when_it_cannot_be_reconstructed(self):
+        """The corner the method's own advantage creates: every *segment* integrates and the
+        *whole horizon* does not.
+
+        That is the case multiple shooting exists for, and it is also the one where the run
+        has a perfectly good augmented objective and no right to report it -- an ADR-0109
+        certificate is an ordinary single-shoot score, and a segmented score is not
+        comparable with any fit a user has ever run. So the stage solves, the trace prints
+        ``inf``, and the run says it has no fit rather than reporting a number nothing can
+        reproduce.
+        """
+        # A segment of the m=4 stage spans 0.75; the whole horizon is 3.0.
+        backend = TwoStateBackend(refuse_span_beyond=1.0)
+        problem, _spec, _free = build_stage(4, backend=backend, start_u=(0.55, 0.9))
+        u = problem.layout.initial_point([0.55, 0.9])
+        assert problem.objective_at(u).is_finite()          # the segmented fit is fine
+        assert not problem.certify(np.array([0.55, 0.9])).accepted
+
+        result = run_ladder(TwoStateBackend(refuse_span_beyond=1.0), start=(0.55, 0.9))
+        assert result.best is None and result.reported is None
+        assert result.trace().startswith('m=4: inf')
+
+    def test_a_run_stopped_by_its_budget_still_reports_what_it_earned(self):
+        """The ``stopped`` branch, which has always reported the work already done -- pinned
+        here at the shooting layer because ``wall_time_fit`` reaches this loop through the
+        same seam a pathological point does, and both end a run mid-ladder."""
+        backend = TwoStateBackend()
+        result = run_ladder(backend, start=(0.55, 0.9),
+                        stop_check=lambda: backend.n_simulations > 40)
+
+        assert result.stop_reason == 'stopped'
+        assert [stage.name for stage in result.stages] == ['m=4']    # it never got further
+        assert result.best is not None and np.isfinite(result.best_score)
+        assert result.best_score < single_shoot_score([0.55, 0.9])
+
+
+class TestTheSegmentOutputContract:
+    """What a segment simulation has to *return*, as opposed to what it has to compute.
+
+    Both of these come back finite, in the right columns, at a point that integrates -- so
+    neither the trajectory finiteness check nor ``SegmentTrace.is_finite`` sees anything
+    wrong with them.
+    """
+
+    def test_a_span_that_stops_short_of_its_end_knot_is_refused(self):
+        """An integration that returned a partial result rather than raising: the span is
+        finite and shorter than it was asked for, and the row its end state would be read
+        from is at the wrong time."""
+        backend = TwoStateBackend(stop_short=1)
+        times = np.linspace(1.0, 2.0, 6)
+        data = backend.simulate(pset_from_u_for(variables())(np.array([0.4, 0.8])), times,
+                                {'y': 1.0, 'w': W0})
+
+        with pytest.raises(SegmentSimulationFailed, match='end knot'):
+            trace_from_data(data, backend.state_names, end_time=float(times[-1]))
+
+        # ...and this is why it has to be refused rather than noticed downstream: read
+        # without the knot to check it against, the last row that *did* arrive is a
+        # perfectly plausible end state, at the wrong time.
+        loose = trace_from_data(data, backend.state_names)
+        assert np.all(np.isfinite(loose.end_state))
+        assert loose.end_state[0] == pytest.approx(np.exp(0.4 * (times[-2] - times[0])))
+        assert loose.end_state[0] != pytest.approx(np.exp(0.4 * (times[-1] - times[0])))
+
+    def test_a_short_segment_never_becomes_a_plausible_continuity_defect(self):
+        """The consequence at the layer that would have absorbed it: a stage seeded from a
+        continuous trajectory is feasible at iteration zero, so a wrong-time end state does
+        not read as an error -- it reads as a stage that started slightly infeasible and
+        would have been optimised against."""
+        healthy, _spec, _free = build_stage(4)
+        assert healthy.equality_at(healthy.layout.initial_point([0.4, 0.8])).defect_norm \
+            == pytest.approx(0.0, abs=1e-9)
+
+        short, _s, _f = build_stage(4, backend=TwoStateBackend(stop_short=1))
+        model = short.equality_at(short.layout.initial_point([0.4, 0.8]))
+        assert not model.is_finite()
+        assert not short.objective_at(short.layout.initial_point([0.4, 0.8])).is_finite()
+
+    def test_a_segment_carrying_no_sensitivity_tensor_names_the_segment_seam(self):
+        """A missing tensor is not a property of the point -- every point comes back the
+        same way -- so it is an error rather than a back-off, and it says which computation
+        is missing what."""
+        problem, _spec, _free = build_stage(
+            4, backend=TwoStateBackend(drop_sensitivities=True))
+
+        with pytest.raises(PybnfError, match='carrying no forward sensitivities'):
+            problem.objective_at(problem.layout.initial_point([0.4, 0.8]))


### PR DESCRIPTION
Closes #584.

The suites verified arithmetic and said nothing about robustness. This adds the fixture the
issue asks for — one whose failures are controllable — and holds the consumer to behavioural
claims instead of numerical ones. Writing them turned up two silent defects, both fixed here.

## The fixture

`TwoStateBackend` grows one switch per thing a real model does at a pathological point and a
closed-form exponential never does by itself. All are off by default, so every existing test
sees the same well-behaved flow it saw before.

| switch | what it models |
| --- | --- |
| `fail_beyond` | a region of parameter space that does not integrate (already existed) |
| `overflow_beyond` | the trajectory is finite and the forward sensitivities are not — **#581's exact shape** |
| `refuse_span_beyond` | a span longer than the "model" can carry: every segment integrates, the whole horizon does not |
| `fail_on_call` | a one-off refusal on the n-th call — the only shape that makes an inner-solver *trial* unusable without making the start point unusable |
| `drop_sensitivities` | a trajectory and no tensor at all |
| `stop_short` | an integration that returned a partial result instead of raising |

A refusal counter travels with them so a test asserts the pathology it configured actually
fired, rather than passing vacuously if a switch stops triggering.

## The claims

The three ADR-0110 states as design properties and nothing checked:

* **an unusable local model backs the search off rather than ending the run** — one refused
  trial segment mid-solve still reaches the optimum the healthy fixture reaches; a whole
  region of overflowing sensitivities is a wall the search stops at, reporting the fit it
  earned on the good side, rather than a fit-ending error;
* **a run that stops early still reports what it has already earned** — a run whose start
  point's sensitivities overflow reports that point's certificate (#581, offline, in
  milliseconds: reverting `_certify_unusable` fails this test), and a budget that expires
  mid-ladder reports the rung it finished;
* **an unusable point never becomes a reported fit** — a run that never integrates says it
  has no fit rather than inventing one, and a run whose segments all integrate while the
  unsegmented reconstruction does not reports no fit rather than a segmented score no
  ordinary run could reproduce. That last one is the corner the method's own advantage
  creates, and it had no test.

## The two defects

**A segment that stopped short of its end knot was read at the wrong time.** Every continuity
row is built from the *last row* of a segment's trajectory, which is the end knot only if the
integration reached it. A partial result is finite, in the right columns, and belongs to an
earlier instant, so `c_j = Phi_j(z_j, θ) − z_{j+1}` becomes a difference of states taken at
two different *times* — a different constraint, satisfied by a different trajectory. Nothing
downstream could notice, because the symptom is a nonzero defect, which is what an honest
stage shows after θ has moved: on the offline fixture, a stage seeded to be feasible at
iteration zero, whose defect norm is `0`, reported `0.0399` and would have optimised against
it. The seam now checks that the span reached the knot it was asked for and treats one that
did not as a point that did not integrate — a back-off, not a fit-ending error, since that is
what a step-limited integration is.

**A segment carrying no sensitivity tensor stopped on the wrong message.** It reached the
gradient assembly's own `enable the gradient path (apply_routing) on every scored model`,
which tells a `job_type = ms` user to enable a path they did enable. A sensitivity request is
applied per action (#475/#482), so a segment run under a suffix the request never reached
comes back with a perfectly good trajectory and nothing else — an internal wiring error, hit
by every point in the fit. It is now refused where it happens, naming the segment, the
experiment, and which axis the continuity block needed.

## Not in scope

The formula-observable class the issue lists fourth stays where #579 put it
(`tests/test_shooting_sbml.py`): materialising an `observableFormula` needs the measurement
layer and a real model, which is exactly what the offline fixture does not have.

## Verification

* `tests/test_shooting.py` 47 → 58; the whole shooting/transcription set (`test_shooting`,
  `test_shooting_net`, `test_shooting_sbml` including its slow end-to-end `ms` fit,
  `test_transcription`) passes: 181 passed, 1 skipped.
* The three new contract tests fail on `main`'s source with the exact production symptoms.
* Mutation-checked: reverting #581's `_certify_unusable` fails exactly the test that pins it;
  making a non-finite local model fatal in the inner solver fails five of the new behavioural
  tests plus the existing failed-segment one.
* `ruff@0.15.14 check .` clean. The rest of the local suite's failures are pre-existing and
  environmental (no `BNG2.pl` on this machine — identical counts with the branch stashed).
