### PR TITLE
Fix _cleanup_dask_workspace to remove dask-scratch-space (#620)

### DIFF
--- a/pybnf/pybnf.py
+++ b/pybnf/pybnf.py
@@ -610,21 +610,30 @@ def _teardown_cluster(cluster):
 
 
 def _cleanup_dask_workspace():
-    """Remove any leftover ``dask-worker-space`` directories (cwd and home)."""
-    # Attempt to remove dask-worker-space directory if necessary
-    # (exists in directory where workers were instantiated)
-    # Tries current and home directories
-    if os.path.isdir('dask-worker-space'):
-        if os.name == 'nt':  # Windows
-            shutil.rmtree('dask-worker-space', ignore_errors=True)
-        else:
-            run(['rm', '-rf', 'dask-worker-space'])  # More likely to succeed than rmtree()
-    home_dask_dir = os.path.expanduser(os.path.join('~', 'dask-worker-space'))
-    if os.path.isdir(home_dask_dir):
-        if os.name == 'nt':  # Windows
-            shutil.rmtree(home_dask_dir, ignore_errors=True)
-        else:
-            run(['rm', '-rf', home_dask_dir])
+    """Remove any leftover dask workspace directories (cwd and home).
+    
+    Cleans up both ``dask-scratch-space`` (current dask versions) and
+    ``dask-worker-space`` (legacy name from older dask versions).
+    """
+    # Dask changed the directory name from 'dask-worker-space' to 'dask-scratch-space'.
+    # Clean both so leftover directories from old and new versions are removed.
+    dir_names = ['dask-scratch-space', 'dask-worker-space']
+    
+    for dir_name in dir_names:
+        # Try current working directory
+        if os.path.isdir(dir_name):
+            if os.name == 'nt':  # Windows
+                shutil.rmtree(dir_name, ignore_errors=True)
+            else:
+                run(['rm', '-rf', dir_name])  # More likely to succeed than rmtree()
+        
+        # Try home directory
+        home_dask_dir = os.path.expanduser(os.path.join('~', dir_name))
+        if os.path.isdir(home_dask_dir):
+            if os.name == 'nt':  # Windows
+                shutil.rmtree(home_dask_dir, ignore_errors=True)
+            else:
+                run(['rm', '-rf', home_dask_dir])
 
 
 def main():

--- a/tests/test_pybnf_cleanup.py
+++ b/tests/test_pybnf_cleanup.py
@@ -7,9 +7,11 @@ cleanup must propagate, not be masked by the ``exit()`` call (which previously
 sat in a ``finally`` block that swallowed any in-flight exception).
 """
 
+import os
+
 import pytest
 
-from pybnf.pybnf import _finalize
+from pybnf.pybnf import _cleanup_dask_workspace, _finalize
 
 
 class _StubAlg:
@@ -60,3 +62,106 @@ def test_finalize_does_not_mask_keyboard_interrupt():
     alg = _StubAlg(exc=KeyboardInterrupt())
     with pytest.raises(KeyboardInterrupt):
         _finalize(success=False, alg=alg, start_time=0.0)
+
+
+# Tests for _cleanup_dask_workspace (issue #620)
+
+
+def test_cleanup_dask_scratch_space_in_cwd(tmp_path):
+    """Cleanup removes dask-scratch-space (current dask directory name) from cwd."""
+    # Create the directory that modern dask creates
+    scratch_dir = tmp_path / 'dask-scratch-space'
+    scratch_dir.mkdir()
+    (scratch_dir / 'test_file.txt').write_text('test')
+    
+    # Change to the temp directory and run cleanup
+    original_dir = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        _cleanup_dask_workspace()
+        # The directory should be removed
+        assert not scratch_dir.exists()
+    finally:
+        os.chdir(original_dir)
+
+
+def test_cleanup_dask_worker_space_in_cwd(tmp_path):
+    """Cleanup removes dask-worker-space (legacy dask directory name) from cwd."""
+    # Create the directory that old dask created
+    worker_dir = tmp_path / 'dask-worker-space'
+    worker_dir.mkdir()
+    (worker_dir / 'test_file.txt').write_text('test')
+    
+    # Change to the temp directory and run cleanup
+    original_dir = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        _cleanup_dask_workspace()
+        # The directory should be removed
+        assert not worker_dir.exists()
+    finally:
+        os.chdir(original_dir)
+
+
+def test_cleanup_both_dask_directories(tmp_path):
+    """Cleanup removes both old and new dask directory names when both exist."""
+    scratch_dir = tmp_path / 'dask-scratch-space'
+    worker_dir = tmp_path / 'dask-worker-space'
+    scratch_dir.mkdir()
+    worker_dir.mkdir()
+    (scratch_dir / 'file1.txt').write_text('test')
+    (worker_dir / 'file2.txt').write_text('test')
+    
+    original_dir = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        _cleanup_dask_workspace()
+        # Both should be removed
+        assert not scratch_dir.exists()
+        assert not worker_dir.exists()
+    finally:
+        os.chdir(original_dir)
+
+
+def test_cleanup_when_no_dask_directories_exist(tmp_path):
+    """Cleanup runs without error when no dask directories exist."""
+    # No directories created - just run cleanup
+    original_dir = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        # Should not raise any errors
+        _cleanup_dask_workspace()
+    finally:
+        os.chdir(original_dir)
+
+
+def test_cleanup_dask_scratch_space_in_home(tmp_path, monkeypatch):
+    """Cleanup removes dask-scratch-space from the home directory."""
+    # Mock home directory to point to our temp directory
+    monkeypatch.setenv('HOME', str(tmp_path))
+    monkeypatch.setenv('USERPROFILE', str(tmp_path))  # Windows
+    
+    # Create the directory in "home"
+    scratch_dir = tmp_path / 'dask-scratch-space'
+    scratch_dir.mkdir()
+    (scratch_dir / 'test_file.txt').write_text('test')
+    
+    _cleanup_dask_workspace()
+    # The directory should be removed
+    assert not scratch_dir.exists()
+
+
+def test_cleanup_dask_worker_space_in_home(tmp_path, monkeypatch):
+    """Cleanup removes dask-worker-space (legacy name) from the home directory."""
+    # Mock home directory to point to our temp directory
+    monkeypatch.setenv('HOME', str(tmp_path))
+    monkeypatch.setenv('USERPROFILE', str(tmp_path))  # Windows
+    
+    # Create the legacy directory in "home"
+    worker_dir = tmp_path / 'dask-worker-space'
+    worker_dir.mkdir()
+    (worker_dir / 'test_file.txt').write_text('test')
+    
+    _cleanup_dask_workspace()
+    # The directory should be removed
+    assert not worker_dir.exists()

--- a/tests/test_pybnf_cleanup.py
+++ b/tests/test_pybnf_cleanup.py
@@ -136,32 +136,49 @@ def test_cleanup_when_no_dask_directories_exist(tmp_path):
 
 
 def test_cleanup_dask_scratch_space_in_home(tmp_path, monkeypatch):
-    """Cleanup removes dask-scratch-space from the home directory."""
-    # Mock home directory to point to our temp directory
-    monkeypatch.setenv('HOME', str(tmp_path))
-    monkeypatch.setenv('USERPROFILE', str(tmp_path))  # Windows
-    
+    """Cleanup removes dask-scratch-space from the home directory.
+
+    Home and cwd are deliberately different directories. If they were the
+    same, the cwd branch of the cleanup would remove the directory and this
+    test would pass even with the home branch broken.
+    """
+    home = tmp_path / 'home'
+    home.mkdir()
+    workdir = tmp_path / 'work'
+    workdir.mkdir()
+    monkeypatch.setenv('HOME', str(home))
+    monkeypatch.setenv('USERPROFILE', str(home))  # Windows
+    monkeypatch.chdir(workdir)
+
     # Create the directory in "home"
-    scratch_dir = tmp_path / 'dask-scratch-space'
+    scratch_dir = home / 'dask-scratch-space'
     scratch_dir.mkdir()
     (scratch_dir / 'test_file.txt').write_text('test')
-    
+
     _cleanup_dask_workspace()
     # The directory should be removed
     assert not scratch_dir.exists()
 
 
 def test_cleanup_dask_worker_space_in_home(tmp_path, monkeypatch):
-    """Cleanup removes dask-worker-space (legacy name) from the home directory."""
-    # Mock home directory to point to our temp directory
-    monkeypatch.setenv('HOME', str(tmp_path))
-    monkeypatch.setenv('USERPROFILE', str(tmp_path))  # Windows
-    
+    """Cleanup removes dask-worker-space (legacy name) from the home directory.
+
+    Home and cwd are deliberately different directories, for the same reason
+    as the test above.
+    """
+    home = tmp_path / 'home'
+    home.mkdir()
+    workdir = tmp_path / 'work'
+    workdir.mkdir()
+    monkeypatch.setenv('HOME', str(home))
+    monkeypatch.setenv('USERPROFILE', str(home))  # Windows
+    monkeypatch.chdir(workdir)
+
     # Create the legacy directory in "home"
-    worker_dir = tmp_path / 'dask-worker-space'
+    worker_dir = home / 'dask-worker-space'
     worker_dir.mkdir()
     (worker_dir / 'test_file.txt').write_text('test')
-    
+
     _cleanup_dask_workspace()
     # The directory should be removed
     assert not worker_dir.exists()


### PR DESCRIPTION
## Summary

Fixes #620.

Dask changed its worker scratch directory name from \dask-worker-space\ to \dask-scratch-space\. The cleanup function in \_cleanup_dask_workspace\ only looked for the old name, so directories created by modern dask (>=2024.1.0, which PyBNF already requires) were silently left behind after every run and accumulated in the working directory and home directory.

On shared cluster storage with limited quota this can eventually stop users from working entirely — and the problem is invisible because the cleanup runs, reports nothing, and appears successful.

## Changes

### \pybnf/pybnf.py\
- Updated \_cleanup_dask_workspace\ to loop over both directory names: \dask-scratch-space\ (current) and \dask-worker-space\ (legacy)
- Checks both the current working directory and home directory for each name
- Existing Windows (\shutil.rmtree\) vs Unix (\m -rf\) behaviour is unchanged
- Updated docstring to reflect both names

### \	ests/test_pybnf_cleanup.py\
- Added 6 new tests for \_cleanup_dask_workspace\ covering:
  - \dask-scratch-space\ in cwd (the name dask actually creates now)
  - \dask-worker-space\ in cwd (regression guard for the legacy name)
  - Both names present at the same time
  - No directories present (no-op, must not error)
  - \dask-scratch-space\ in home directory
  - \dask-worker-space\ in home directory

## Testing

All 6 new tests pass locally. The 4 existing \_finalize\ tests are untouched and still pass.