### PR TITLE
feat(cluster): start workers inside the SLURM allocation instead of over SSH (#614)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@ All notable changes to PyBNF are documented below. This project adheres to
 ## [Unreleased]
 
 ### Added
+- **A multi-machine fit can start its workers without logging in anywhere, so clusters that
+  use host-based or Kerberos SSH can run one at all (#614, ADR-0122).** PyBNF had exactly one
+  way to run across several machines: `dask-ssh`, which logs in to every node with **paramiko**
+  rather than with the operating system's `ssh`. paramiko offers a public key or a password and
+  nothing else. A cluster whose nodes authenticate to each other by **host-based** SSH (no user
+  credential exists to offer) or by **Kerberos/GSSAPI** (paramiko can, dask never enables it)
+  therefore refused every login PyBNF attempted, on a machine where `ssh OTHER hostname` from
+  the same shell succeeds — and the advice in `docs/cluster.rst`, to set up SSH keys, could not
+  fix a cluster that is not asking for a key. The run stopped before a single simulation.
+  **`cluster_type = slurm-srun`** (or `pybnf -t slurm-srun`) starts the workers with SLURM's own
+  `srun` instead. No credential is involved because the scheduler granted the allocation before
+  PyBNF started: PyBNF runs a dask scheduler on its own node, has `srun` place one worker process
+  group on each node of the allocation, and connects through the scheduler file the scheduler
+  writes — a file it now also *creates*, so under this launcher `scheduler_file` chooses where it
+  goes (default `dask_scheduler.json` in `output_dir`) rather than naming a cluster to attach to.
+  `-t slurm` and every other path construct exactly the calls they did before; this is a second
+  launcher, not a change to the existing one.
+  Both bring-up steps wait on a real signal rather than a fixed sleep, and watch the process they
+  started while waiting: the scheduler is ready when its connection file *parses* with an address
+  (dask writes that file in place, so a reader can catch it half-written), and the workers are
+  ready when one has registered. That second check is the one that cannot be dropped — connecting
+  to our own scheduler always succeeds, so a failed placement would otherwise turn into a fit that
+  submits jobs and never gets one back, with `srun`'s explanation sitting unread. Both failures
+  quote that output. Running outside an allocation is refused up front, since `srun` there does not
+  place a task but submits a job and waits, which would read as PyBNF hanging.
+  The workers are placed one task per node with the CPUs their processes need, taken from what
+  SLURM granted (`$SLURM_CPUS_ON_NODE`): under cgroup binding a task that took the default single
+  CPU would confine every worker it forked to that one CPU and quietly serialize the node. Two logs,
+  `dask_scheduler.log` and `dask_workers.log`, are written to the output directory.
 - **A fit's start point is a supported, validated, per-parameter fact that every optimizer
   reads, and the resolved start is recorded beside the results (#583, #559, ADR-0117).**
   There was no supported way to say "start this fit at exactly this point, inside the

--- a/docs/adr/0122-a-cluster-that-cannot-be-logged-into-is-still-a-cluster-so-pybnf-starts-its-workers-inside-the-allocation-slurm-already-granted-rather-than-over-ssh.md
+++ b/docs/adr/0122-a-cluster-that-cannot-be-logged-into-is-still-a-cluster-so-pybnf-starts-its-workers-inside-the-allocation-slurm-already-granted-rather-than-over-ssh.md
@@ -1,0 +1,184 @@
+# A cluster that cannot be logged into is still a cluster, so PyBNF starts its workers inside the allocation SLURM already granted rather than over SSH (issue #614)
+
+**Status: Accepted and implemented (2026-08-21).** PyBNF had exactly one way to run a fit across
+several machines: run `dask-ssh`, which logs in to every node. On a cluster whose nodes authenticate
+to each other by host-based or Kerberos SSH, that login cannot succeed -- not with more
+configuration, not with SSH keys -- so multi-machine fitting was unavailable there outright. This
+ADR adds a second launcher, selected by `cluster_type = slurm-srun`, that starts the workers with
+SLURM's own `srun` and never authenticates anything. The SSH launcher is unchanged and remains the
+default for `-t slurm`.
+
+## The problem
+
+`Cluster.setup_cluster` starts workers by running `dask-ssh`, and `dask-ssh` opens its connections
+with **paramiko**, not with the operating system's `ssh`. paramiko offers two ways to log in: a
+public key, or a password. Clusters commonly use neither:
+
+* **Host-based authentication**, where the machines are configured to trust each other and no user
+  credential is involved at all. paramiko has no support for it.
+* **Kerberos / GSSAPI**. paramiko can do this; dask never turns it on.
+
+The user-visible shape of the failure is what makes it costly: on the cluster in #614, logging in by
+hand from the same shell works.
+
+```console
+$ salloc -N 2
+$ ssh OTHER hostname
+OTHER                                    # succeeds
+
+$ python -c "import paramiko; c = paramiko.SSHClient(); \
+    c.set_missing_host_key_policy(paramiko.AutoAddPolicy()); c.connect('OTHER')"
+paramiko.ssh_exception.AuthenticationException: Authentication failed.
+```
+
+The second command is the login PyBNF attempts. So the run stops before a single simulation starts,
+while every check the user can think to make says SSH is fine. `docs/cluster.rst` answered this
+symptom with instructions for creating SSH keys, which cannot help: the cluster is not asking for a
+key, and on a host-based cluster there is no per-user credential to install.
+
+Nothing in that chain is PyBNF's to fix. paramiko does not implement host-based authentication;
+enabling its GSSAPI support is dask's call, not ours, and would still leave host-based clusters out.
+The fix has to be a way of starting workers that does not log in at all.
+
+## The decision
+
+### A second launcher, chosen by a new `cluster_type` value
+
+`cluster_type = slurm-srun` (also accepted: `slurm_srun`, `slurmsrun`, `srun`) selects a launcher
+that does the same three things a cluster bring-up always does, without an SSH login anywhere:
+
+1. start a dask **scheduler** on the node PyBNF is running on, told to write a connection file;
+2. start the **workers** with `srun`, one task per node of the allocation, each reading that file;
+3. **connect** through the same file -- which PyBNF already supported, via `scheduler_file`.
+
+No credential is involved in step 2 because SLURM granted the allocation before PyBNF started. That
+is the entire argument for the design: the authorization the SSH login was trying to re-establish
+already exists, and `srun` is the interface to it.
+
+This is a new value rather than a change to `slurm` so that **anyone whose SSH setup already works
+is unaffected**. Both spellings reach the same node-list code (`read_node_names`); only the way the
+workers are started differs. One ordering hazard is load-bearing and is pinned by a test:
+`re.match('slurm', 'slurm-srun')` succeeds, so the srun test has to come first, or the new value
+would silently take the SSH path it exists to avoid.
+
+### The scheduler runs here; only the workers go through SLURM
+
+The scheduler is an ordinary subprocess of the PyBNF process, on the node PyBNF is already running
+on. Nothing is gained by placing it with `srun` -- it is not a compute task, it must outlive
+individual worker failures, and the process PyBNF wants to be able to terminate at teardown is
+better held directly than through a job step. `srun` is used for exactly the thing it is needed for:
+placing processes on machines this process cannot log in to.
+
+Both commands are run as `sys.executable -m dask ...` rather than as a bare `dask` on `PATH`. A
+launcher whose purpose is to remove ambiguity about *how* a worker starts should not reintroduce
+ambiguity about *which* environment starts it, and PyBNF already requires the shared filesystem that
+makes this interpreter path valid on every node. (It also sidesteps the console-script rename behind
+issue #615 outright: `dask-scheduler` and `dask-worker` no longer exist as separate scripts, and
+`python -m dask` does not depend on which of them a given dask version installs.)
+
+### Readiness is polled on a real signal, never slept through
+
+The SSH launcher waits a fixed ten seconds and hopes. The srun launcher waits on the two facts it
+actually needs, and watches the process it started while it waits:
+
+| Wait | Signal | Failure it catches at once |
+| --- | --- | --- |
+| scheduler up | the connection file parses as JSON with an `address` | scheduler exited -- port in use, bad interpreter |
+| workers up | at least one worker registered with the scheduler | `srun` exited -- bad flags, request larger than the allocation |
+
+The file is written in place rather than renamed into place, so a reader can catch it half-written;
+requiring it to *parse* is what makes its appearance a readiness signal rather than a race. A
+scheduler file left over from an earlier run is deleted before the scheduler starts, so its
+reappearance proves this scheduler started rather than being indistinguishable from history.
+
+The worker check is the one that cannot be dropped. Connecting to our own scheduler always succeeds
+-- a scheduler with no workers is a perfectly good scheduler -- so a failed placement would
+otherwise surface as a fit that submits jobs and never gets one back, with the reason sitting
+unread in `srun`'s output. Both failures quote that output in the error.
+
+### Preconditions are refused, not discovered
+
+Outside an allocation, `srun` does not place a task: it *submits a job* and waits to be granted one.
+That failure would look like PyBNF hanging with no output, possibly for hours, so a missing
+`$SLURM_JOB_ID` is refused up front with a message naming the remedy (start PyBNF from the shell
+that holds the allocation -- the one `salloc` opened, or the `sbatch` script -- since a separate
+login into an allocated node does not inherit it).
+
+### The CPU request tracks the worker count
+
+The workers are placed as `--ntasks-per-node 1 --cpus-per-task N`, one `dask worker` launcher per
+node forking `N` single-threaded workers. `--cpus-per-task` is not decoration: under `task/cgroup`
+binding, a task that took the default single CPU confines every process it forks to that one CPU,
+which would quietly serialize a whole node while looking like a healthy cluster. So the request
+tracks the number of workers, capped at what the job actually holds -- SLURM refuses a request
+larger than the allocation, and a deliberately oversubscribed `parallel_count` (which the SSH
+launcher has always allowed) should not become a hard failure.
+
+Where that count comes from differs between the launchers, and deliberately so. This path reads
+`$SLURM_CPUS_ON_NODE` -- what the job was *granted* -- because it does not merely count workers with
+that number, it asks SLURM for that many CPUs, and a number taken from the whole machine would be
+refused. The SSH launcher still uses `multiprocessing.cpu_count()`; that it does so is issue #616,
+and it has to be fixed there rather than here.
+
+### `scheduler_file` names an output under this launcher
+
+Everywhere else, `scheduler_file` means *attach to a cluster someone else brought up* -- PyBNF starts
+nothing. Under the srun launcher PyBNF starts the scheduler that writes the file, so the key
+instead chooses **where** it is written, defaulting to `dask_scheduler.json` inside `output_dir`.
+The two readings are not in tension: with the launcher selected the user has explicitly asked PyBNF
+to bring the cluster up, so the file can only be an output. What PyBNF wrote it also removes at
+teardown, since a connection file naming a scheduler that is shutting down is exactly what the next
+run would mistake for a live cluster. A file PyBNF did not write is never touched.
+
+## Consequences
+
+* **Multi-machine fitting is possible on host-based and Kerberos clusters**, which is the whole
+  point. The reporter confirmed the approach on the cluster in #614: two workers started on two
+  separate machines on every attempt.
+* **What was verified where.** The behavior above -- both bring-up steps, both readiness checks,
+  the failure paths, and teardown -- was exercised end to end on one machine with stand-ins for
+  `srun` and `scontrol` on `PATH`: a real dask scheduler, two real workers, a real task computed
+  through the client, both processes gone after teardown. That validates the commands PyBNF
+  constructs and its own logic; it does not validate SLURM's placement semantics, which is what the
+  reporter's cluster test covers.
+* **Nothing changes for a run that does not ask for it.** `-t slurm`, `scheduler_node` /
+  `worker_nodes`, an attached `scheduler_file`, and every local run construct exactly the calls they
+  did before. The srun branch is entered only by the new `cluster_type` values.
+* **Two logs, in the output directory.** `dask_scheduler.log` and `dask_workers.log` are the only
+  record of what those processes said, since neither has a terminal. They are files rather than
+  pipes because both processes outlive the call that starts them and an undrained pipe would
+  eventually deadlock the writer.
+* **A failed bring-up leaves nothing running.** A constructor that raises never becomes a `Cluster`,
+  so nobody else can tear it down; the srun path stops what it started on the way out.
+* **Per-machine worker counts become expressible.** `dask ssh` takes one worker count for all hosts,
+  which is why #617 cannot be fixed on that path; `srun` is invoked per allocation and can be
+  invoked per node group, so this launcher is what that fix will be built on.
+* **`#398`'s complaint is not fixed, only not repeated.** The SSH launcher's two fixed ten-second
+  sleeps are untouched. The new path has none.
+
+## Alternatives considered
+
+* **Turn on paramiko's GSSAPI support in dask.** Rejected: it is an upstream change we do not
+  control, it would not help host-based clusters at all (paramiko cannot do host-based
+  authentication), and it would leave PyBNF's multi-machine support depending on a login that the
+  cluster is configured not to need.
+* **Shell out to the system `ssh` instead of paramiko.** This would honor whatever the cluster's own
+  SSH is configured to do, including both failing modes. Rejected because it means reimplementing
+  `dask ssh` -- remote process launch, log forwarding, teardown, failure detection -- inside PyBNF,
+  to solve a problem SLURM solves in one command for the clusters that have this problem in the
+  first place.
+* **Use `dask-jobqueue`'s `SLURMCluster`.** It submits *new* jobs and scales them, which is a
+  different execution model from PyBNF's (run inside the allocation the user already holds), would
+  change what a `-N 4` allocation means for a fit, and adds a dependency to fix a login bug.
+* **Make srun the only SLURM launcher.** Rejected: users whose SSH setup works today would be
+  migrated onto a path with different placement semantics and a hard requirement to be the only job
+  step in the allocation, for no benefit to them. #614 asks for a new value precisely so that they
+  are unaffected.
+* **Pass `--overlap` to `srun` so a second job step can always be created.** Rejected: the flag does
+  not exist before SLURM 20.11, where passing it turns a working bring-up into an immediate failure.
+  PyBNF launches exactly one job step, so the case it guards against is a user running another one
+  concurrently -- documented, and named in the timeout message, rather than paid for on every
+  cluster.
+* **Let the workers keep the default single CPU per task and rely on `--cpu-bind=none`.** Rejected:
+  where the binding comes from a cgroup, `--cpu-bind=none` does not widen it. Requesting the CPUs
+  the workers need is the only request that is honored under both task plugins.

--- a/docs/cluster.rst
+++ b/docs/cluster.rst
@@ -39,7 +39,43 @@ The above instructions assume that PyBNF can access all allocated nodes via SSH.
 
 To confirm that SSH keys are set up correctly, make sure that you are able to SSH into all allocated nodes without needing to enter a password.
 
-If SSH access is not possible on your cluster, you will have to use `Manual configuration with Dask`_.
+Setting up SSH keys does not help on every cluster. If your cluster's nodes authenticate to each other by host-based or Kerberos SSH, use `Starting workers without SSH`_ instead; if SSH access is not possible for some other reason, you can also fall back on `Manual configuration with Dask`_.
+
+.. _srun:
+
+Starting workers without SSH
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+``-t slurm`` starts the workers by logging in to each allocated node over SSH, using dask's ``dask-ssh`` command. That command logs in with the paramiko library, which offers only two ways of authenticating: a public key, or a password. Clusters commonly use two others:
+
+* **host-based authentication**, where the machines are configured to trust each other and no user credential is involved. paramiko does not support this at all.
+* **Kerberos (GSSAPI)**. paramiko can do this, but dask never turns it on.
+
+On a cluster that relies on either one, the login fails no matter what you configure -- even though ``ssh`` from the same shell succeeds -- and setting up SSH keys cannot fix it.
+
+Pass ``-t slurm-srun`` instead (or set ``cluster_type = slurm-srun``) to start the workers with SLURM's own ``srun`` command, which needs no credentials at all: the scheduler has already granted the allocation. PyBNF then
+
+1. starts a Dask scheduler on the node PyBNF itself is running on, and has it write a connection file -- ``dask_scheduler.json`` in the output directory, or wherever ``scheduler_file`` points;
+2. runs ``srun`` to start one Dask worker process group on each node of the allocation, each reading that file; and
+3. connects through that same file, waiting until at least one worker has registered before the fit starts.
+
+Run PyBNF from the shell that holds the allocation: the one ``salloc`` opened, or your ``sbatch`` script. A separate login into one of the allocated nodes does not inherit the allocation, and ``srun`` would then queue a new job rather than start the workers; PyBNF refuses to start in that case instead of appearing to hang. For the same reason, PyBNF should be the only job step running in the allocation, since a concurrent second ``srun`` can leave the workers waiting for resources.
+
+An example batch script, the ``-t slurm`` one with a single word changed::
+
+    #!/bin/bash
+    #SBATCH --nodes=4
+    #SBATCH --mincpus=32
+    #SBATCH --time=1-00:00:00
+    #SBATCH --job-name=pybnf
+
+    # Your cluster may require loading a module to get the right Python environment.
+    module load anaconda/Anaconda3
+
+    pybnf -c tcr-ss.conf -t slurm-srun -o
+
+By default, each node runs one single-threaded worker process per CPU the job was granted on that node. Setting ``parallel_count`` overrides that with a total number of worker processes over all nodes, divided evenly among them.
+
+Two log files are written to the output directory: ``dask_scheduler.log`` and ``dask_workers.log``. The second is where ``srun`` reports anything that went wrong with placing the workers, and PyBNF quotes from it in the error message if no worker ever registers.
 
 
 TORQUE/PBS

--- a/docs/config_keys.rst
+++ b/docs/config_keys.rst
@@ -971,7 +971,7 @@ Parallel Computing
 
   Each parallel job runs in its own **single-threaded worker process**, whether or not this key is set: the simulation backends hold process-wide state that is not thread-safe, so PyBNF never places two concurrently running jobs in one process. This key therefore sets a process count, not a thread count. Lowering it is the way to reduce the memory a run uses, since each worker process holds its own copy of the models.
 
-  Default: Use all available cores -- one single-threaded worker per core. Locally, the core count comes from Dask, which honors CPU affinity and cgroup quotas (so a run confined to 4 cores gets 4 workers, not the host's full count). On a cluster, the number of available cores per node is determined by running ``multiprocessing.cpu_count()`` from the scheduler node.
+  Default: Use all available cores -- one single-threaded worker per core. Locally, the core count comes from Dask, which honors CPU affinity and cgroup quotas (so a run confined to 4 cores gets 4 workers, not the host's full count). On a cluster, the number of available cores per node is determined by running ``multiprocessing.cpu_count()`` from the scheduler node; with ``cluster_type = slurm-srun`` it is instead the number of cores SLURM granted the job on a node (``$SLURM_CPUS_ON_NODE``).
 
   Example:
   
@@ -979,7 +979,12 @@ Parallel Computing
 
 **cluster_type**
   Type of cluster used for running the fit. This key may be omitted, and instead specified on the command line with the
-  ``-t`` flag. Currently supports ``slurm`` or ``none``.
+  ``-t`` flag. Currently supports ``slurm``, ``slurm-srun``, or ``none``.
+
+  ``slurm`` starts the workers by logging in to each allocated node over SSH. ``slurm-srun`` starts them with SLURM's
+  ``srun`` command instead, which requires no login and therefore works on clusters whose nodes authenticate to each
+  other by host-based or Kerberos SSH -- where the SSH route cannot work at all. It must be run from the shell that
+  holds the allocation. See :ref:`Starting workers without SSH <srun>`.
 
   Default: None (local fitting run).
 
@@ -1002,6 +1007,10 @@ Parallel Computing
 **scheduler_file**
   Provide a scheduler file to link PyBNF to a Dask scheduler already created outside of PyBNF. See :ref:`Manual configuration with Dask <manualdask>` for more information. 
   This option may also be specified on the command line with the ``-s`` flag. 
+
+  With ``cluster_type = slurm-srun``, PyBNF starts the scheduler itself, so this key instead chooses the path that
+  scheduler writes its connection information to. It must be on a filesystem the compute nodes share. Default in that
+  case: ``dask_scheduler.json`` inside ``output_dir``.
   
   Default: None
   

--- a/pybnf/cluster.py
+++ b/pybnf/cluster.py
@@ -1,13 +1,32 @@
-"""Functions for managing dask cluster setup and teardown on distributed computing systems"""
+"""Functions for managing dask cluster setup and teardown on distributed computing systems
+
+Two launchers bring up a multi-machine cluster, chosen by ``cluster_type``:
+
+* the **SSH launcher** (``cluster_type = slurm``, or ``scheduler_node`` / ``worker_nodes``
+  set by hand), which runs ``dask-ssh`` and therefore logs in to every node; and
+* the **srun launcher** (``cluster_type = slurm-srun``, #614), which never logs in
+  anywhere. It starts the scheduler here, has SLURM place one ``dask worker`` per node
+  inside the allocation the scheduler already granted, and connects through the scheduler
+  file the scheduler writes.
+
+The srun launcher exists because the SSH one cannot work at all on a cluster whose nodes
+authenticate to each other by host-based or Kerberos (GSSAPI) SSH: ``dask-ssh`` logs in
+with paramiko, which offers only public-key and password authentication -- it has no
+host-based support and dask never enables its GSSAPI support -- so on such a cluster the
+login fails no matter what the user configures, and no amount of ``ssh-keygen`` helps. See
+docs/adr/0122 for the full argument.
+"""
 
 
 from .printing import PybnfError
 
-from subprocess import run, TimeoutExpired, Popen, PIPE, CalledProcessError, DEVNULL
+from subprocess import run, TimeoutExpired, Popen, PIPE, CalledProcessError, DEVNULL, STDOUT
 from tempfile import TemporaryFile
 
+import json
 import logging
 import re
+import sys
 import time
 import numpy as np
 import os
@@ -18,6 +37,46 @@ from distributed import __version__ as distributedv
 from .config import init_logging, reinit_logging
 
 logger = logging.getLogger(__name__)
+
+
+# The cluster_type values that select the srun launcher (#614): ``slurm-srun`` is the
+# documented spelling; ``slurm_srun``, ``slurmsrun`` and a bare ``srun`` are accepted so a
+# reasonable guess is not answered with "Unknown cluster type". Matched with fullmatch, so
+# this never swallows a plain ``slurm`` (and, conversely, the SLURM branch's prefix match
+# must be tested *after* this one, since ``re.match('slurm', 'slurm-srun')`` succeeds).
+SRUN_CLUSTER_TYPE_RE = re.compile(r'(slurm[-_]?)?srun', flags=re.IGNORECASE)
+
+# What the srun launcher writes into the output directory. The scheduler file is how the
+# workers and this process find the scheduler, so it has to live on the shared filesystem
+# PyBNF already requires for a cluster run; the two logs are the only record of what the
+# scheduler and the srun-launched workers said, since neither has a terminal.
+SRUN_SCHEDULER_FILENAME = 'dask_scheduler.json'
+SRUN_SCHEDULER_LOG = 'dask_scheduler.log'
+SRUN_WORKER_LOG = 'dask_workers.log'
+
+# Readiness limits for the srun launcher. Both waits are polls on a real signal -- the
+# scheduler file appearing, and a worker registering with the scheduler -- rather than a
+# fixed sleep, and both also watch the launched process, so a bring-up that fails outright
+# is reported in the time it takes to fail rather than after the whole timeout (#398 asks
+# for the same treatment of the SSH path's two fixed 10 s sleeps, which this does not
+# touch).
+SCHEDULER_FILE_TIMEOUT = 60.
+SRUN_WORKER_TIMEOUT = 120.
+READINESS_POLL_INTERVAL = 0.25
+
+
+def uses_srun(cluster_type):
+    """
+    Whether this ``cluster_type`` selects the srun launcher (#614).
+
+    :param cluster_type: The configured cluster_type, or None for a local run
+    :type cluster_type: str or None
+    :return: True if workers should be started with srun rather than over SSH
+    :rtype: bool
+    """
+    if not cluster_type:
+        return False
+    return SRUN_CLUSTER_TYPE_RE.fullmatch(cluster_type.strip()) is not None
 
 
 class Cluster:
@@ -41,9 +100,43 @@ class Cluster:
         """
         logger.info('Initializing the Cluster')
 
+        # The process that starts the workers: dask-ssh on the SSH launcher, srun on the
+        # srun launcher. None for a local run or when attaching to a cluster someone else
+        # brought up.
+        self._dask_proc = None
+        # A dask scheduler PyBNF started itself, and the scheduler file it was told to
+        # write. Both are None unless the srun launcher is in use -- every other path
+        # either attaches to an existing scheduler or lets dask-ssh start one (#614).
+        self._scheduler_proc = None
+        self._own_scheduler_file = None
+        self._srun_worker_log = None
+
+        # Where the client should look for the scheduler. This is the user's
+        # ``scheduler_file`` when they are attaching to a cluster of their own, and the
+        # file PyBNF asks its own scheduler to write under the srun launcher.
+        scheduler_file = config.config['scheduler_file']
+
         # Find the name of the scheduler node, and a list of all available nodes (node_string), depending on what
         # cluster options are set
-        if config.config['scheduler_file']:
+        if uses_srun(config.config['cluster_type']):
+            # srun launcher (#614): no node names are needed to *reach* the nodes -- SLURM
+            # places the workers itself -- but the node count is, because it is what the
+            # per-node worker arithmetic divides by.
+            scheduler_node = None
+            node_string = None
+            if config.config['scheduler_node'] or config.config['worker_nodes']:
+                logger.warning('cluster_type = %s starts workers with srun, so the '
+                               'scheduler_node / worker_nodes keys are ignored.'
+                               % config.config['cluster_type'])
+            self.require_slurm_allocation()
+            scheduler_file = self.srun_scheduler_file(config)
+            self._own_scheduler_file = scheduler_file
+            out_dir = config.config['output_dir']
+            self._srun_worker_log = os.path.join(out_dir, SRUN_WORKER_LOG)
+            dummy, srun_nodes = self.read_node_names(config)
+            self._scheduler_proc, self._dask_proc = self.setup_srun_cluster(
+                scheduler_file, out_dir, len(srun_nodes.split()), config.config['parallel_count'])
+        elif config.config['scheduler_file']:
             # Scheduler node will be read in from scheduler file stored on shared file system
             node_string = None
             scheduler_node = None
@@ -58,15 +151,28 @@ class Cluster:
 
         if node_string:
             self._dask_proc = self.setup_cluster(node_string, os.getcwd(), config.config['parallel_count'])
-        else:
-            self._dask_proc = None
 
         logger.info(f'Initializing dask Client with dask v{daskv}, distributed v{distributedv}')
 
-        if config.config['scheduler_file']:
+        if self._scheduler_proc is not None:
+            # srun launcher: PyBNF owns the scheduler and the workers, so it is also the
+            # one path that can tell whether the workers arrived. Connecting to our own
+            # scheduler always succeeds -- a scheduler with no workers is a perfectly good
+            # scheduler -- so without the readiness check a failed placement would surface
+            # as a fit that submits jobs and never gets one back. Anything that fails here
+            # leaves processes we started running, so stop them before propagating.
+            logger.info('Creating a client using the scheduler file PyBNF wrote')
+            try:
+                self.client = Client(scheduler_file=scheduler_file)
+                self.local = False
+                self.wait_for_srun_workers(self.client, self._dask_proc, self._srun_worker_log)
+            except Exception:
+                self.stop_own_processes()
+                raise
+        elif scheduler_file:
             # Scheduler node read in from scheduler file stored on shared file system
             logger.info('Creating a client using the scheduler file')
-            self.client = Client(scheduler_file=config.config['scheduler_file'])
+            self.client = Client(scheduler_file=scheduler_file)
             self.local = False
         elif scheduler_node:
             logger.info(f'Creating a client by connecting to the scheduler node {scheduler_node}:8786')
@@ -135,7 +241,11 @@ class Cluster:
         # Set up cluster if necessary
         if config.config['cluster_type']:
             ctype = config.config['cluster_type']
-            if re.match('slurm', ctype, flags=re.IGNORECASE):
+            # The srun launcher is a SLURM cluster too -- it reads the same node list, and
+            # only the way the workers are *started* differs -- so it shares this branch.
+            # It has to be tested first: re.match('slurm', 'slurm-srun') succeeds, so the
+            # prefix test below cannot distinguish them (#614).
+            if uses_srun(ctype) or re.match('slurm', ctype, flags=re.IGNORECASE):
                 logger.debug('Detected selection of SLURM cluster')
                 # Build the command as an argument list and run it WITHOUT a
                 # shell (ROB-3). The node list comes from $SLURM_JOB_NODELIST,
@@ -217,13 +327,348 @@ class Cluster:
                                 else 'Check the cluster log directory for details.'))
         return dask_ssh_proc
 
+    # ----------------------------------------------------------------------- #
+    # The srun launcher (#614, ADR-0122): bring the cluster up without an SSH
+    # login, by asking SLURM to place the workers inside the allocation it has
+    # already granted.
+    # ----------------------------------------------------------------------- #
+
+    @staticmethod
+    def require_slurm_allocation():
+        """
+        Refuse the srun launcher when this process is not inside a SLURM allocation.
+
+        Outside an allocation ``srun`` does not place a task, it *submits a job* and then
+        waits for the scheduler to grant it -- so the failure this catches would otherwise
+        look like PyBNF hanging with no output, possibly for hours. The allocation is what
+        makes the launcher credential-free, so its absence is a configuration error.
+
+        :raises PybnfError: if no SLURM allocation is visible in the environment
+        """
+        if not (os.environ.get('SLURM_JOB_ID') or os.environ.get('SLURM_JOBID')):
+            logger.error('cluster_type selects the srun launcher, but $SLURM_JOB_ID is not set')
+            raise PybnfError('This cluster_type starts workers with srun, which must run inside a '
+                             'SLURM allocation, but no allocation was found ($SLURM_JOB_ID is not '
+                             'set).',
+                             hint=['Start PyBNF from the shell that holds the allocation: the one '
+                                   'salloc opened, or your sbatch script. A separate login to one '
+                                   'of the allocated nodes does not inherit it.',
+                                   'To run on nodes PyBNF reaches over SSH instead, set '
+                                   'cluster_type = slurm.'])
+
+    @staticmethod
+    def srun_scheduler_file(config):
+        """
+        The scheduler file the srun launcher writes, as an absolute path.
+
+        Under this launcher the scheduler file is an *output*: PyBNF starts the scheduler
+        that writes it. ``scheduler_file`` therefore chooses where it goes (useful when the
+        output directory is not the filesystem you want the workers to read connection
+        information from), and defaults to the output directory, which a cluster run
+        already requires to be shared.
+
+        :param config: PyBNF configuration
+        :type config: pybnf.config.Configuration
+        :return: absolute path of the scheduler file
+        :rtype: str
+        """
+        named = config.config['scheduler_file']
+        if named:
+            return os.path.abspath(named)
+        return os.path.abspath(os.path.join(config.config['output_dir'], SRUN_SCHEDULER_FILENAME))
+
+    @staticmethod
+    def cpus_per_node():
+        """
+        The number of CPUs the running job was granted on a node.
+
+        ``$SLURM_CPUS_ON_NODE`` is what the allocation actually granted; ``cpu_count()`` is
+        the size of the whole machine, which is only the same number when whole nodes were
+        allocated. The srun launcher reads the former because it does not merely count
+        workers with it -- it also asks SLURM for that many CPUs per task, and a request
+        larger than the allocation is refused outright. (The SSH launcher still uses
+        ``cpu_count()``; correcting that is issue #616, and it has to be corrected there
+        too rather than here.)
+
+        :return: CPUs granted per node, falling back to the machine's core count
+        :rtype: int
+        """
+        granted = os.environ.get('SLURM_CPUS_ON_NODE', '').strip()
+        if granted.isdigit() and int(granted) > 0:
+            return int(granted)
+        return cpu_count()
+
+    @staticmethod
+    def srun_worker_command(scheduler_file, node_count, parallel_count=None):
+        """
+        Build the srun invocation that starts one ``dask worker`` process group per node.
+
+        :param scheduler_file: Path of the scheduler file the workers should read
+        :type scheduler_file: str
+        :param node_count: Number of nodes in the allocation
+        :type node_count: int
+        :param parallel_count: Total number of worker processes over all nodes, or None for
+            one per granted CPU
+        :type parallel_count: int or None
+        :return: the srun argument list
+        :rtype: list
+        """
+        granted = Cluster.cpus_per_node()
+        if parallel_count is None:
+            n_per_node = granted
+        else:
+            # Same arithmetic as the SSH launcher: parallel_count is a total over all nodes.
+            # Per-node counts on nodes of different sizes are issue #617, which needs a
+            # per-node command either launcher can express -- ``dask ssh`` cannot.
+            n_per_node = max(1, int(np.ceil(parallel_count / node_count)))
+        # One task per node, each of which forks n_per_node single-threaded workers. The
+        # task has to be given CPUs for all of them: with task/cgroup binding, a task that
+        # asked for the default single CPU confines every process it forks to that one CPU,
+        # which would quietly serialize the whole node. Capped at what was granted so that
+        # a deliberately oversubscribed parallel_count still runs (SLURM refuses a request
+        # for more CPUs than the job holds) rather than failing the run.
+        cpus_per_task = max(1, min(n_per_node, granted))
+        logger.info('Starting %i worker process(es) per node on %i node(s), %i CPU(s) per node'
+                    % (n_per_node, node_count, cpus_per_task))
+        return ['srun',
+                '--nodes', str(node_count), '--ntasks', str(node_count),
+                '--ntasks-per-node', '1', '--cpus-per-task', str(cpus_per_task),
+                # Prefix each output line with its task number, so one log file records
+                # which node said what.
+                '--label',
+                # Run the worker with *this* interpreter rather than whatever ``dask`` the
+                # remote PATH resolves to: the launcher exists to remove ambiguity about
+                # which environment starts the workers, and PyBNF already requires the
+                # shared filesystem that makes this path valid on every node.
+                sys.executable, '-m', 'dask', 'worker',
+                '--scheduler-file', scheduler_file,
+                '--nworkers', str(n_per_node),
+                # One thread per worker, for the same reason every other PyBNF-built worker
+                # is single-threaded (#526, ADR-0089): the simulation backends hold
+                # process-wide state that is not thread-safe.
+                '--nthreads', '1']
+
+    @staticmethod
+    def setup_srun_cluster(scheduler_file, out_dir, node_count, parallel_count=None):
+        """
+        Start a dask scheduler here and a set of dask workers with srun, with no SSH login.
+
+        The scheduler runs as an ordinary subprocess of this process, on this node, and is
+        told to write ``scheduler_file``; the workers are one srun task per node, each
+        reading that file. Nothing authenticates anywhere: SLURM already granted the
+        allocation, which is the whole point of the launcher (#614).
+
+        :param scheduler_file: Path the scheduler should write its connection information to
+        :type scheduler_file: str
+        :param out_dir: Directory for the scheduler and worker logs
+        :type out_dir: str
+        :param node_count: Number of nodes in the allocation
+        :type node_count: int
+        :param parallel_count: Total number of worker processes over all nodes, or None
+        :type parallel_count: int or None
+        :return: the scheduler process and the srun process
+        :rtype: tuple
+        """
+        # Both of these would otherwise fail inside dask, or as a bare OSError from opening
+        # a log file, rather than as a configuration error naming the path at fault.
+        scheduler_dir = os.path.dirname(scheduler_file) or '.'
+        if not os.path.isdir(scheduler_dir):
+            raise PybnfError('Cannot write the dask scheduler file to %s: the directory does not '
+                             'exist.' % scheduler_file)
+        if not os.path.isdir(out_dir):
+            raise PybnfError('Cannot write the dask cluster logs to %s: the directory does not '
+                             'exist.' % out_dir)
+        # A scheduler file left behind by an earlier run names a scheduler that is no longer
+        # listening. Remove it up front, so that its reappearance is proof that *this*
+        # scheduler started rather than something we have to distinguish from history.
+        if os.path.exists(scheduler_file):
+            logger.info('Removing a scheduler file left over from an earlier run: %s' % scheduler_file)
+            os.remove(scheduler_file)
+
+        scheduler_log = os.path.join(out_dir, SRUN_SCHEDULER_LOG)
+        scheduler_cmd = [sys.executable, '-m', 'dask', 'scheduler', '--scheduler-file', scheduler_file]
+        logger.info('Starting the dask scheduler on this node, logging to %s' % scheduler_log)
+        scheduler_proc = Cluster.popen_logged(scheduler_cmd, scheduler_log)
+        try:
+            address = Cluster.wait_for_scheduler_file(scheduler_file, scheduler_proc, scheduler_log)
+        except Exception:
+            scheduler_proc.terminate()
+            raise
+        logger.info('The dask scheduler is listening at %s' % address)
+
+        worker_log = os.path.join(out_dir, SRUN_WORKER_LOG)
+        srun_cmd = Cluster.srun_worker_command(scheduler_file, node_count, parallel_count)
+        logger.info('Starting dask workers with srun, logging to %s' % worker_log)
+        srun_proc = Cluster.popen_logged(srun_cmd, worker_log)
+        return scheduler_proc, srun_proc
+
+    @staticmethod
+    def popen_logged(cmd, log_path):
+        """
+        Launch ``cmd`` with no shell, sending its output to ``log_path``.
+
+        Both srun-launcher processes outlive this call and neither has a terminal, so their
+        output has to go somewhere a user can read it afterwards -- and somewhere that
+        cannot fill up and deadlock the writer, as an undrained pipe would. stderr is
+        merged into stdout so one file reads in order.
+
+        :param cmd: The argument list to run
+        :type cmd: list
+        :param log_path: File to write the process output to
+        :type log_path: str
+        :return: subprocess.Popen
+        """
+        logger.debug('Running: %s' % ' '.join(cmd))
+        log_file = open(log_path, 'wb')
+        try:
+            return Popen(cmd, stdout=log_file, stderr=STDOUT)
+        finally:
+            # The child holds its own duplicate of the descriptor, so this handle is not
+            # needed once the process exists; the log is read back from disk when a failure
+            # has to be reported.
+            log_file.close()
+
+    @staticmethod
+    def log_tail(log_path, lines=20):
+        """
+        The last few lines of a log file, for inclusion in an error message.
+
+        :param log_path: File to read
+        :type log_path: str
+        :param lines: Number of trailing lines to keep
+        :type lines: int
+        :return: the trailing text, or '' if the file cannot be read
+        :rtype: str
+        """
+        try:
+            with open(log_path, 'rb') as f:
+                text = f.read().decode('UTF-8', errors='replace')
+        except OSError:
+            return ''
+        return '\n'.join(text.strip().splitlines()[-lines:])
+
+    @staticmethod
+    def wait_for_scheduler_file(scheduler_file, scheduler_proc, scheduler_log,
+                                timeout=SCHEDULER_FILE_TIMEOUT, poll=READINESS_POLL_INTERVAL):
+        """
+        Wait until the scheduler has written a usable scheduler file, and return its address.
+
+        The file is written without being renamed into place, so a reader can catch it
+        half-written; requiring it to parse as JSON carrying an address is what makes its
+        appearance a readiness signal rather than a race. The scheduler process is checked
+        on every pass, so a scheduler that dies (an occupied port, a bad interpreter) is
+        reported immediately instead of after the timeout.
+
+        :param scheduler_file: Path the scheduler was told to write
+        :type scheduler_file: str
+        :param scheduler_proc: The running scheduler process
+        :param scheduler_log: Path of the scheduler's log, quoted if it failed
+        :type scheduler_log: str
+        :param timeout: Seconds to wait before giving up
+        :type timeout: float
+        :param poll: Seconds between checks
+        :type poll: float
+        :return: the scheduler address recorded in the file
+        :rtype: str
+        :raises PybnfError: if the scheduler exits, or the file does not appear in time
+        """
+        for _ in range(max(1, int(timeout / poll))):
+            returncode = scheduler_proc.poll()
+            if returncode is not None:
+                details = Cluster.log_tail(scheduler_log)
+                logger.error('The dask scheduler exited with code %s during cluster bring-up. '
+                             'Log:\n%s' % (returncode, details))
+                raise PybnfError('The dask scheduler exited with code %s during cluster bring-up. %s'
+                                 % (returncode, ('Details:\n%s' % details) if details
+                                    else 'See %s for details.' % scheduler_log))
+            try:
+                with open(scheduler_file) as f:
+                    address = json.load(f).get('address')
+            except (OSError, ValueError):
+                address = None
+            if address:
+                return address
+            time.sleep(poll)
+        logger.error('The dask scheduler did not write %s within %s s' % (scheduler_file, timeout))
+        raise PybnfError('The dask scheduler did not write its connection file %s within %s s. '
+                         'See %s for details.' % (scheduler_file, timeout, scheduler_log))
+
+    @staticmethod
+    def wait_for_srun_workers(client, srun_proc, worker_log,
+                              timeout=SRUN_WORKER_TIMEOUT, poll=READINESS_POLL_INTERVAL):
+        """
+        Wait until at least one srun-launched worker has registered with the scheduler.
+
+        :param client: The connected dask Client
+        :param srun_proc: The running srun process
+        :param worker_log: Path of the srun output log, quoted if the workers never arrive
+        :type worker_log: str
+        :param timeout: Seconds to wait before giving up
+        :type timeout: float
+        :param poll: Seconds between checks
+        :type poll: float
+        :return: the number of workers that had registered
+        :rtype: int
+        :raises PybnfError: if srun exits, or no worker registers in time
+        """
+        for _ in range(max(1, int(timeout / poll))):
+            returncode = srun_proc.poll()
+            if returncode is not None:
+                details = Cluster.log_tail(worker_log)
+                logger.error('srun exited with code %s before any worker started. Log:\n%s'
+                             % (returncode, details))
+                raise PybnfError('srun exited with code %s before any dask worker started. %s'
+                                 % (returncode, ('Details:\n%s' % details) if details
+                                    else 'See %s for details.' % worker_log))
+            try:
+                n_workers = len(client.scheduler_info()['workers'])
+            except Exception:
+                n_workers = 0
+            if n_workers:
+                logger.info('%i dask worker process(es) registered with the scheduler' % n_workers)
+                return n_workers
+            time.sleep(poll)
+        details = Cluster.log_tail(worker_log)
+        logger.error('No dask worker registered within %s s. Log:\n%s' % (timeout, details))
+        raise PybnfError('No dask worker started by srun registered with the scheduler within '
+                         '%s s.%s' % (timeout, ('\nLog:\n%s' % details) if details else ''),
+                         hint=['Read %s: srun reports there what it is waiting for.' % worker_log,
+                               'A message about job step creation means another step already holds '
+                               'the allocation; run PyBNF as the only job step.'])
+
     def teardown(self):
         """
-        Terminates the process running the `dask-ssh` script after completion of fitting run
+        Terminates the processes PyBNF started for this run, after the fitting run completes
 
+        The worker launcher goes first and the scheduler second: terminating srun signals
+        the workers, which are the processes that would otherwise be left talking to a
+        scheduler that is already gone. Nothing here touches a cluster PyBNF did not start
+        -- ``scheduler_file`` and ``scheduler_node`` runs have no processes of their own.
         """
         logger.info('Closing client')
         self.client.close()
+        self.stop_own_processes()
+
+    def stop_own_processes(self):
+        """
+        Terminate the cluster processes PyBNF started, and remove the scheduler file it wrote
+
+        Separate from :meth:`teardown` because bring-up can fail before there is a client to
+        close, and the processes started up to that point still have to be stopped.
+        """
         if self._dask_proc:
-            logger.info('Closing dask-ssh subprocess')
+            logger.info('Closing the worker launcher subprocess')
             self._dask_proc.terminate()
+            self._dask_proc = None
+        if self._scheduler_proc:
+            logger.info('Closing the dask scheduler subprocess')
+            self._scheduler_proc.terminate()
+            self._scheduler_proc = None
+        if self._own_scheduler_file and os.path.exists(self._own_scheduler_file):
+            # The file names a scheduler that is being shut down, so leaving it in place
+            # would leave a live-looking connection file behind for the next run to find.
+            try:
+                os.remove(self._own_scheduler_file)
+            except OSError:
+                logger.debug('Could not remove the scheduler file %s' % self._own_scheduler_file)
+            self._own_scheduler_file = None

--- a/pybnf/pybnf.py
+++ b/pybnf/pybnf.py
@@ -128,9 +128,13 @@ def _build_arg_parser():
     parser.add_argument('-o', '--overwrite', action='store_true',
                         help='automatically overwrites existing folders if necessary')
     parser.add_argument('-t', '--cluster_type', action='store',
-                        help='optional string denoting the type of cluster')
+                        help='optional string denoting the type of cluster: "slurm" to start workers on the '
+                             'allocated nodes over SSH, or "slurm-srun" to start them with srun, which needs no '
+                             'login and so works on clusters that use host-based or Kerberos SSH')
     parser.add_argument('-s', '--scheduler_file', action='store',
-                        help='optional file on shared filesystem to get scheduler location, should be same as passed to dask-scheduler and dask-worker.')
+                        help='optional file on shared filesystem to get scheduler location, should be the same as '
+                             'the one passed to the dask scheduler and workers. With cluster_type "slurm-srun", '
+                             'PyBNF starts the scheduler itself and this instead chooses where it writes the file.')
     parser.add_argument('-r', '--resume', action='store', nargs='?', const=0, default=None, type=int,
                         metavar='iterations',
                         help='automatically resume the previously stopped fitting run; '

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -10,6 +10,13 @@ per-node arithmetic, or the ``Client(...)``/``LocalCluster(...)`` call the
 config selects. (For glue with no math, "the right command/Client call was
 made" *is* the oracle — not the mock-the-world anti-pattern.)
 
+The srun launcher (#614, ADR-0122) is tested the same way: its oracle is the
+``dask scheduler`` / ``srun ... dask worker`` argument lists PyBNF constructs,
+the readiness polls it makes on the scheduler file and the worker count, and
+the branch dispatch that keeps it away from ``dask-ssh``. No SLURM and no dask
+is involved -- ``Popen``, ``time.sleep`` and the ``Client`` are substituted, and
+the scheduler file is a real file in ``tmp_path``.
+
 Substitution strategy (per dependency):
   * ``cluster.run`` (subprocess) — **mock**: a recorder returning a fake proc
     with canned ``.stdout`` bytes, or raising ``TimeoutExpired`` /
@@ -26,7 +33,9 @@ dask/distributed internals or a pinned dask version (the version-specific
 ``reinit_logging`` workaround is asserted *to be called*, not pinned), so they
 remain a valid safety net across the dask-unpinning upgrade.
 """
+import json
 import os
+import sys
 import types
 
 import pytest
@@ -41,7 +50,7 @@ from .context import cluster, printing
 # --------------------------------------------------------------------------- #
 def _cfg(**overrides):
     base = {'scheduler_file': None, 'scheduler_node': None, 'worker_nodes': None,
-            'parallel_count': None, 'cluster_type': None}
+            'parallel_count': None, 'cluster_type': None, 'output_dir': 'pybnf_output'}
     base.update(overrides)
     return types.SimpleNamespace(config=base)
 
@@ -55,12 +64,17 @@ class _FakeProc:
 
 
 class _FakeDaskProc:
-    """Stand-in for the dask-ssh Popen object: setup_cluster only calls poll()."""
+    """Stand-in for a launched Popen object: the bring-up paths only poll it, and
+    terminate it when they have to abandon a partly-built cluster."""
     def __init__(self, returncode=None):
         self._returncode = returncode
+        self.terminated = False
 
     def poll(self):
         return self._returncode
+
+    def terminate(self):
+        self.terminated = True
 
 
 class TestReadNodeNames:
@@ -141,6 +155,16 @@ class TestReadNodeNames:
         capitalization takes the SLURM branch (and runs scontrol)."""
         monkeypatch.setattr(cluster, 'run', lambda *a, **k: _FakeProc(b'a\nb\n'))
         assert cluster.Cluster.read_node_names(_cfg(cluster_type=ctype)) == ('a', 'a b')
+
+    @pytest.mark.parametrize('ctype', ['slurm-srun', 'slurm_srun', 'SLURM-SRUN', 'srun'])
+    def test_srun_cluster_types_read_the_same_slurm_node_list(self, monkeypatch, ctype):
+        """#614: the srun launcher is a SLURM cluster too -- it reads the node list
+        the same way and only starts the workers differently -- so every srun
+        spelling takes the SLURM branch and returns the same names. This also pins
+        the ordering hazard: ``re.match('slurm', 'slurm-srun')`` succeeds, so a
+        prefix test placed first would have swallowed ``slurm-srun`` silently."""
+        monkeypatch.setattr(cluster, 'run', lambda *a, **k: _FakeProc(b'n1\nn2\n'))
+        assert cluster.Cluster.read_node_names(_cfg(cluster_type=ctype)) == ('n1', 'n1 n2')
 
     def test_timeout_maps_to_pybnf_error(self, monkeypatch):
         """scontrol hanging past the 10s timeout (TimeoutExpired) is translated to
@@ -296,13 +320,30 @@ class TestSetupCluster:
 # --------------------------------------------------------------------------- #
 # __init__ — node-detection dispatch + Client-construction dispatch
 # --------------------------------------------------------------------------- #
+class _ProcStub:
+    """Stand-in for a process PyBNF started and later terminates."""
+    def __init__(self, returncode=None):
+        self.terminated = False
+        self._returncode = returncode
+
+    def poll(self):
+        return self._returncode
+
+    def terminate(self):
+        self.terminated = True
+
+
 class _ClientStub:
-    def __init__(self):
+    def __init__(self, workers=('tcp://n1:1',)):
         self.run_calls = []
         self.closed = False
+        self._workers = dict.fromkeys(workers, {})
 
     def run(self, *args, **kwargs):
         self.run_calls.append((args, kwargs))
+
+    def scheduler_info(self):
+        return {'workers': self._workers}
 
     def close(self):
         self.closed = True
@@ -321,6 +362,8 @@ class _Recorder:
         self.reinit_logging_calls = []
         self.read_calls = []
         self.setup_calls = []
+        self.srun_setup_calls = []   # (scheduler_file, out_dir, node_count, parallel_count)
+        self.srun_wait_calls = []    # (client, srun_proc, worker_log)
 
     def Client(self, *args, **kwargs):
         self.client_calls.append((args, kwargs))
@@ -333,7 +376,7 @@ class _Recorder:
         return self.last_lc
 
 
-def _patch_init(monkeypatch, read_returns=(None, None)):
+def _patch_init(monkeypatch, read_returns=(None, None), srun_raises=None):
     rec = _Recorder()
     monkeypatch.setattr(cluster, 'Client', rec.Client)
     monkeypatch.setattr(cluster, 'LocalCluster', rec.LocalCluster)
@@ -350,8 +393,21 @@ def _patch_init(monkeypatch, read_returns=(None, None)):
         rec.setup_calls.append((node_string, out_dir, parallel_count))
         return 'PROC'
 
+    def fake_setup_srun(scheduler_file, out_dir, node_count, parallel_count):
+        rec.srun_setup_calls.append((scheduler_file, out_dir, node_count, parallel_count))
+        return _ProcStub(), _ProcStub()
+
+    def fake_wait(client, srun_proc, worker_log, **kwargs):
+        rec.srun_wait_calls.append((client, srun_proc, worker_log))
+        if srun_raises:
+            raise srun_raises
+        return 1
+
     monkeypatch.setattr(cluster.Cluster, 'read_node_names', staticmethod(fake_read))
     monkeypatch.setattr(cluster.Cluster, 'setup_cluster', staticmethod(fake_setup))
+    monkeypatch.setattr(cluster.Cluster, 'setup_srun_cluster', staticmethod(fake_setup_srun))
+    monkeypatch.setattr(cluster.Cluster, 'wait_for_srun_workers', staticmethod(fake_wait))
+    monkeypatch.setattr(cluster.Cluster, 'require_slurm_allocation', staticmethod(lambda: None))
     return rec
 
 
@@ -535,12 +591,14 @@ class TestLocalClusterKwargs:
 # --------------------------------------------------------------------------- #
 # teardown — close the client, terminate the dask-ssh proc only if it exists
 # --------------------------------------------------------------------------- #
-class _ProcStub:
-    def __init__(self):
-        self.terminated = False
-
-    def terminate(self):
-        self.terminated = True
+def _torn_down(client=None, dask_proc=None, scheduler_proc=None, scheduler_file=None):
+    """A Cluster built by hand, carrying only the attributes teardown reads."""
+    c = object.__new__(cluster.Cluster)
+    c.client = client if client is not None else _ClientStub()
+    c._dask_proc = dask_proc
+    c._scheduler_proc = scheduler_proc
+    c._own_scheduler_file = scheduler_file
+    return c
 
 
 class TestTeardown:
@@ -548,23 +606,604 @@ class TestTeardown:
     def test_closes_client_and_terminates_proc(self):
         """With a live dask-ssh proc, teardown closes the client and terminates
         the proc."""
-        c = object.__new__(cluster.Cluster)
-        c.client = _ClientStub()
-        c._dask_proc = _ProcStub()
+        proc = _ProcStub()
+        c = _torn_down(dask_proc=proc)
 
         c.teardown()
 
         assert c.client.closed is True
-        assert c._dask_proc.terminated is True
+        assert proc.terminated is True
 
     def test_no_proc_only_closes_client(self):
         """When _dask_proc is None (a local client with no dask-ssh subprocess),
         teardown closes the client and must NOT attempt to terminate None — an
         unconditional terminate would raise AttributeError here."""
-        c = object.__new__(cluster.Cluster)
-        c.client = _ClientStub()
-        c._dask_proc = None
+        c = _torn_down()
 
         c.teardown()  # must not raise
 
         assert c.client.closed is True
+
+    def test_srun_teardown_stops_workers_then_scheduler_and_removes_the_file(self, tmp_path):
+        """#614: under the srun launcher PyBNF owns both processes and the
+        scheduler file, so teardown terminates both and deletes the file. Order
+        matters -- srun (the workers) is signalled before the scheduler they talk
+        to -- and the file must go, since a connection file naming a scheduler
+        that is shutting down is exactly what the next run would mistake for a
+        live cluster."""
+        order = []
+        sched_file = tmp_path / 'dask_scheduler.json'
+        sched_file.write_text('{"address": "tcp://n1:8786"}')
+        srun_proc, scheduler_proc = _ProcStub(), _ProcStub()
+        srun_proc.terminate = lambda: order.append('workers')
+        scheduler_proc.terminate = lambda: order.append('scheduler')
+        c = _torn_down(dask_proc=srun_proc, scheduler_proc=scheduler_proc,
+                       scheduler_file=str(sched_file))
+
+        c.teardown()
+
+        assert c.client.closed is True
+        assert order == ['workers', 'scheduler']
+        assert not sched_file.exists()
+
+    def test_teardown_leaves_a_scheduler_file_pybnf_did_not_write(self, tmp_path):
+        """A ``scheduler_file`` run attaches to a cluster someone else brought up:
+        PyBNF neither started those processes nor wrote that file, so teardown
+        must not delete it (_own_scheduler_file is None on that path)."""
+        sched_file = tmp_path / 'their_cluster.json'
+        sched_file.write_text('{"address": "tcp://n1:8786"}')
+        c = _torn_down()
+
+        c.teardown()
+
+        assert sched_file.exists()
+
+    def test_stop_own_processes_is_idempotent(self, tmp_path):
+        """stop_own_processes runs both from a failed bring-up and from teardown,
+        so calling it twice must not terminate an already-terminated process or
+        fail on the file it just deleted."""
+        sched_file = tmp_path / 'dask_scheduler.json'
+        sched_file.write_text('{}')
+        srun_proc, scheduler_proc = _ProcStub(), _ProcStub()
+        c = _torn_down(dask_proc=srun_proc, scheduler_proc=scheduler_proc,
+                       scheduler_file=str(sched_file))
+
+        c.stop_own_processes()
+        c.stop_own_processes()  # must not raise
+
+        assert (srun_proc.terminated, scheduler_proc.terminated) == (True, True)
+        assert (c._dask_proc, c._scheduler_proc, c._own_scheduler_file) == (None, None, None)
+
+
+# --------------------------------------------------------------------------- #
+# The srun launcher (#614, ADR-0122)
+# --------------------------------------------------------------------------- #
+class TestUsesSrun:
+    """Which cluster_type values select the srun launcher."""
+
+    @pytest.mark.parametrize('ctype', ['slurm-srun', 'slurm_srun', 'slurmsrun', 'srun',
+                                       'SLURM-SRUN', 'Slurm_Srun', '  slurm-srun  '])
+    def test_accepted_spellings(self, ctype):
+        """The documented spelling is ``slurm-srun``; the underscore, run-together
+        and bare-``srun`` forms are accepted too, case-insensitively and with
+        surrounding whitespace stripped, so a reasonable guess is not answered
+        with "Unknown cluster type"."""
+        assert cluster.uses_srun(ctype) is True
+
+    @pytest.mark.parametrize('ctype', [None, '', 'slurm', 'SLURM', 'torque', 'pbs',
+                                       'srunny', 'slurm srun', 'srun-slurm'])
+    def test_rejected_spellings(self, ctype):
+        """Everything else is not the srun launcher. ``slurm`` in particular must
+        stay on the SSH launcher (matched here by fullmatch, so a value that
+        merely *starts* with a recognized word does not select it)."""
+        assert cluster.uses_srun(ctype) is False
+
+
+class TestRequireSlurmAllocation:
+
+    def test_allocation_present_is_accepted(self, monkeypatch):
+        """Inside an allocation, the check passes silently."""
+        monkeypatch.setenv('SLURM_JOB_ID', '12345')
+        cluster.Cluster.require_slurm_allocation()  # must not raise
+
+    def test_legacy_variable_is_accepted(self, monkeypatch):
+        """Older SLURM exports the allocation as $SLURM_JOBID; either name counts."""
+        monkeypatch.delenv('SLURM_JOB_ID', raising=False)
+        monkeypatch.setenv('SLURM_JOBID', '12345')
+        cluster.Cluster.require_slurm_allocation()  # must not raise
+
+    def test_no_allocation_is_refused_with_a_remedy(self, monkeypatch):
+        """Outside an allocation, srun does not *place* a task -- it submits a job
+        and waits for one, which would read as PyBNF hanging with no output. That
+        is refused up front, and the message says where to start PyBNF instead."""
+        monkeypatch.delenv('SLURM_JOB_ID', raising=False)
+        monkeypatch.delenv('SLURM_JOBID', raising=False)
+        with pytest.raises(printing.PybnfError) as exc:
+            cluster.Cluster.require_slurm_allocation()
+        assert 'SLURM_JOB_ID' in str(exc.value)
+        # The remedy is a hint, so it reaches the user's message without displacing
+        # the diagnosis (#527): both are present in what gets printed.
+        assert 'SLURM_JOB_ID' in exc.value.message
+        assert 'salloc' in exc.value.message
+
+
+class TestSrunSchedulerFile:
+
+    def test_defaults_into_the_output_directory(self):
+        """With no scheduler_file set, PyBNF writes the connection file into the
+        output directory -- which a cluster run already requires to be on the
+        shared filesystem the workers read. Absolute, so it means the same thing
+        in the srun command as it does here."""
+        path = cluster.Cluster.srun_scheduler_file(_cfg(output_dir='out'))
+        assert path == os.path.abspath(os.path.join('out', 'dask_scheduler.json'))
+
+    def test_scheduler_file_chooses_where_it_is_written(self):
+        """Under this launcher the scheduler file is an *output* (PyBNF starts the
+        scheduler that writes it), so scheduler_file selects the path rather than
+        naming a cluster to attach to."""
+        path = cluster.Cluster.srun_scheduler_file(
+            _cfg(scheduler_file='/shared/mine.json', output_dir='out'))
+        assert path == '/shared/mine.json'
+
+
+class TestCpusPerNode:
+
+    def test_reads_what_slurm_granted(self, monkeypatch):
+        """$SLURM_CPUS_ON_NODE is what the *allocation* granted, which is the
+        number the launcher can actually ask SLURM for."""
+        monkeypatch.setenv('SLURM_CPUS_ON_NODE', '12')
+        monkeypatch.setattr(cluster, 'cpu_count', lambda: 64)
+        assert cluster.Cluster.cpus_per_node() == 12
+
+    @pytest.mark.parametrize('value', [None, '', 'many', '0', '-4'])
+    def test_falls_back_to_the_machine_core_count(self, monkeypatch, value):
+        """With nothing usable in the environment, fall back to the machine's own
+        core count (the number the SSH launcher uses unconditionally)."""
+        monkeypatch.delenv('SLURM_CPUS_ON_NODE', raising=False)
+        if value is not None:
+            monkeypatch.setenv('SLURM_CPUS_ON_NODE', value)
+        monkeypatch.setattr(cluster, 'cpu_count', lambda: 64)
+        assert cluster.Cluster.cpus_per_node() == 64
+
+
+class TestSrunWorkerCommand:
+
+    def _patch(self, monkeypatch, granted=8):
+        monkeypatch.setenv('SLURM_CPUS_ON_NODE', str(granted))
+
+    def test_default_is_one_worker_per_granted_cpu(self, monkeypatch):
+        """parallel_count unset ⇒ one single-threaded worker per CPU the job holds
+        on a node, one srun task per node, and that task given all the CPUs its
+        workers need. Oracle: the exact argument list (a literal argv list run
+        with no shell, ROB-3), including the interpreter running the workers --
+        this process's own, not whatever ``dask`` the remote PATH resolves to."""
+        self._patch(monkeypatch, granted=8)
+        cmd = cluster.Cluster.srun_worker_command('/shared/s.json', 3, parallel_count=None)
+        assert cmd == ['srun', '--nodes', '3', '--ntasks', '3', '--ntasks-per-node', '1',
+                       '--cpus-per-task', '8', '--label',
+                       sys.executable, '-m', 'dask', 'worker',
+                       '--scheduler-file', '/shared/s.json',
+                       '--nworkers', '8', '--nthreads', '1']
+
+    def test_parallel_count_divides_per_node_with_ceil(self, monkeypatch):
+        """parallel_count is a total over all nodes, divided the same way the SSH
+        launcher divides it: ceil(5/3) = 2 workers per node (floor would give 1)."""
+        self._patch(monkeypatch, granted=8)
+        cmd = cluster.Cluster.srun_worker_command('/s.json', 3, parallel_count=5)
+        assert cmd[cmd.index('--nworkers') + 1] == '2'
+        assert cmd[cmd.index('--cpus-per-task') + 1] == '2'
+
+    def test_cpus_requested_match_the_workers_started(self, monkeypatch):
+        """The CPU request is not decoration: with task/cgroup binding, a task that
+        took the default single CPU would confine every worker it forks to that one
+        CPU and quietly serialize the node. So --cpus-per-task tracks --nworkers."""
+        self._patch(monkeypatch, granted=16)
+        cmd = cluster.Cluster.srun_worker_command('/s.json', 2, parallel_count=8)
+        assert cmd[cmd.index('--nworkers') + 1] == '4'
+        assert cmd[cmd.index('--cpus-per-task') + 1] == '4'
+
+    def test_oversubscription_caps_the_cpu_request_not_the_worker_count(self, monkeypatch):
+        """A parallel_count above what the job holds is the user deliberately
+        oversubscribing, which the SSH launcher has always allowed. SLURM refuses a
+        request for more CPUs than the job holds, so the *request* is capped at the
+        allocation while the requested number of workers still starts."""
+        self._patch(monkeypatch, granted=4)
+        cmd = cluster.Cluster.srun_worker_command('/s.json', 1, parallel_count=16)
+        assert cmd[cmd.index('--nworkers') + 1] == '16'
+        assert cmd[cmd.index('--cpus-per-task') + 1] == '4'
+
+    def test_never_asks_for_zero_workers(self, monkeypatch):
+        """parallel_count = 0 is not validated anywhere upstream; ``--nworkers 0``
+        would start a cluster that can never run a job, so the floor is one."""
+        self._patch(monkeypatch, granted=4)
+        cmd = cluster.Cluster.srun_worker_command('/s.json', 2, parallel_count=0)
+        assert cmd[cmd.index('--nworkers') + 1] == '1'
+        assert cmd[cmd.index('--cpus-per-task') + 1] == '1'
+
+    def test_workers_are_single_threaded(self, monkeypatch):
+        """Same policy as every other worker PyBNF starts (#526, ADR-0089): the
+        simulation backends hold process-wide state that is not thread-safe, so a
+        worker process runs one job at a time."""
+        self._patch(monkeypatch)
+        cmd = cluster.Cluster.srun_worker_command('/s.json', 2)
+        assert cmd[cmd.index('--nthreads') + 1] == '1'
+
+    def test_scheduler_file_is_one_literal_argument(self, monkeypatch):
+        """ROB-3: the path reaches srun as a single literal argv entry, so a path
+        carrying shell metacharacters is never interpreted by a shell."""
+        self._patch(monkeypatch)
+        cmd = cluster.Cluster.srun_worker_command('/tmp/a b$(whoami).json', 1)
+        assert cmd[cmd.index('--scheduler-file') + 1] == '/tmp/a b$(whoami).json'
+
+
+class _SchedulerSpy:
+    """A fake ``Popen`` for the srun launcher: records each command, and optionally
+    writes the scheduler file the way ``dask scheduler`` would."""
+
+    def __init__(self, scheduler_file=None, address='tcp://n1:8786', returncode=None,
+                 write_after=0, log_text=b''):
+        self.calls = []                       # (cmd, kwargs) per launch
+        self.procs = []
+        self._scheduler_file = scheduler_file
+        self._address = address
+        self._returncode = returncode
+        self._write_after = write_after       # polls to wait before the file appears
+        self._log_text = log_text
+
+    def __call__(self, cmd, **kwargs):
+        self.calls.append((cmd, kwargs))
+        if self._log_text:
+            kwargs['stdout'].write(self._log_text)
+            kwargs['stdout'].flush()
+        proc = _FakeDaskProc(self._returncode if len(self.calls) == 1 else None)
+        self.procs.append(proc)
+        if self._scheduler_file is not None and len(self.calls) == 1:
+            self._sleeps = 0
+        return proc
+
+    def sleep(self, _seconds):
+        """Stands in for time.sleep: the scheduler file appears after N polls."""
+        self._sleeps = getattr(self, '_sleeps', 0) + 1
+        if self._scheduler_file is not None and self._sleeps >= self._write_after:
+            with open(self._scheduler_file, 'w') as f:
+                json.dump({'type': 'Scheduler', 'address': self._address}, f)
+
+
+class TestWaitForSchedulerFile:
+
+    def test_returns_the_address_once_the_file_is_complete(self, monkeypatch, tmp_path):
+        """The scheduler's readiness signal is its connection file: the wait returns
+        the address the file names, so the caller can log where the cluster is."""
+        sched_file = tmp_path / 's.json'
+        spy = _SchedulerSpy(str(sched_file), address='tcp://10.0.0.1:8786', write_after=2)
+        monkeypatch.setattr(cluster.time, 'sleep', spy.sleep)
+        address = cluster.Cluster.wait_for_scheduler_file(
+            str(sched_file), _FakeDaskProc(), str(tmp_path / 'sched.log'))
+        assert address == 'tcp://10.0.0.1:8786'
+
+    def test_a_half_written_file_is_not_treated_as_ready(self, monkeypatch, tmp_path):
+        """dask writes the file in place rather than renaming it into place, so a
+        reader can catch it half-written. Requiring it to parse as JSON carrying an
+        address is what makes its appearance a readiness signal and not a race:
+        here the first poll sees a truncated file and the wait continues."""
+        sched_file = tmp_path / 's.json'
+        sched_file.write_text('{"type": "Sched')          # torn mid-write
+        polls = []
+
+        def fake_sleep(_seconds):
+            polls.append(1)
+            if len(polls) == 2:
+                sched_file.write_text('{"address": "tcp://n2:8786"}')
+
+        monkeypatch.setattr(cluster.time, 'sleep', fake_sleep)
+        address = cluster.Cluster.wait_for_scheduler_file(
+            str(sched_file), _FakeDaskProc(), str(tmp_path / 'sched.log'))
+        assert address == 'tcp://n2:8786'
+        assert len(polls) == 2                            # it kept waiting rather than failing
+
+    def test_a_dead_scheduler_is_reported_immediately_with_its_log(self, monkeypatch, tmp_path):
+        """A scheduler that exits (an occupied port, a bad interpreter) is reported
+        as soon as it exits rather than after the full timeout, and its log is
+        quoted -- that text is the only place the reason exists."""
+        log = tmp_path / 'sched.log'
+        log.write_text('OSError: [Errno 48] Address already in use')
+        monkeypatch.setattr(cluster.time, 'sleep', lambda *_: None)
+        with pytest.raises(printing.PybnfError) as exc:
+            cluster.Cluster.wait_for_scheduler_file(
+                str(tmp_path / 'absent.json'), _FakeDaskProc(returncode=1), str(log))
+        assert 'code 1' in str(exc.value)
+        assert 'Address already in use' in str(exc.value)
+
+    def test_a_file_that_never_appears_times_out_naming_the_log(self, monkeypatch, tmp_path):
+        """A scheduler that stays alive but never writes the file cannot be waited
+        on forever; the error names the file and the log to read."""
+        monkeypatch.setattr(cluster.time, 'sleep', lambda *_: None)
+        with pytest.raises(printing.PybnfError) as exc:
+            cluster.Cluster.wait_for_scheduler_file(
+                str(tmp_path / 'absent.json'), _FakeDaskProc(), str(tmp_path / 'sched.log'),
+                timeout=1.)
+        assert 'absent.json' in str(exc.value)
+        assert 'sched.log' in str(exc.value)
+
+
+class TestWaitForSrunWorkers:
+
+    def test_returns_once_a_worker_registers(self, monkeypatch):
+        """The readiness signal for the workers is a worker registering with the
+        scheduler -- not srun having been launched, which says nothing."""
+        monkeypatch.setattr(cluster.time, 'sleep', lambda *_: None)
+        n = cluster.Cluster.wait_for_srun_workers(
+            _ClientStub(workers=('tcp://n1:1', 'tcp://n2:1')), _FakeDaskProc(), '/log')
+        assert n == 2
+
+    def test_waits_while_the_cluster_is_still_empty(self, monkeypatch):
+        """A scheduler with no workers yet is not an error: the poll continues
+        until the workers arrive."""
+        client = _ClientStub(workers=())
+        polls = []
+
+        def fake_sleep(_seconds):
+            polls.append(1)
+            if len(polls) == 3:
+                client._workers = {'tcp://n1:1': {}}
+
+        monkeypatch.setattr(cluster.time, 'sleep', fake_sleep)
+        assert cluster.Cluster.wait_for_srun_workers(client, _FakeDaskProc(), '/log') == 1
+        assert len(polls) == 3
+
+    def test_a_transient_scheduler_error_is_not_fatal(self, monkeypatch):
+        """A failed round-trip to the scheduler during bring-up is a hiccup, not a
+        verdict: it counts as "no workers yet" and the poll continues."""
+        class _FlakyClient(_ClientStub):
+            def __init__(self):
+                super().__init__()
+                self.attempts = 0
+
+            def scheduler_info(self):
+                self.attempts += 1
+                if self.attempts == 1:
+                    raise OSError('connection reset')
+                return {'workers': {'tcp://n1:1': {}}}
+
+        monkeypatch.setattr(cluster.time, 'sleep', lambda *_: None)
+        assert cluster.Cluster.wait_for_srun_workers(_FlakyClient(), _FakeDaskProc(), '/log') == 1
+
+    def test_srun_exiting_early_is_reported_with_its_log(self, monkeypatch, tmp_path):
+        """srun exiting before any worker registered means the placement failed --
+        a bad flag, a request larger than the allocation. Reported at once, quoting
+        srun's own message rather than waiting out the timeout."""
+        log = tmp_path / 'workers.log'
+        log.write_text('srun: error: Unable to allocate resources')
+        monkeypatch.setattr(cluster.time, 'sleep', lambda *_: None)
+        with pytest.raises(printing.PybnfError) as exc:
+            cluster.Cluster.wait_for_srun_workers(
+                _ClientStub(workers=()), _FakeDaskProc(returncode=1), str(log))
+        assert 'code 1' in str(exc.value)
+        assert 'Unable to allocate resources' in str(exc.value)
+
+    def test_no_worker_in_time_names_the_log_and_the_step_hazard(self, monkeypatch, tmp_path):
+        """srun still running with no worker registered is the shape of a queued
+        job step: connecting to our own scheduler succeeded, so nothing else would
+        report it, and the fit would submit jobs no one takes. The message points
+        at srun's own log and at the likely cause."""
+        log = tmp_path / 'workers.log'
+        log.write_text('srun: Job step creation temporarily disabled, retrying')
+        monkeypatch.setattr(cluster.time, 'sleep', lambda *_: None)
+        with pytest.raises(printing.PybnfError) as exc:
+            cluster.Cluster.wait_for_srun_workers(
+                _ClientStub(workers=()), _FakeDaskProc(), str(log), timeout=1.)
+        assert 'srun: Job step creation' in str(exc.value)   # srun's own words, in the log
+        assert 'workers.log' in exc.value.message            # ... and where to read more
+        assert 'job step' in exc.value.message.lower()
+
+
+class TestSetupSrunCluster:
+
+    def test_starts_the_scheduler_here_then_the_workers_with_srun(self, monkeypatch, tmp_path):
+        """The whole point of the launcher: two commands, neither of which logs in
+        anywhere. The scheduler runs on this node as an ordinary subprocess and is
+        told to write the connection file; the workers are one srun task per node
+        reading that same file. Both are argv lists run with no shell, and both
+        write to a named log in the output directory (an undrained pipe would
+        deadlock a process that outlives this call)."""
+        sched_file = tmp_path / 'dask_scheduler.json'
+        spy = _SchedulerSpy(str(sched_file), write_after=1)
+        monkeypatch.setattr(cluster, 'Popen', spy)
+        monkeypatch.setattr(cluster.time, 'sleep', spy.sleep)
+        monkeypatch.setenv('SLURM_CPUS_ON_NODE', '4')
+
+        scheduler_proc, srun_proc = cluster.Cluster.setup_srun_cluster(
+            str(sched_file), str(tmp_path), 2, parallel_count=None)
+
+        (sched_cmd, sched_kwargs), (srun_cmd, srun_kwargs) = spy.calls
+        assert sched_cmd == [sys.executable, '-m', 'dask', 'scheduler',
+                             '--scheduler-file', str(sched_file)]
+        assert srun_cmd[0] == 'srun'
+        assert srun_cmd[srun_cmd.index('--scheduler-file') + 1] == str(sched_file)
+        assert srun_cmd[srun_cmd.index('--nworkers') + 1] == '4'
+        for kwargs in (sched_kwargs, srun_kwargs):
+            assert kwargs.get('shell', False) is False
+            assert kwargs['stderr'] is cluster.STDOUT
+            assert hasattr(kwargs['stdout'], 'write')
+        assert (tmp_path / 'dask_scheduler.log').exists()
+        assert (tmp_path / 'dask_workers.log').exists()
+        assert (scheduler_proc, srun_proc) == (spy.procs[0], spy.procs[1])
+
+    def test_the_workers_are_started_only_after_the_scheduler_is_ready(self, monkeypatch, tmp_path):
+        """Ordering is load-bearing: a worker started before the scheduler file
+        exists has nothing to read. srun is launched only after the wait returns."""
+        sched_file = tmp_path / 'dask_scheduler.json'
+        spy = _SchedulerSpy(str(sched_file), write_after=3)
+        launched_at = []
+
+        def fake_sleep(seconds):
+            launched_at.append(len(spy.calls))
+            spy.sleep(seconds)
+
+        monkeypatch.setattr(cluster, 'Popen', spy)
+        monkeypatch.setattr(cluster.time, 'sleep', fake_sleep)
+        cluster.Cluster.setup_srun_cluster(str(sched_file), str(tmp_path), 1)
+
+        assert launched_at == [1, 1, 1]      # only the scheduler was running while waiting
+        assert len(spy.calls) == 2
+
+    def test_a_stale_scheduler_file_is_removed_before_the_scheduler_starts(self, monkeypatch, tmp_path):
+        """A file left by an earlier run names a scheduler that is no longer
+        listening. It is removed first, so the file's reappearance is proof that
+        *this* scheduler started -- otherwise the wait would return instantly and
+        the client would connect to nothing."""
+        sched_file = tmp_path / 'dask_scheduler.json'
+        sched_file.write_text('{"address": "tcp://dead:8786"}')
+        spy = _SchedulerSpy(str(sched_file), address='tcp://live:8786', write_after=1)
+        seen = []
+        monkeypatch.setattr(cluster, 'Popen',
+                            lambda cmd, **k: seen.append(sched_file.exists()) or spy(cmd, **k))
+        monkeypatch.setattr(cluster.time, 'sleep', spy.sleep)
+
+        cluster.Cluster.setup_srun_cluster(str(sched_file), str(tmp_path), 1)
+
+        assert seen[0] is False                             # gone before the scheduler started
+        assert json.loads(sched_file.read_text())['address'] == 'tcp://live:8786'
+
+    def test_a_scheduler_that_dies_takes_no_srun_with_it(self, monkeypatch, tmp_path):
+        """If the scheduler never comes up, the workers are not started at all --
+        and the dead scheduler process is terminated rather than left behind by a
+        constructor that raised before there was a Cluster to tear down."""
+        spy = _SchedulerSpy(returncode=1, log_text=b'Address already in use')
+        monkeypatch.setattr(cluster, 'Popen', spy)
+        monkeypatch.setattr(cluster.time, 'sleep', lambda *_: None)
+
+        with pytest.raises(printing.PybnfError, match='scheduler exited'):
+            cluster.Cluster.setup_srun_cluster(
+                str(tmp_path / 'dask_scheduler.json'), str(tmp_path), 2)
+
+        assert len(spy.calls) == 1                          # srun was never launched
+        assert spy.procs[0].terminated is True
+
+    def test_a_missing_scheduler_file_directory_is_refused_up_front(self, tmp_path):
+        """A scheduler file in a directory that does not exist would fail inside
+        dask, as a traceback in a log file nobody is watching. Checked here, where
+        it can be a configuration error naming the path."""
+        with pytest.raises(printing.PybnfError, match='scheduler file .* does not exist'):
+            cluster.Cluster.setup_srun_cluster(
+                str(tmp_path / 'no_such_dir' / 's.json'), str(tmp_path), 1)
+
+    def test_a_missing_log_directory_is_refused_up_front(self, tmp_path):
+        """Likewise for the directory the logs go in: opening that file is the first
+        thing the bring-up does, and a bare OSError from it would reach the user as
+        "an unknown error ... please report this bug"."""
+        with pytest.raises(printing.PybnfError, match='logs .* does not exist'):
+            cluster.Cluster.setup_srun_cluster(
+                str(tmp_path / 's.json'), str(tmp_path / 'no_such_dir'), 1)
+
+
+class TestInitSrunDispatch:
+
+    def _cfg_srun(self, **overrides):
+        return _cfg(cluster_type='slurm-srun', **overrides)
+
+    def test_srun_type_never_reaches_dask_ssh(self, monkeypatch):
+        """#614's whole point: with the srun launcher selected, the SSH bring-up
+        must not run. (``re.match('slurm', 'slurm-srun')`` succeeds, so a dispatch
+        that tested the SSH branch first would have started dask-ssh here and
+        failed the login this issue is about.)"""
+        rec = _patch_init(monkeypatch, read_returns=('n1', 'n1 n2'))
+        c = _build(self._cfg_srun())
+
+        assert rec.setup_calls == []                        # no dask-ssh
+        assert len(rec.srun_setup_calls) == 1
+        assert c.local is False
+
+    def test_brings_up_srun_with_the_node_count_and_connects_by_file(self, monkeypatch):
+        """The srun bring-up gets the scheduler-file path, the output directory,
+        the *number* of nodes (all srun needs -- it places the workers itself) and
+        parallel_count; the client then connects through that file."""
+        rec = _patch_init(monkeypatch, read_returns=('n1', 'n1 n2 n3'))
+        c = _build(self._cfg_srun(output_dir='out', parallel_count=12))
+
+        expected_file = os.path.abspath(os.path.join('out', 'dask_scheduler.json'))
+        assert rec.srun_setup_calls == [(expected_file, 'out', 3, 12)]
+        assert rec.client_calls == [((), {'scheduler_file': expected_file})]
+        assert c._own_scheduler_file == expected_file
+
+    def test_scheduler_file_chooses_the_path_rather_than_an_existing_cluster(self, monkeypatch):
+        """With the srun launcher, scheduler_file says *where PyBNF writes*; the
+        cluster is still brought up. (Without the launcher the same key means the
+        opposite -- attach to a cluster someone else started -- and that path must
+        keep starting nothing.)"""
+        rec = _patch_init(monkeypatch, read_returns=('n1', 'n1'))
+        _build(self._cfg_srun(scheduler_file='/shared/mine.json'))
+        assert rec.srun_setup_calls[0][0] == '/shared/mine.json'
+        assert rec.client_calls == [((), {'scheduler_file': '/shared/mine.json'})]
+
+        rec = _patch_init(monkeypatch, read_returns=('n1', 'n1'))
+        c = _build(_cfg(scheduler_file='/shared/theirs.json'))
+        assert rec.srun_setup_calls == []
+        assert c._scheduler_proc is None
+
+    def test_the_allocation_is_checked_before_anything_is_started(self, monkeypatch):
+        """The refusal outside an allocation is a precondition, not a diagnosis
+        after the fact: nothing is launched and no client is built."""
+        real_check = cluster.Cluster.require_slurm_allocation
+        rec = _patch_init(monkeypatch, read_returns=('n1', 'n1'))
+        monkeypatch.delenv('SLURM_JOB_ID', raising=False)
+        monkeypatch.delenv('SLURM_JOBID', raising=False)
+        monkeypatch.setattr(cluster.Cluster, 'require_slurm_allocation', staticmethod(real_check))
+        with pytest.raises(printing.PybnfError, match='SLURM_JOB_ID'):
+            _build(self._cfg_srun())
+        assert rec.srun_setup_calls == []
+        assert rec.client_calls == []
+
+    def test_waits_for_the_workers_before_returning(self, monkeypatch):
+        """Handing back a client whose cluster has no workers would turn a failed
+        placement into a fit that submits jobs and never gets one back, so the
+        constructor does not return until a worker has registered."""
+        rec = _patch_init(monkeypatch, read_returns=('n1', 'n1 n2'))
+        c = _build(self._cfg_srun(output_dir='out'))
+
+        assert len(rec.srun_wait_calls) == 1
+        client, srun_proc, worker_log = rec.srun_wait_calls[0]
+        assert client is rec.last_client
+        assert srun_proc is c._dask_proc
+        assert worker_log == os.path.join('out', 'dask_workers.log')
+
+    def test_a_failed_worker_wait_stops_what_it_started(self, monkeypatch):
+        """A constructor that raises never becomes a Cluster, so no one else can
+        tear it down: the scheduler and srun processes it started are stopped on
+        the way out rather than left running in the allocation."""
+        rec = _patch_init(monkeypatch, read_returns=('n1', 'n1'),
+                          srun_raises=printing.PybnfError('no workers'))
+        started = []
+        faked_setup = cluster.Cluster.setup_srun_cluster   # the recorder _patch_init installed
+
+        def spy_setup(*args):
+            procs = faked_setup(*args)
+            started.extend(procs)
+            return procs
+
+        monkeypatch.setattr(cluster.Cluster, 'setup_srun_cluster', staticmethod(spy_setup))
+        with pytest.raises(printing.PybnfError, match='no workers'):
+            _build(self._cfg_srun())
+
+        assert [p.terminated for p in started] == [True, True]
+
+    def test_node_keys_are_ignored_with_a_warning(self, monkeypatch, caplog):
+        """scheduler_node / worker_nodes name machines to log in to, which this
+        launcher never does. They are ignored -- but loudly, since a user who set
+        them is expecting them to decide something."""
+        rec = _patch_init(monkeypatch, read_returns=('n1', 'n1 n2'))
+        with caplog.at_level('WARNING'):
+            _build(self._cfg_srun(scheduler_node='head', worker_nodes=['w1', 'w2']))
+
+        assert rec.setup_calls == []                       # no dask-ssh to those nodes
+        assert rec.client_calls[0][1].get('scheduler_file')  # connected by file, not to head:8786
+        assert any('ignored' in r.message for r in caplog.records)
+
+    def test_no_logging_broadcast_to_srun_workers(self, monkeypatch):
+        """Like every other remote path, the srun workers are not local processes
+        sharing this run's log file; init_logging is broadcast only to workers a
+        LocalCluster spawned here."""
+        rec = _patch_init(monkeypatch, read_returns=('n1', 'n1'))
+        _build(self._cfg_srun())
+        assert rec.last_client.run_calls == []
+        assert rec.reinit_logging_calls == [(('pf', False, 'INFO'), {})]


### PR DESCRIPTION
Closes #614.

## What was wrong

PyBNF had exactly one way to run a fit across several machines: run `dask-ssh`, which logs in to every allocated node. That command connects with **paramiko**, not with the operating system's `ssh`, and paramiko offers a public key or a password and nothing else. Clusters commonly use neither:

- **host-based authentication**, where the machines are configured to trust each other and no user credential exists to offer — paramiko cannot do this at all;
- **Kerberos / GSSAPI** — paramiko can, but dask never enables it.

On such a cluster the login fails no matter what the user configures, on a machine where `ssh OTHER hostname` from the same shell succeeds — and the advice in `docs/cluster.rst`, to create SSH keys, cannot fix a cluster that is not asking for a key. The run stops before a single simulation starts.

## What changed

`cluster_type = slurm-srun` (or `pybnf -t slurm-srun`) selects a second launcher that never logs in anywhere. No credential is involved because SLURM granted the allocation before PyBNF started:

1. a dask scheduler runs on the node PyBNF is on, writing a connection file;
2. `srun` places one dask worker process group on each node of the allocation, each reading that file;
3. the client connects through the same file.

Under this launcher the scheduler file is an **output**, so `scheduler_file` chooses where it is written (default `dask_scheduler.json` in `output_dir`) rather than naming a cluster to attach to; PyBNF removes the file it wrote at teardown. `-t slurm`, `scheduler_node` / `worker_nodes`, an attached `scheduler_file`, and every local run construct exactly the calls they did before — this is a second launcher, not a change to the existing one.

One ordering hazard is pinned by a test: `re.match('slurm', 'slurm-srun')` succeeds, so the srun test has to be made first, or the new value silently takes the SSH path it exists to avoid.

### Readiness, not sleeps

Both bring-up steps wait on a real signal and watch the process they started while waiting:

| wait | signal | failure caught at once |
| --- | --- | --- |
| scheduler up | the connection file **parses** as JSON with an `address` | scheduler exited — port in use, bad interpreter |
| workers up | at least one worker registered | `srun` exited — bad flags, request larger than the allocation |

dask writes that file in place rather than renaming it, so a reader can catch it half-written; requiring it to parse is what makes its appearance a readiness signal. A stale file from an earlier run is removed first, so its reappearance proves *this* scheduler started.

The worker check is the one that cannot be dropped: connecting to our own scheduler always succeeds (a scheduler with no workers is a perfectly good scheduler), so a failed placement would otherwise become a fit that submits jobs and never gets one back, with srun's explanation sitting unread in a log. Both failures quote that log, and a bring-up that fails stops what it started rather than leaving a scheduler running in the allocation.

Running outside an allocation is refused up front: there `srun` does not place a task, it submits a job and waits, which would read as PyBNF hanging.

### Placement

Workers are placed one task per node with the CPUs their processes need, taken from what SLURM granted (`$SLURM_CPUS_ON_NODE`): under `task/cgroup` binding, a task that took the default single CPU would confine every worker it forked to that one CPU and quietly serialize the node. `parallel_count` still means a total over all nodes, divided the way the SSH launcher divides it. Two logs, `dask_scheduler.log` and `dask_workers.log`, go to the output directory.

## Deliberately left out

The SSH launcher's own defects: the stale `dask-ssh` command name (#615), its whole-machine worker count (#616), per-machine counts (#617) — which this launcher makes expressible for the first time, since `dask ssh` takes one count for all hosts — and the fixed ten-second sleeps (#398). None of them is touched here.

## Verification

- End to end on one machine with stand-ins for `srun` and `scontrol` on `PATH`: a real dask scheduler, two real workers, a real task computed through the client, the stale-file and srun-failure paths, both processes gone after teardown. That covers the commands PyBNF constructs and its own logic — not SLURM's placement semantics, which the reporter confirmed on the cluster in #614 (two workers on two separate machines, every attempt).
- 43 new tests in `tests/test_cluster.py`; full suite green (4457 passed, 23 skipped).
- Docs build clean under the `-W` gate.

`docs/adr/0122` records the alternatives weighed, including enabling paramiko's GSSAPI in dask, shelling out to the system `ssh`, `dask-jobqueue`, and passing `--overlap`.
