### PR TITLE
Let the inline test client say it is a local run, because it is one

### DIFF
--- a/tests/integration_harness.py
+++ b/tests/integration_harness.py
@@ -66,7 +66,23 @@ class FakeFuture:
 
 
 class FakeClient:
-    """Runs every submitted callable inline and returns a finished future."""
+    """Runs every submitted callable inline and returns a finished future.
+
+    ``cluster`` is set because this double stands in for a LOCAL run, and a real local
+    ``Client`` owns the ``LocalCluster`` it drives. ``_report_parallelism`` reads exactly
+    that attribute to tell a local run from a cluster one (#621), so a double without it
+    claims to be a cluster run and then fails the ``scheduler_info()`` call that claim
+    leads to.
+
+    Nothing breaks: the failure is caught and the fit is unaffected. What it costs is
+    attention. ``logger.exception`` records a full traceback, and pytest shows a captured
+    log only for a test that FAILS, so the traceback appears in exactly the situation
+    where someone is reading the log to find out why something broke, attached to a fit
+    that broke for an unrelated reason. It came up while diagnosing #648 and had to be
+    ruled out first. The attribute only has to be non-None; nothing reads through it.
+    """
+
+    cluster = 'local'
 
     def scatter(self, objs, broadcast=False):
         return [FakeFuture(o) for o in objs]


### PR DESCRIPTION
`FakeClient` in the integration harness runs every submitted callable inline, so it stands in for a local run. It did not set the attribute that says so.

`_report_parallelism` tells a local run from a cluster run by whether the client owns a cluster object, because a real local `Client` drives a `LocalCluster` and a cluster client connects to a scheduler and owns nothing. The double set no such attribute, so it presented itself as a cluster run, and then failed the `scheduler_info()` call that claim leads to.

Nothing breaks. The failure is caught and the fit is unaffected. What it costs is attention. The handler records a full traceback, and pytest shows a captured log only for a test that **fails**, so the traceback turns up in exactly the situation where someone is reading a log to find out why something broke, attached to a fit that broke for an unrelated reason. It came up while diagnosing #648 and had to be ruled out before the real cause could be found.

Test only, one attribute. It just has to be present; nothing reads through it.

Checked on `test_run_loop.py`, `test_wall_time_fit.py` and `test_cluster.py`: 305 passed, 3 skipped, and the traceback is gone from a failing test's captured log.