### PR TITLE
docs: record the dask fix in the changelog, and credit the contributors the list had missed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,6 +169,18 @@ All notable changes to PyBNF are documented below. This project adheres to
   says what it has not bisected.
 
 ### Fixed
+- **The temporary directory dask leaves behind is now removed under the name dask actually
+  creates (#620).** `_cleanup_dask_workspace` deleted `dask-worker-space` — the name dask used
+  before it renamed the directory to `dask-scratch-space`. Every dask version the project
+  supports (`>=2024.1.0`) creates the new name, so the cleanup matched nothing and the scratch
+  directories accumulated in the working directory and in the home directory, one per run. The
+  failure was invisible by construction: the cleanup ran, raised nothing, reported nothing, and
+  looked exactly like a cleanup that had worked. On a cluster, where home is usually shared
+  storage under a quota, that ends with a user unable to write at all — with no indication that
+  a fit was the thing filling the quota. Both names are now removed, from both locations, so
+  directories left by earlier runs are cleared alongside new ones. There is no public API that
+  reports the name: `distributed` hardcodes the `dask-scratch-space` literal itself, so the
+  cleanup carries both names deliberately rather than deriving one.
 - **A multiple-shooting segment that comes back short of its end knot is refused instead of
   being read at the wrong time (#584).** `job_type = ms` builds every continuity row from the
   **last row** of a segment's trajectory, which is the end knot only if the integration

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,8 +1,13 @@
 # Contributors
 
+Listed alphabetically by family name. Contributors known only by their GitHub
+handle are listed by handle, in the same sequence.
+
+- bpiper02
 - Ye Chen
 - Joshua Colvin
 - Abell T. Duprat
+- Song Feng
 - William S. Hlavacek
 - Andrew Hu
 - Alexander Ionkov

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -17,6 +17,7 @@ handle are listed by handle, in the same sequence.
 - Eshan D. Mitra
 - Jacob Neumann
 - Richard G. Posner
+- psamuelvijay
 - Herbert M. Sauro
 - Ryan Suderman
 - Brandon R. Thomas


### PR DESCRIPTION
Bookkeeping for the two contributions that landed today (#626, #627), plus one committer the list had missed long before them.

## `CONTRIBUTORS.md`

- **Song Feng** — the `np.Inf` -> `np.inf` deprecation fix in December 2025 (455f2013), authored under the GitHub handle `LifeWorks`. 
- **bpiper02** — the contributor setup rewrite in #627.
- **psamuelvijay** — the dask scratch-directory fix in #626.

Seven listed names have no commits in the history (Chen, Duprat, Hu, Lin, Posner, Sauro, Thomas). These are co-authors of one or more PyBNF papers. The file had never stated its own ordering, so the header now says it.

Both new contributors are listed by handle.

## `CHANGELOG.md`

#626 merged without an entry. It is a user-visible defect with a real consequence on shared storage — scratch directories accumulating unnoticed until a quota fills — so it goes under `[Unreleased]` -> `Fixed`, newest first, matching the surrounding entries.

The entry also records why the cleanup carries both directory names rather than deriving one: `distributed` hardcodes the `dask-scratch-space` literal itself, so there is no API to ask. That is worth writing down where the next reader will find it, since #620 originally asked for the derived version.

No contributor credit in the changelog — there is no precedent for it in the file, so the credit stays in `CONTRIBUTORS.md`.