### PR TITLE
fix(cluster): run `dask ssh`, the command dask still installs (#615)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -198,6 +198,30 @@ All notable changes to PyBNF are documented below. This project adheres to
   says what it has not bisected.
 
 ### Fixed
+- **Multi-machine fits run the command dask actually installs, so a cluster run gets past
+  its first second (#615).** PyBNF started remote workers by running **`dask-ssh`** — one of
+  three standalone scripts (with `dask-scheduler` and `dask-worker`) that distributed stopped
+  installing in **2026.6.0**. On any current install, every run that used more than one machine
+  died immediately with `FileNotFoundError: dask-ssh`, before a single simulation, on both
+  routes through that code: `-t slurm` and a hand-set `scheduler_node` / `worker_nodes`. The
+  same feature is now a subcommand of the unified `dask` program, and PyBNF runs it as
+  **`dask ssh`**.
+  The subcommand form is not a version trade: `ssh`, `scheduler` and `worker` are registered in
+  the `dask_cli` entry point group in **2024.1.0**, the oldest dask/distributed `pyproject.toml`
+  allows, so the fix works across the whole supported range and no floor had to move. PyBNF
+  invokes it as `<its own interpreter> -m dask ssh` rather than as a bare `dask` from `PATH`,
+  because `dask ssh` passes its own `sys.executable` on to the workers it starts remotely — a
+  `dask` picked up from `PATH` could therefore run the fit's workers under a different Python
+  than the fit.
+  A missing command is now **refused before anything is launched**, naming the subcommands the
+  installation does offer and the package that provides them, instead of surfacing as
+  `FileNotFoundError` inside "an unknown error … please report this bug". The check asks the
+  same `dask_cli` entry point group dask's own CLI builds its command set from, so it cannot
+  disagree with what `dask` will actually run — and the test that exercises it against the real
+  environment is the one that would have gone red for this issue, where every mocked assertion
+  stayed green against a command that no longer existed.
+  `docs/cluster.rst` and `tests/full_tests/cluster_manual.sh` now give `dask scheduler` and
+  `dask worker` for manual setups, for the same reason.
 - **The temporary directory dask leaves behind is now removed under the name dask actually
   creates (#620).** `_cleanup_dask_workspace` deleted `dask-worker-space` — the name dask used
   before it renamed the directory to `dask-scratch-space`. Every dask version the project

--- a/docs/cluster.rst
+++ b/docs/cluster.rst
@@ -45,7 +45,7 @@ Setting up SSH keys does not help on every cluster. If your cluster's nodes auth
 
 Starting workers without SSH
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-``-t slurm`` starts the workers by logging in to each allocated node over SSH, using dask's ``dask-ssh`` command. That command logs in with the paramiko library, which offers only two ways of authenticating: a public key, or a password. Clusters commonly use two others:
+``-t slurm`` starts the workers by logging in to each allocated node over SSH, using dask's ``dask ssh`` command. That command logs in with the paramiko library, which offers only two ways of authenticating: a public key, or a password. Clusters commonly use two others:
 
 * **host-based authentication**, where the machines are configured to trust each other and no user credential is involved. paramiko does not support this at all.
 * **Kerberos (GSSAPI)**. paramiko can do this, but dask never turns it on.
@@ -102,23 +102,25 @@ PyBNF uses `Dask.distributed <http://distributed.readthedocs.io/en/latest/index.
 
 For a local (single-machine) run, PyBNF builds a Dask ``LocalCluster`` with one thread per worker process, and as many worker processes as there are available cores (or ``parallel_count`` of them, if that key is set). One thread per worker is not tunable: the simulation backends hold process-wide state that is not thread-safe, so two jobs running concurrently in one process can interfere with each other.
 
-In the automatic PyBNF setup, the command ``dask-ssh`` is run on one of the available nodes (which becomes the scheduler node), with all available nodes as arguments (which become the worker nodes). ``dask-ssh`` is run with ``--nthreads 1`` and ``--nworkers`` equal to the number of available cores per node. The default number of available processes per core is the value returned by ``multiprocessing.cpu_count()``; this default can be overridden by specifying the ``parallel_count`` key equal to the total number of processes over all nodes. This entire automatic setup with ``dask-ssh`` can be overridden as described below. If overriding the automatic setup, it is recommended to keep ``nthreads`` equal to 1 for SBML models because the SBML simulator is not thread safe.
+In the automatic PyBNF setup, the command ``dask ssh`` is run on one of the available nodes (which becomes the scheduler node), with all available nodes as arguments (which become the worker nodes). ``dask ssh`` is run with ``--nthreads 1`` and ``--nworkers`` equal to the number of available cores per node. The default number of available processes per core is the value returned by ``multiprocessing.cpu_count()``; this default can be overridden by specifying the ``parallel_count`` key equal to the total number of processes over all nodes. This entire automatic setup with ``dask ssh`` can be overridden as described below. If overriding the automatic setup, it is recommended to keep ``nthreads`` equal to 1 for SBML models because the SBML simulator is not thread safe.
 
 For manual configuration, you will need to run the series of commands described below. All of these commands must remain running during the entire PyBNF run. Utilites such as ``nohup`` or ``screen`` are helpful for keeping multiple commands running at once. 
 
-To begin, run the command ``dask-scheduler`` on the node you want to use as the scheduler. Pass the argument ``--scheduler-file`` to create a JSON-encoded text file containing connection information. For example:
+To begin, run the command ``dask scheduler`` on the node you want to use as the scheduler. Pass the argument ``--scheduler-file`` to create a JSON-encoded text file containing connection information. For example:
 
-    :command:`dask-scheduler --scheduler-file cluster.json`
+    :command:`dask scheduler --scheduler-file cluster.json`
 
-On each node you want to use as a worker, run the command ``dask-worker``. Pass the scheduler file, and also specify the number of processes and threads per process to use on that worker. For example:
+On each node you want to use as a worker, run the command ``dask worker``. Pass the scheduler file, and also specify the number of processes and threads per process to use on that worker. For example:
 
-    :command:`dask-worker --scheduler-file cluster.json --nworkers 32 --nthreads 1`
+    :command:`dask worker --scheduler-file cluster.json --nworkers 32 --nthreads 1`
+
+(These are subcommands of the single ``dask`` program. Older versions of dask also installed them as separate ``dask-scheduler`` and ``dask-worker`` programs; those were dropped in distributed 2026.6.0, and the subcommand form works in every version PyBNF supports.)
 
 Finally, run PyBNF, and pass PyBNF the scheduler file using the ``-s`` command line argument or the ``scheduler_file`` configuration key:
 
     :command:`pybnf -c fit.conf -s cluster.json`
     
-For additional ``dask-scheduler`` and ``dask-worker`` options, refer to the `Dask.distributed <http://distributed.readthedocs.io/en/latest/index.html>`_ documentation.
+For additional ``dask scheduler`` and ``dask worker`` options, refer to the `Dask.distributed <http://distributed.readthedocs.io/en/latest/index.html>`_ documentation.
 
 (Optional) Logging configuration for remote machines
 ----------------------------------------------------

--- a/pybnf/cluster.py
+++ b/pybnf/cluster.py
@@ -3,14 +3,14 @@
 Two launchers bring up a multi-machine cluster, chosen by ``cluster_type``:
 
 * the **SSH launcher** (``cluster_type = slurm``, or ``scheduler_node`` / ``worker_nodes``
-  set by hand), which runs ``dask-ssh`` and therefore logs in to every node; and
+  set by hand), which runs ``dask ssh`` and therefore logs in to every node; and
 * the **srun launcher** (``cluster_type = slurm-srun``, #614), which never logs in
   anywhere. It starts the scheduler here, has SLURM place one ``dask worker`` per node
   inside the allocation the scheduler already granted, and connects through the scheduler
   file the scheduler writes.
 
 The srun launcher exists because the SSH one cannot work at all on a cluster whose nodes
-authenticate to each other by host-based or Kerberos (GSSAPI) SSH: ``dask-ssh`` logs in
+authenticate to each other by host-based or Kerberos (GSSAPI) SSH: ``dask ssh`` logs in
 with paramiko, which offers only public-key and password authentication -- it has no
 host-based support and dask never enables its GSSAPI support -- so on such a cluster the
 login fails no matter what the user configures, and no amount of ``ssh-keygen`` helps. See
@@ -20,6 +20,8 @@ docs/adr/0122 for the full argument.
 
 from .printing import PybnfError
 
+from importlib.metadata import entry_points
+from importlib.util import find_spec
 from subprocess import run, TimeoutExpired, Popen, PIPE, CalledProcessError, DEVNULL, STDOUT
 from tempfile import TemporaryFile
 
@@ -65,6 +67,60 @@ SRUN_WORKER_TIMEOUT = 120.
 READINESS_POLL_INTERVAL = 0.25
 
 
+# How PyBNF invokes dask's command line interface (#615). Two things are decided here.
+#
+# **The subcommand form.** PyBNF used to run ``dask-ssh``, one of three standalone scripts
+# (with ``dask-scheduler`` and ``dask-worker``) that distributed stopped installing in
+# 2026.6.0 -- so on any current install every multi-machine run died immediately on
+# ``FileNotFoundError: dask-ssh``, before a single simulation. The same features are
+# subcommands of the unified ``dask`` program, and have been since well before 2024.1.0,
+# the oldest dask/distributed pyproject.toml allows: that release already registers
+# ``ssh``, ``scheduler`` and ``worker`` in the ``dask_cli`` entry point group the CLI
+# builds itself from. So the new form works across the whole supported range, and no
+# version floor has to move.
+#
+# **Through this interpreter, not through PATH.** ``dask ssh`` propagates its own
+# ``sys.executable`` into the commands it starts on the remote nodes, so a ``dask``
+# resolved from PATH -- a system-wide one, say, when PyBNF is run from a virtualenv by
+# absolute path without activating it -- would start the remote workers under a different
+# Python than the one running the fit. ``-m`` makes the environment that runs the workers
+# the same one that runs PyBNF, by construction.
+DASK_CLI = [sys.executable, '-m', 'dask']
+
+
+def check_dask_subcommand(subcommand):
+    """
+    Confirm that ``dask <subcommand>`` can be run by this interpreter, before running it.
+
+    A missing command surfaces as ``FileNotFoundError`` or an unrecognized-command exit
+    from a subprocess PyBNF launched -- either an "unknown error ... please report this
+    bug" traceback or, worse, a bring-up that fails ten seconds later for a reason the
+    user has to go digging for (#615). This is the same question dask's own CLI asks when
+    it assembles its command group: subcommands come from the ``dask_cli`` entry point
+    group, so anything this check cannot see, ``dask`` cannot run either.
+
+    :param subcommand: The dask subcommand PyBNF is about to run, e.g. 'ssh'
+    :type subcommand: str
+    :raises PybnfError: if this interpreter has no dask CLI, or no such subcommand
+    """
+    if find_spec('dask.__main__') is None:
+        logger.error('The installed dask has no command line interface (dask.__main__)')
+        raise PybnfError('The installed dask (v%s) has no command line interface, which PyBNF '
+                         'needs to start workers on other machines.' % daskv,
+                         hint=['Install dask 2024.1.0 or newer in the environment running '
+                               'PyBNF (%s).' % sys.executable])
+    available = sorted(ep.name for ep in entry_points(group='dask_cli'))
+    if subcommand not in available:
+        logger.error("The dask CLI has no '%s' subcommand; it offers: %s"
+                     % (subcommand, ', '.join(available) or 'nothing'))
+        raise PybnfError("The installed dask has no '%s' subcommand, which PyBNF needs to start "
+                         "workers on other machines. Available subcommands: %s."
+                         % (subcommand, ', '.join(available) or 'none'),
+                         hint=["'%s' is provided by the distributed package (v%s here); install "
+                               'distributed 2024.1.0 or newer alongside dask in the environment '
+                               'running PyBNF (%s).' % (subcommand, distributedv, sys.executable)])
+
+
 def uses_srun(cluster_type):
     """
     Whether this ``cluster_type`` selects the srun launcher (#614).
@@ -100,13 +156,13 @@ class Cluster:
         """
         logger.info('Initializing the Cluster')
 
-        # The process that starts the workers: dask-ssh on the SSH launcher, srun on the
+        # The process that starts the workers: dask ssh on the SSH launcher, srun on the
         # srun launcher. None for a local run or when attaching to a cluster someone else
         # brought up.
         self._dask_proc = None
         # A dask scheduler PyBNF started itself, and the scheduler file it was told to
         # write. Both are None unless the srun launcher is in use -- every other path
-        # either attaches to an existing scheduler or lets dask-ssh start one (#614).
+        # either attaches to an existing scheduler or lets dask ssh start one (#614).
         self._scheduler_proc = None
         self._own_scheduler_file = None
         self._srun_worker_log = None
@@ -206,13 +262,13 @@ class Cluster:
         (issue #525 caught exactly that: concurrent emissions through bngsim's cached
         sympy->C printer intermittently reported ordinary quotients as non-differentiable,
         which killed a `trf` fit). Every other client PyBNF builds is already single-threaded
-        per worker: both ``dask-ssh`` branches pass ``--nthreads 1``, and the manual-setup
+        per worker: both ``dask ssh`` branches pass ``--nthreads 1``, and the manual-setup
         documentation recommends the same. Only the local *default* used to let dask pick,
         so a user who set nothing got the less safe configuration.
 
         ``n_workers`` is left to dask when ``parallel_count`` is None: given one thread per
         worker, dask sizes the pool at one worker per available core (``dask.system.CPU_COUNT``,
-        which honors CPU affinity and cgroup quotas), matching the ``dask-ssh`` default of
+        which honors CPU affinity and cgroup quotas), matching the ``dask ssh`` default of
         ``--nworkers <cores> --nthreads 1``. Total concurrency is therefore unchanged from the
         old default -- the same number of jobs run at once, each in its own process.
 
@@ -282,39 +338,45 @@ class Cluster:
     @staticmethod
     def setup_cluster(node_string, out_dir, parallel_count=None):
         """
-        Sets up a Dask cluster using the `dask-ssh` convenience script
+        Sets up a Dask cluster using the `dask ssh` command
 
         :param node_string: A string composed of a list of compute nodes
         :param out_dir: A directory for cluster logging output
         :param parallel_count: Total number of parallel threads to use over all nodes. If None, use all available threads
-            (the dask-ssh default)
+            (the dask ssh default)
         :return: subprocess.Popen
         """
-        logger.info(f'Starting dask-ssh subprocess using nodes {node_string}')
-        # Build the dask-ssh invocation as an argument list and launch it WITHOUT
+        # Ask before launching, so a dask that cannot do this reads as a configuration
+        # error rather than as a FileNotFoundError traceback from Popen (#615).
+        check_dask_subcommand('ssh')
+        logger.info(f'Starting dask ssh subprocess using nodes {node_string}')
+        # Build the dask ssh invocation as an argument list and launch it WITHOUT
         # a shell (ROB-3): each node name becomes its own literal argv entry, so
         # node names from config/SLURM can't be interpreted by a shell.
+        # The command is `dask ssh`, not the `dask-ssh` script PyBNF used to run:
+        # distributed stopped installing that script in 2026.6.0 (#615). See DASK_CLI
+        # for why it is invoked through this interpreter rather than found on PATH.
         # The per-host worker-count flag is --nworkers. distributed renamed it
         # from --nprocs (the old name was deprecated ~2022.10 and removed by
         # 2023.x), so --nprocs no longer parses on any supported dask version
         # (pyproject pins dask/distributed >=2024.1.0).
         nodes = node_string.split()
         if parallel_count is None:
-            dask_ssh_cmd = ['dask-ssh', *nodes,
+            dask_ssh_cmd = [*DASK_CLI, 'ssh', *nodes,
                             '--log-directory', out_dir, '--nthreads', '1', '--nworkers', str(cpu_count())]
         else:
             n_per_node = int(np.ceil(parallel_count/len(nodes)))
             logger.info('Manually setting %i workers per node' % n_per_node)
-            dask_ssh_cmd = ['dask-ssh', *nodes,
+            dask_ssh_cmd = [*DASK_CLI, 'ssh', *nodes,
                             '--log-directory', out_dir, '--nworkers', str(n_per_node), '--nthreads', '1']
-        # Capture stderr to a temp file rather than a PIPE: dask-ssh stays
+        # Capture stderr to a temp file rather than a PIPE: dask ssh stays
         # running for the whole fit, and an undrained PIPE would deadlock once
         # its buffer fills. A regular file lets us surface an early bring-up
         # failure below without that risk.
         dask_ssh_err = TemporaryFile()
         dask_ssh_proc = Popen(dask_ssh_cmd, stdout=DEVNULL, stderr=dask_ssh_err)
         time.sleep(10)
-        # If dask-ssh has already exited, the cluster never came up. Surface the
+        # If dask ssh has already exited, the cluster never came up. Surface the
         # failure here instead of letting it resurface later as an opaque dask
         # Client connection error.
         returncode = dask_ssh_proc.poll()
@@ -322,8 +384,8 @@ class Cluster:
             dask_ssh_err.seek(0)
             err_text = dask_ssh_err.read().decode('UTF-8', errors='replace').strip()
             dask_ssh_err.close()
-            logger.error(f'dask-ssh exited with code {returncode} during cluster bring-up. stderr:\n{err_text}')
-            raise PybnfError('Failed to start the dask-ssh cluster (dask-ssh exited with code {}). {}'.format(returncode, (f'Details:\n{err_text}') if err_text
+            logger.error(f'dask ssh exited with code {returncode} during cluster bring-up. stderr:\n{err_text}')
+            raise PybnfError('Failed to start the dask ssh cluster (dask ssh exited with code {}). {}'.format(returncode, (f'Details:\n{err_text}') if err_text
                                 else 'Check the cluster log directory for details.'))
         return dask_ssh_proc
 
@@ -439,8 +501,8 @@ class Cluster:
                 # Run the worker with *this* interpreter rather than whatever ``dask`` the
                 # remote PATH resolves to: the launcher exists to remove ambiguity about
                 # which environment starts the workers, and PyBNF already requires the
-                # shared filesystem that makes this path valid on every node.
-                sys.executable, '-m', 'dask', 'worker',
+                # shared filesystem that makes this path valid on every node (DASK_CLI).
+                *DASK_CLI, 'worker',
                 '--scheduler-file', scheduler_file,
                 '--nworkers', str(n_per_node),
                 # One thread per worker, for the same reason every other PyBNF-built worker
@@ -485,8 +547,10 @@ class Cluster:
             logger.info('Removing a scheduler file left over from an earlier run: %s' % scheduler_file)
             os.remove(scheduler_file)
 
+        check_dask_subcommand('scheduler')
+        check_dask_subcommand('worker')
         scheduler_log = os.path.join(out_dir, SRUN_SCHEDULER_LOG)
-        scheduler_cmd = [sys.executable, '-m', 'dask', 'scheduler', '--scheduler-file', scheduler_file]
+        scheduler_cmd = [*DASK_CLI, 'scheduler', '--scheduler-file', scheduler_file]
         logger.info('Starting the dask scheduler on this node, logging to %s' % scheduler_log)
         scheduler_proc = Cluster.popen_logged(scheduler_cmd, scheduler_log)
         try:

--- a/pybnf/pset.py
+++ b/pybnf/pset.py
@@ -221,9 +221,9 @@ def _subprocess_env(cmd, env=None):
 # or normal completion) by SIGKILL-ing each recorded group -- see
 # reap_active_sims(). The directory is node-local (each host's own tempdir), so
 # its PGIDs are only ever killed by a process on the same host, because killpg is
-# host-local. Remote dask-ssh worker nodes get no registry (the env var below is
-# not inherited across ssh); their orphans are cleaned by SLURM's cgroup tracking
-# at step/job teardown.
+# host-local. Remote cluster worker nodes get no registry (the env var below is
+# inherited by neither an ssh login nor an srun task); their orphans are cleaned by
+# SLURM's cgroup tracking at step/job teardown.
 #
 # Storage is bounded: the files are empty (the PGID *is* the filename) and are
 # removed when their sim finishes, so the live count tracks the number of

--- a/pybnf/pybnf.py
+++ b/pybnf/pybnf.py
@@ -588,7 +588,7 @@ def _reap_running_sims():
     Called from ``main()``'s finally on every exit. On a clean finish it is a
     no-op (finished sims have deregistered); on a Ctrl-C or crash it kills the
     in-flight, detached sim process groups that would otherwise orphan (the
-    "kill -9 needed" problem). Local node only: sims on remote dask-ssh worker
+    "kill -9 needed" problem). Local node only: sims on remote worker
     nodes are cleaned by SLURM's cgroup tracking at step/job teardown.
     """
     try:
@@ -601,7 +601,7 @@ def _reap_running_sims():
 
 def _teardown_cluster(cluster):
     """Tear down the dask cluster after a run, logging (not raising on) any failure."""
-    # Stop dask-ssh regardless of success
+    # Stop the cluster's worker launcher (dask ssh, or srun) regardless of success
     if cluster:
         try:
             cluster.teardown()

--- a/tests/full_tests/cluster_manual.sh
+++ b/tests/full_tests/cluster_manual.sh
@@ -16,12 +16,14 @@
 # Enable Python virtual environment. Edit this depending on your Python configuration. 
 source $P/python_envs/env1/bin/activate
 
-# Automatically set up dask-scheduler and dask-worker on the cluster allocation. 
-# This block should probably work for any SLURM cluster
-dask-scheduler --scheduler-file sf &
-workerpath=$(which dask-worker)
+# Automatically set up the dask scheduler and workers on the cluster allocation. 
+# This block should probably work for any SLURM cluster.
+# `dask scheduler` and `dask worker` are subcommands of the single `dask` program; the
+# separate dask-scheduler and dask-worker programs were dropped in distributed 2026.6.0.
+dask scheduler --scheduler-file sf &
+daskpath=$(which dask)
 scontrol show hostname $SLURM_JOB_NODELIST | while read node; do
-    ssh -n -f $node "cd $PWD ; nohup $workerpath --scheduler-file sf --nthreads 1 --nworkers 36 > /dev/null 2>&1 &"
+    ssh -n -f $node "cd $PWD ; nohup $daskpath worker --scheduler-file sf --nthreads 1 --nworkers 36 > /dev/null 2>&1 &"
 done
 
 # Run the test script

--- a/tests/full_tests/run_all.py
+++ b/tests/full_tests/run_all.py
@@ -6,7 +6,7 @@ The problems are designed to be as short as possible while testing all / as many
 The total run time is about 30 minutes
 
 Run with no arguments to run locally
-Run with the argument ssh to use PyBNF's automatic cluster setup with dask-ssh
+Run with the argument ssh to use PyBNF's automatic cluster setup with dask ssh
 Run with the argument sf to use manual cluster setup, with a preconfigured dask cluster with scheduler file named sf
 Bash files are provided in this folder to run this script using the cluster options. 
 

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -4,7 +4,7 @@ Orchestration tests for ``pybnf.cluster.Cluster`` — the SSH/HPC dask bring-up.
 This is glue code, not numerical math: the only deterministic contracts are
 *which external call PyBNF constructs, with what arguments, and which branch
 fires for which config*. So the oracle for each test is the constructed
-``scontrol``/``dask-ssh`` command string, the SLURM stdout parse, the
+``scontrol``/``dask ssh`` command string, the SLURM stdout parse, the
 subprocess-error → PybnfError mapping, the ``ceil(parallel_count/num_nodes)``
 per-node arithmetic, or the ``Client(...)``/``LocalCluster(...)`` call the
 config selects. (For glue with no math, "the right command/Client call was
@@ -13,7 +13,7 @@ made" *is* the oracle — not the mock-the-world anti-pattern.)
 The srun launcher (#614, ADR-0122) is tested the same way: its oracle is the
 ``dask scheduler`` / ``srun ... dask worker`` argument lists PyBNF constructs,
 the readiness polls it makes on the scheduler file and the worker count, and
-the branch dispatch that keeps it away from ``dask-ssh``. No SLURM and no dask
+the branch dispatch that keeps it away from ``dask ssh``. No SLURM and no dask
 is involved -- ``Popen``, ``time.sleep`` and the ``Client`` are substituted, and
 the scheduler file is a real file in ``tmp_path``.
 
@@ -204,8 +204,63 @@ class TestReadNodeNames:
 
 
 # --------------------------------------------------------------------------- #
-# setup_cluster — the dask-ssh command string + per-node arithmetic
+# check_dask_subcommand — the pre-flight on the dask CLI (#615)
 # --------------------------------------------------------------------------- #
+class _FakeEntryPoint:
+    def __init__(self, name):
+        self.name = name
+
+
+class TestCheckDaskSubcommand:
+
+    @pytest.mark.parametrize('subcommand', ['ssh', 'scheduler', 'worker'])
+    def test_the_installed_dask_really_provides_what_pybnf_runs(self, subcommand):
+        """Deliberately NOT mocked: this asks the installed environment, through the
+        same ``dask_cli`` entry point group dask's own CLI builds its command set
+        from. It is the one assertion in this file that would go red if dask renamed
+        or dropped a command PyBNF runs -- which is exactly what happened in #615,
+        where every other test here stayed green against a ``dask-ssh`` that no
+        longer existed on any current install."""
+        cluster.check_dask_subcommand(subcommand)   # must not raise
+
+    def test_missing_subcommand_names_what_is_available(self, monkeypatch):
+        """The refusal has to be actionable: it says which subcommand was wanted,
+        what the installation does offer, and which package supplies it."""
+        monkeypatch.setattr(cluster, 'entry_points',
+                            lambda group: [_FakeEntryPoint('scheduler'), _FakeEntryPoint('worker')])
+        with pytest.raises(printing.PybnfError) as exc:
+            cluster.check_dask_subcommand('ssh')
+        assert "no 'ssh' subcommand" in str(exc.value)
+        assert 'scheduler, worker' in str(exc.value)          # what is there instead
+        assert 'distributed' in exc.value.message             # the hint names the package
+
+    def test_no_dask_cli_at_all_is_a_distinct_error(self, monkeypatch):
+        """A dask too old to have a command line interface is a different problem
+        from a dask whose CLI lacks one command, and says so."""
+        monkeypatch.setattr(cluster, 'find_spec', lambda name: None)
+        with pytest.raises(printing.PybnfError, match='no command line interface'):
+            cluster.check_dask_subcommand('ssh')
+
+    def test_the_group_queried_is_the_one_dask_itself_reads(self, monkeypatch):
+        """The check is only as good as the question it asks: dask assembles its
+        subcommands from the ``dask_cli`` entry point group, so anything this cannot
+        see, ``dask`` cannot run either."""
+        groups = []
+        monkeypatch.setattr(cluster, 'entry_points',
+                            lambda group: groups.append(group) or [_FakeEntryPoint('ssh')])
+        cluster.check_dask_subcommand('ssh')
+        assert groups == ['dask_cli']
+
+
+# --------------------------------------------------------------------------- #
+# setup_cluster — the dask ssh command string + per-node arithmetic
+# --------------------------------------------------------------------------- #
+# What PyBNF prepends to every worker-launch command (#615). Spelled out here
+# rather than imported from cluster.DASK_CLI so that the tests below pin the
+# actual argv, not merely agree with whatever the module happens to build.
+DASK_SSH = [sys.executable, '-m', 'dask', 'ssh']
+
+
 class TestSetupCluster:
 
     def _patch(self, monkeypatch, cpu=4, returncode=None, stderr_bytes=b''):
@@ -229,7 +284,7 @@ class TestSetupCluster:
         return popen_calls
 
     def test_default_parallel_count_uses_cpu_count(self, monkeypatch):
-        """parallel_count=None ⇒ dask-ssh's own default of one worker per CPU:
+        """parallel_count=None ⇒ dask ssh's own default of one worker per CPU:
         ``--nthreads 1 --nworkers {cpu_count()}`` (note this branch's flag order is
         --nthreads then --nworkers). Oracle: the exact argument list (ROB-3: an argv
         list launched with no shell, each node its own entry) with cpu_count()=7."""
@@ -238,7 +293,7 @@ class TestSetupCluster:
 
         assert proc.poll() is None
         (args, kwargs), = popen_calls
-        assert args[0] == ['dask-ssh', 'n1', 'n2',
+        assert args[0] == [*DASK_SSH, 'n1', 'n2',
                            '--log-directory', '/out', '--nthreads', '1', '--nworkers', '7']
         assert kwargs.get('shell', False) is False         # no shell -> no injection
         assert kwargs['stdout'] is cluster.DEVNULL
@@ -247,15 +302,41 @@ class TestSetupCluster:
         assert kwargs['stderr'] is not cluster.DEVNULL
         assert hasattr(kwargs['stderr'], 'read')
 
+    def test_the_launcher_is_dask_ssh_through_this_interpreter(self, monkeypatch):
+        """#615: the command is the ``dask ssh`` *subcommand*, run through the
+        interpreter running PyBNF -- not the standalone ``dask-ssh`` script, which
+        distributed stopped installing in 2026.6.0 and whose absence killed every
+        multi-machine run on FileNotFoundError, and not a bare ``dask`` from PATH,
+        which could belong to a different environment than this fit (dask ssh
+        passes its own sys.executable on to the remote workers)."""
+        popen_calls = self._patch(monkeypatch)
+        cluster.Cluster.setup_cluster('n1', '/log', parallel_count=1)
+
+        (args, _), = popen_calls
+        assert args[0][:4] == [sys.executable, '-m', 'dask', 'ssh']
+        assert 'dask-ssh' not in args[0]
+        assert args[0][0] != 'dask'
+
+    def test_a_missing_subcommand_is_refused_before_launching(self, monkeypatch):
+        """The pre-flight runs *before* Popen, so a dask that cannot do this reads
+        as a configuration error naming what is installed, rather than as a
+        FileNotFoundError traceback ("an unknown error ... please report this bug")
+        from a process PyBNF already tried to start."""
+        popen_calls = self._patch(monkeypatch)
+        monkeypatch.setattr(cluster, 'entry_points', lambda group: [])
+        with pytest.raises(printing.PybnfError, match="no 'ssh' subcommand"):
+            cluster.Cluster.setup_cluster('n1', '/log', parallel_count=1)
+        assert popen_calls == []
+
     def test_running_proc_is_returned_without_raising(self, monkeypatch):
-        """The happy path: dask-ssh is still running after the startup wait
+        """The happy path: dask ssh is still running after the startup wait
         (poll() is None), so setup_cluster returns the proc rather than raising."""
         self._patch(monkeypatch)
         proc = cluster.Cluster.setup_cluster('n1', '/log', parallel_count=1)
         assert proc.poll() is None
 
     def test_failed_bringup_raises_with_stderr(self, monkeypatch):
-        """If dask-ssh has already exited after the startup wait, the cluster
+        """If dask ssh has already exited after the startup wait, the cluster
         never came up. setup_cluster must raise PybnfError (not return a dead
         proc that later surfaces as an opaque Client connection error), and the
         captured stderr is included for diagnosis."""
@@ -276,7 +357,7 @@ class TestSetupCluster:
         cluster.Cluster.setup_cluster('a b c', '/log', parallel_count=5)
 
         (args, _), = popen_calls
-        assert args[0] == ['dask-ssh', 'a', 'b', 'c',
+        assert args[0] == [*DASK_SSH, 'a', 'b', 'c',
                            '--log-directory', '/log', '--nworkers', '2', '--nthreads', '1']
 
     def test_parallel_count_exact_division(self, monkeypatch):
@@ -285,7 +366,7 @@ class TestSetupCluster:
         popen_calls = self._patch(monkeypatch)
         cluster.Cluster.setup_cluster('h1 h2', '/log', parallel_count=4)
         (args, _), = popen_calls
-        assert args[0] == ['dask-ssh', 'h1', 'h2',
+        assert args[0] == [*DASK_SSH, 'h1', 'h2',
                            '--log-directory', '/log', '--nworkers', '2', '--nthreads', '1']
 
     def test_single_node_gets_all_workers(self, monkeypatch):
@@ -294,21 +375,21 @@ class TestSetupCluster:
         popen_calls = self._patch(monkeypatch)
         cluster.Cluster.setup_cluster('only', '/log', parallel_count=6)
         (args, _), = popen_calls
-        assert args[0] == ['dask-ssh', 'only',
+        assert args[0] == [*DASK_SSH, 'only',
                            '--log-directory', '/log', '--nworkers', '6', '--nthreads', '1']
 
     def test_node_names_passed_as_literal_argv_no_shell(self, monkeypatch):
-        """ROB-3: node names reach dask-ssh as their own literal argv entries with
+        """ROB-3: node names reach dask ssh as their own literal argv entries with
         shell off, so a metacharacter-bearing node name can't be interpreted by a
         shell."""
         popen_calls = self._patch(monkeypatch)
         cluster.Cluster.setup_cluster('n1$(whoami) n2', '/log', parallel_count=2)
         (args, kwargs), = popen_calls
-        assert args[0][:3] == ['dask-ssh', 'n1$(whoami)', 'n2']  # literal, unexpanded
+        assert args[0][:len(DASK_SSH) + 2] == [*DASK_SSH, 'n1$(whoami)', 'n2']  # literal, unexpanded
         assert kwargs.get('shell', False) is False
 
     def test_sleeps_ten_seconds_for_startup(self, monkeypatch):
-        """After launching dask-ssh, setup_cluster waits 10s for workers to come
+        """After launching dask ssh, setup_cluster waits 10s for workers to come
         up before returning the proc. Oracle: time.sleep called once with 10."""
         self._patch(monkeypatch)
         sleeps = []
@@ -419,7 +500,7 @@ class TestInitNodeDispatch:
 
     def test_scheduler_file_skips_setup_and_uses_scheduler_file_client(self, monkeypatch):
         """scheduler_file set ⇒ the scheduler is read from the shared-FS file:
-        no dask-ssh bring-up (_dask_proc is None, setup_cluster never called) and
+        no dask ssh bring-up (_dask_proc is None, setup_cluster never called) and
         the client is built via Client(scheduler_file=...). read_node_names is
         bypassed entirely."""
         rec = _patch_init(monkeypatch)
@@ -433,7 +514,7 @@ class TestInitNodeDispatch:
 
     def test_scheduler_node_plus_worker_nodes_joins_worker_list(self, monkeypatch):
         """scheduler_node + explicit worker_nodes ⇒ node_string is the
-        space-joined worker list (read_node_names is NOT consulted), dask-ssh is
+        space-joined worker list (read_node_names is NOT consulted), dask ssh is
         brought up on that list, and the client connects to scheduler_node:8786."""
         rec = _patch_init(monkeypatch)
         c = _build(_cfg(scheduler_node='head', worker_nodes=['w1', 'w2', 'w3'],
@@ -462,7 +543,7 @@ class TestInitNodeDispatch:
     def test_detected_cluster_uses_both_outputs_of_read_node_names(self, monkeypatch):
         """Neither scheduler_file nor scheduler_node ⇒ both the scheduler and the
         worker list come from read_node_names. With a non-empty node_string,
-        dask-ssh is set up and the client connects to the *detected* scheduler."""
+        dask ssh is set up and the client connects to the *detected* scheduler."""
         rec = _patch_init(monkeypatch, read_returns=('sched9', 'sched9 c1 c2'))
         c = _build(_cfg(parallel_count=4))
 
@@ -524,12 +605,12 @@ class TestInitClientDispatch:
         assert lc_kwargs['threads_per_worker'] == 1
 
     def test_local_and_dask_ssh_defaults_agree_on_one_thread(self, monkeypatch):
-        """The two default paths -- local and dask-ssh -- must request the same
+        """The two default paths -- local and dask ssh -- must request the same
         thread-per-worker policy, since the same non-thread-safe backends run on
-        both. Oracle: with nothing configured, dask-ssh asks for --nthreads 1 and
+        both. Oracle: with nothing configured, dask ssh asks for --nthreads 1 and
         the local LocalCluster asks for threads_per_worker=1.
 
-        (The dask-ssh half runs first: _patch_init replaces setup_cluster with a
+        (The dask ssh half runs first: _patch_init replaces setup_cluster with a
         fake, so the real one has to be exercised before that.)"""
         popen_calls = []
         monkeypatch.setattr(cluster, 'Popen',
@@ -589,7 +670,7 @@ class TestLocalClusterKwargs:
 
 
 # --------------------------------------------------------------------------- #
-# teardown — close the client, terminate the dask-ssh proc only if it exists
+# teardown — close the client, terminate the launcher proc only if it exists
 # --------------------------------------------------------------------------- #
 def _torn_down(client=None, dask_proc=None, scheduler_proc=None, scheduler_file=None):
     """A Cluster built by hand, carrying only the attributes teardown reads."""
@@ -604,7 +685,7 @@ def _torn_down(client=None, dask_proc=None, scheduler_proc=None, scheduler_file=
 class TestTeardown:
 
     def test_closes_client_and_terminates_proc(self):
-        """With a live dask-ssh proc, teardown closes the client and terminates
+        """With a live dask ssh proc, teardown closes the client and terminates
         the proc."""
         proc = _ProcStub()
         c = _torn_down(dask_proc=proc)
@@ -615,7 +696,7 @@ class TestTeardown:
         assert proc.terminated is True
 
     def test_no_proc_only_closes_client(self):
-        """When _dask_proc is None (a local client with no dask-ssh subprocess),
+        """When _dask_proc is None (a local client with no dask ssh subprocess),
         teardown closes the client and must NOT attempt to terminate None — an
         unconditional terminate would raise AttributeError here."""
         c = _torn_down()
@@ -1105,12 +1186,12 @@ class TestInitSrunDispatch:
     def test_srun_type_never_reaches_dask_ssh(self, monkeypatch):
         """#614's whole point: with the srun launcher selected, the SSH bring-up
         must not run. (``re.match('slurm', 'slurm-srun')`` succeeds, so a dispatch
-        that tested the SSH branch first would have started dask-ssh here and
+        that tested the SSH branch first would have started dask ssh here and
         failed the login this issue is about.)"""
         rec = _patch_init(monkeypatch, read_returns=('n1', 'n1 n2'))
         c = _build(self._cfg_srun())
 
-        assert rec.setup_calls == []                        # no dask-ssh
+        assert rec.setup_calls == []                        # no dask ssh
         assert len(rec.srun_setup_calls) == 1
         assert c.local is False
 
@@ -1195,7 +1276,7 @@ class TestInitSrunDispatch:
         with caplog.at_level('WARNING'):
             _build(self._cfg_srun(scheduler_node='head', worker_nodes=['w1', 'w2']))
 
-        assert rec.setup_calls == []                       # no dask-ssh to those nodes
+        assert rec.setup_calls == []                       # no dask ssh to those nodes
         assert rec.client_calls[0][1].get('scheduler_file')  # connected by file, not to head:8786
         assert any('ignored' in r.message for r in caplog.records)
 


### PR DESCRIPTION
Closes #615.

## What was wrong

PyBNF started workers on other machines by running **`dask-ssh`** — one of three standalone scripts (with `dask-scheduler` and `dask-worker`) that distributed stopped installing in **2026.6.0**. On any current install, every run that used more than one machine died immediately with

```
FileNotFoundError: [Errno 2] No such file or directory: 'dask-ssh'
```

before a single simulation, on both routes through `setup_cluster`: `-t slurm` and a hand-set `scheduler_node` / `worker_nodes`.

## What changed

PyBNF now runs the subcommand of the unified `dask` program: **`dask ssh`**.

**No version floor has to move.** `ssh`, `scheduler` and `worker` are all registered in the `dask_cli` entry point group in **2024.1.0**, the oldest dask/distributed `pyproject.toml` allows — confirmed against that release's own wheel metadata:

| distributed | `dask-ssh` script | `dask ssh` subcommand |
| --- | --- | --- |
| 2024.1.0 (the floor) | present | **present** |
| 2026.3.0 | present | present |
| 2026.6.0 → 2026.7.1 | **gone** | present |

**Invoked as `<this interpreter> -m dask ssh`, not as a bare `dask` from `PATH`.** `dask ssh` propagates its own `sys.executable` into the commands it starts on the remote nodes, so a `dask` resolved from `PATH` — a system-wide one, say, when PyBNF is run from a virtualenv by absolute path without activating it — would start the fit's workers under a different Python than the fit. `-m` makes those the same interpreter by construction. The srun launcher's two commands now share that decision through one `DASK_CLI` constant instead of repeating it.

**A missing command is refused before anything is launched.** `check_dask_subcommand` asks the same `dask_cli` entry point group dask's own CLI builds its command set from, so it cannot disagree with what `dask` will actually run, and it names the subcommands the installation does offer and the package that provides them — instead of a `FileNotFoundError` reaching the user inside "an unknown error … please report this bug":

```
Error: The installed dask has no 'ssh' subcommand, which PyBNF needs to start workers on
other machines. Available subcommands: scheduler, spec, worker.
  -> 'ssh' is provided by the distributed package (v2026.7.1 here); install distributed
     2024.1.0 or newer alongside dask in the environment running PyBNF (/opt/venv/bin/python).
```

**Docs and scripts**: `docs/cluster.rst` and `tests/full_tests/cluster_manual.sh` gave `dask-scheduler` / `dask-worker` for manual setups; both now give the subcommand form with a note about when the old programs disappeared. Comments in `pybnf.py` and `pset.py` that named `dask-ssh` as *the* worker launcher were stale in a second way after #614 — srun is the other one — and now say so.

## The tests are the part that should not have stayed green

They asserted the argv PyBNF built, which was consistent with itself and with nothing outside the process, so they passed against a program that no longer existed anywhere. Alongside the updated argv assertions there is now one deliberately **unmocked** test that asks the installed environment whether `ssh`, `scheduler` and `worker` are really there — the assertion that would have gone red for this issue, and that will go red if dask renames one of them again. #619 asks for that property more broadly; this is the part of it this fix can carry.

## Verification

- PyBNF's real command line, run against an unreachable host: the process starts and is still running after the bring-up wait — i.e. the CLI accepts every flag PyBNF passes (`--log-directory`, `--nthreads`, `--nworkers`) — where the old argv raises `FileNotFoundError` on the same machine.
- Full suite green (4466 passed, 23 skipped); docs build clean under the `-W` gate.
