### PR TITLE
Renumber the issue 572 evaluation to ADR-0130 and fix its pointer to the corpus

### DIFF
--- a/docs/adr/0123-a-linear-observable-parameter-is-profilable-only-in-the-space-its-own-noise-family-scores-so-the-log-family-half-is-refused-on-the-math-and-the-linear-gaussian-half-stays-open-on-a-measurement-the-corpus-cannot-make.md
+++ b/docs/adr/0123-a-linear-observable-parameter-is-profilable-only-in-the-space-its-own-noise-family-scores-so-the-log-family-half-is-refused-on-the-math-and-the-linear-gaussian-half-stays-open-on-a-measurement-the-corpus-cannot-make.md
@@ -1,14 +1,14 @@
 # A linear observable parameter is profilable only in the space its own noise family scores, so the log-family half is refused on the math and the linear-Gaussian half stays open on a measurement the corpus cannot make (issue #572)
 
-**Status: Superseded in part by ADR-0129 (2026-08-25).** The two measurements this ADR named as
-#572's gate have been taken, and they close it: see ADR-0129 for the decision, the numbers, and the
+**Status: Superseded in part by ADR-0130 (2026-08-25).** The two measurements this ADR named as
+#572's gate have been taken, and they close it: see ADR-0130 for the decision, the numbers, and the
 scope. **What still stands:** finding 1's log-versus-linear split, finding 2's double-binding
-refusal and its two instances, and finding 5's census. **What ADR-0129 corrects:** finding 1's table
+refusal and its two instances, and finding 5's census. **What ADR-0130 corrects:** finding 1's table
 sorts families by the space their residual lives in, which is the wrong axis -- `laplace` scores a
 linear residual but sums absolute values, so least squares is not its conditional optimum and it has
 to be refused for the coupled form; and finding 3's reading of `Laske`'s `Int_nuc_off` ("profiles to
 approximately 57.13 at essentially every box draw"), which is 9 of the 15 draws that integrate, with
-five going to effectively zero -- the compression it reports does reproduce. **What ADR-0129
+five going to effectively zero -- the compression it reports does reproduce. **What ADR-0130
 answers:** finding 4's redundancy question, and the "what would decide it" measurements at the end.
 
 *(Originally -- Narrowed, not decided, 2026-08-21.)* ADR-0066/0099 profile a declared column's
@@ -255,9 +255,8 @@ If (1) shows the coupled pair behaves like `Int_nuc_off` did and (2) shows a ben
   gate.
 * Two reusable tools land in the corpus with their gotchas written down:
   `Grein-2026-benchmark-subset-I/tools/linear_scope.py` and `.../linear_profile.py`.
-  **They were committed and not merged**, to `wshlavacek/BNGL-Models` branch
-  `tools/572-linear-observable-profiling`, so this ADR has been pointing at files that are not on
-  `main`. ADR-0129's branch merges them.
+  They landed as that repository's PR #47, four days after this ADR was written; ADR-0130 adds a
+  third tool and two more confs beside them.
 
 ## Prior art
 

--- a/docs/adr/0130-a-linear-coefficient-profile-is-gated-on-a-quadratic-loss-not-on-a-linear-residual-space-and-on-a-gaussian-family-it-sharpens-the-ordering-rather-than-collapsing-it-and-reaches-the-optimum-sooner.md
+++ b/docs/adr/0130-a-linear-coefficient-profile-is-gated-on-a-quadratic-loss-not-on-a-linear-residual-space-and-on-a-gaussian-family-it-sharpens-the-ordering-rather-than-collapsing-it-and-reaches-the-optimum-sooner.md
@@ -30,12 +30,10 @@ The short version:
 
 ## Where the measurements and the tools live
 
-In `wshlavacek/BNGL-Models`, branch `572-linear-profiling-race`, which also carries the two tools
-ADR-0123 described. **ADR-0123 recorded those as having landed in the corpus and they had not** --
-they were committed to `tools/572-linear-observable-profiling` and never merged, so the ADR has been
-pointing at files that are not on `main`. This is the branch that merges them, together with the
-fixture, the additions below, and the failure modes each one hides, written up in
-`Grein-2026-benchmark-subset-I/tools/README.md`.
+In `wshlavacek/BNGL-Models`. The two tools ADR-0123 describes, and the fixture, landed there as
+that repository's PR #47; the additions below are PR #48. Every failure mode these tools hide is
+written up in `Grein-2026-benchmark-subset-I/tools/README.md`, which is the file to read before
+believing any number taken with them.
 
 What was already there: `linear_scope.py` (which free parameters enter an observable linearly, and
 in what space), `linear_profile.py` (simulate a box point once, then minimize **PyBNF's own


### PR DESCRIPTION
Two pull requests landed close together and both took ADR number 0129. The design of experiments
record (#668) merged first, so the issue 572 evaluation (#670) moves to 0130. The references in
ADR-0123 follow it.

The evaluation also said the tools it used had been committed to a branch in the benchmark corpus
and never merged. That was true when it was written and stopped being true a few minutes later,
when wshlavacek/BNGL-Models#47 merged. Both records now say where the files are rather than where
they were missing from, and point at wshlavacek/BNGL-Models#48 for the additions.

No other change.