### PR TITLE
docs(contributing): ask contributors to sign off on their commits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,21 @@
 Thanks for your interest in contributing to PyBioNetFit!
 
-When making your first contribution, please complete LANL's
-<a href="https://www.clahub.com/agreements/lanl/PyBNF">Contributor License Agreement</a>.
+## Certificate of origin
+
+Contributions are accepted under the project's [BSD-3-Clause license](LICENSE),
+the same terms PyBNF is distributed under.
+
+Please sign off on your commits, certifying that you wrote the contribution or
+otherwise have the right to submit it under that license — the
+[Developer Certificate of Origin](https://developercertificate.org). Add `-s`
+when you commit:
+
+```sh
+git commit -s -m "your message"
+```
+
+which appends a `Signed-off-by:` line using the name and email from your
+`git config`.
 
 ## Development setup
 


### PR DESCRIPTION
Adds a certificate-of-origin section to `CONTRIBUTING.md`.

It states the terms contributions are accepted under — the project's own BSD-3-Clause license — and asks contributors for a [Developer Certificate of Origin](https://developercertificate.org) sign-off via `git commit -s`, so every contribution carries a durable record in the git history that its author had the right to submit it.

Not enforced in CI for now. A blocking check that rejects a first contribution over a missing flag costs more at the door than it is worth; the DCO GitHub App or a small workflow can add enforcement later if it is ever wanted.

This commit is itself signed off.