### PR TITLE
docs(gradient): the ms_segments default names the regime it was measured in, and the tail result that did not move it (#585)

### DIFF
--- a/docs/gradient_fitting.rst
+++ b/docs/gradient_fitting.rst
@@ -234,7 +234,12 @@ are worth leaving alone unless you have a reason:
 * ``ms_segments`` (default ``4``) — the **finest** rung of the ladder, and ``ms_coarsening``
   (default ``2``) the factor between rungs. Starting with many short segments is the wrong end:
   under partial observability an over-segmented stage is under-determined and routinely certifies
-  worse than its own start.
+  worse than its own start. Where that bites is a property of the fit rather than of ``m``: the
+  ``4`` was chosen on the *median* over eight starts at one perturbation radius of the motivating
+  problem, which observes one state of three and leaves ~14 points per segment at ``m = 8``. A
+  repeat at a wider radius favoured ``m = 8`` on the *tail* with the medians close (#585), and a
+  more fully observed or more densely sampled fit can afford a finer rung — but neither
+  measurement is evidence about a different model, which is why the default has not moved.
 * ``ms_penalty`` (default ``10``) and ``ms_penalty_growth`` (default ``5``) — the augmented
   Lagrangian's initial penalty and its growth factor, capped at ``ms_max_penalty``. Deliberately
   **tight**: a loose start was measured both worse *and* twice as expensive, because the inner


### PR DESCRIPTION
## What was wrong

`docs/gradient_fitting.rst` presented the `ms_segments = 4` default with its mechanism stated
generically — *"under partial observability an over-segmented stage is under-determined and
routinely certifies worse than its own start"* — which reads as a property of segmentation. It is
a property of the **fit**: where over-segmentation starts to bite depends on how many states are
observed and how many measurements each segment owns.

The `4` came from ADR-0109 finding 5.2 — eight paired starts at one perturbation radius of
Borghans, selected on the **median**, on a fit that observes one state of three and leaves ~14
points per segment at `m = 8`. None of that was on the page, so a reader deciding whether to raise
or lower the key could not tell whether their own fit resembles the one the default was fitted to.

## What changed

The bullet now names the regime, records the wider-radius result from #585 (tail favours `m = 8`,
medians close), and states why the default stands anyway: both measurements are the same model, at
n = 8 and n = 10, and a tail preference that follows from Borghans' observation density is not
evidence about a different model. #585 was closed without a code change; this puts the same
conclusion where the default lives.

## Scope deliberately left out

* Prose only — the default is unchanged and no key gains a validator.
* The `MSConfig` docstring is untouched: it already says "on the motivating problem" and gives the
  observability, so it was not making the unqualified claim.
* Deriving a segment ceiling from a segment's own observation count against its unknown start
  states — the version of this that would generalize across models — is not attempted.

## Verification

`sphinx -W -b html docs` builds clean (the `-W` gate CI uses).
