### PR TITLE
Confirm the best fit of a stochastic fit by running the top parameter sets again (#659)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@ All notable changes to PyBNF are documented below. This project adheres to
 ## [Unreleased]
 
 ### Added
+- **A stochastic fit now confirms its best fit by running the top parameter sets again
+  (#659).** When a model is stochastic, running it twice with the same parameter values
+  gives two different answers, so the objective value PyBNF computes is a noisy measurement
+  rather than a fixed number. A fit picked its answer by taking the best value it ever saw,
+  and each of those values came from a single simulation. A long fit scores tens of
+  thousands of parameter sets, so the winner of that comparison was very often the
+  parameter set that happened to get a lucky simulation. Two things came out wrong and
+  nothing said so: the reported objective value was the best of many noisy draws and so was
+  optimistic by a wide margin, and the reported parameter values were not the best ones
+  found, because a slightly worse parameter set with a lucky draw beats a better one with
+  an average draw.
+  A fit that uses at least one stochastic model now ends by running its top
+  `best_fit_candidates` parameter sets `best_fit_replicates` more times each, ranking them
+  by their average objective value, and reporting that winner as the best fit. Ten and ten
+  by default, so a hundred simulations against a run that may have done a hundred thousand,
+  all submitted at once on processors that would otherwise sit idle at the end of a run.
+  `Results/best_fit_confirmation.txt` gives each candidate's average, its standard error,
+  and the single value the search had recorded for it, so you can see how much of the
+  search's answer was luck. Everything the run writes afterwards, including the saved
+  simulations, the best-fit model file, the information criteria, a refine's starting
+  point, and a bootstrap replicate's recorded answer, describes the confirmed parameter
+  set.
+  The stage is on under `edition = 2` and above. Under the legacy edition it is off, since
+  an unchanged configuration file has to keep behaving as it always has, and a legacy fit
+  with a stochastic model is told at startup what it is missing and which two keys turn it
+  on. Nothing happens for a fit with no stochastic model. No fitting method searches any
+  differently. This covers the answer the fit reports and not the search that produced it,
+  which is a larger piece of work; the new table is a way to measure how much that matters
+  for a given model.
 - **A multi-start fit now reports how every one of its starts did (#658).** Several fit
   types run more than one search, each from a different starting point, and report the
   best result. That one number cannot be checked. Twenty starts that all reached about the

--- a/docs/config_keys.rst
+++ b/docs/config_keys.rst
@@ -1606,9 +1606,33 @@ Algorithm Options
     * ``sensitivity_fallback = error``
     * ``sensitivity_fallback = ignore``
 
+**best_fit_candidates**
+  How many of the top parameter sets to run again at the end of a fit that uses a stochastic model, so PyBNF can tell which of them is really best. A stochastic model gives a different objective value every time it is run, and a fit picks its answer by taking the best value it ever saw, so the winner is often just the parameter set that got a lucky simulation. See :ref:`the explanation <best_fit_confirmation>`.
+
+  Ignored when no model is stochastic. Ignored when ``best_fit_replicates`` is less than 2, since there would be nothing to average.
+
+  Default: 10 under ``edition = 2`` and above, and 0 (off) under the legacy edition
+
+  Example:
+
+    * ``best_fit_candidates = 20``
+
+**best_fit_replicates**
+  How many times to run each of those candidate parameter sets. Their average objective values decide which one the run reports as its best fit, and ``Results/best_fit_confirmation.txt`` records the averages and their uncertainties. Set to 0 to turn the whole stage off.
+
+  The cost is ``best_fit_candidates`` times ``best_fit_replicates`` simulations after the search has ended, all submitted at once, and times ``smoothing`` again when that is also set. Ignored when no model is stochastic.
+
+  Default: 10 under ``edition = 2`` and above, and 0 (off) under the legacy edition
+
+  Example:
+
+    * ``best_fit_replicates = 20``
+
 **smoothing**
   Number of replicate runs to average together for each parameter set (useful for stochastic simulations). This option can be used with
   ``parallelize_models`` to run model partitions independently within each replicate.
+
+  ``smoothing`` averages the simulated curves of every evaluation the fit makes, which multiplies the cost of the whole fit. It is not a substitute for ``best_fit_replicates``, which runs only the top parameter sets again at the end so the reported answer is not the luckiest of many noisy values. See :ref:`the explanation <best_fit_confirmation>`.
 
   Each replicate gets a distinct deterministic seed under the default
   :ref:`stochastic_seed` policy (``auto``), so smoothing replicates yield

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -183,6 +183,77 @@ for the rest. A refine writes ``Results/multistart_summary_refine.txt``; a fit w
 start writes nothing, since there would be nothing to compare it against.
 
 
+.. _best_fit_confirmation:
+
+My stochastic fit reports an objective value I cannot reproduce
+---------------------------------------------------------------
+When a model is stochastic, such as one simulated with the stochastic simulation algorithm
+or with NFsim, running it twice with the same parameter values gives two different answers.
+The objective value PyBNF computes for a parameter set is therefore a noisy measurement of
+it rather than a fixed number.
+
+A fit picks its answer by taking the best objective value it ever saw, and each of those
+values came from a single simulation. A long fit scores tens of thousands of parameter
+sets, so the winner of that comparison is very often the parameter set that happened to get
+a lucky simulation rather than the parameter set that is genuinely best. Two things then
+come out wrong. The reported objective value is the best of many noisy draws, so it is
+optimistic, sometimes by several times the spread among the good parameter sets. And the
+reported parameter values are not the best ones found, because a slightly worse parameter
+set with a lucky draw beats a better one with an average draw.
+
+So a fit that uses at least one stochastic model ends with one more stage. The top
+``best_fit_candidates`` parameter sets are each run ``best_fit_replicates`` more times, they
+are ranked by their average objective value, and the winner of that ranking is what the run
+reports as its best fit. All of those simulations are submitted at once, which uses
+processors that would otherwise sit idle at the end of a run. The stage writes
+``Results/best_fit_confirmation.txt``::
+
+    candidates	3
+    replicates_requested	4
+    winner	iter2p0h4
+    winner_mean_objective	72838.74908
+    winner_standard_error	5521.750431
+    winner_search_objective	54877.73818
+    optimism	17961.0109
+    # rank	name	mean_objective	standard_error	std_deviation	runs	failed	search_objective
+    1	iter2p0h4	72838.74908	5521.750431	11043.50086	4	0	54877.73818
+    2	init4	87262.13928	3134.119241	6268.238482	4	0	99030.06578
+    3	iter2p5h3	100953.6321	3221.85557	6443.71114	4	0	101437.2518
+
+``mean_objective`` is the number to quote. Compare it against ``search_objective`` in the
+same row to see how much of the search's answer was luck; the ``optimism`` line does that
+subtraction for the winner. ``standard_error`` says how well this stage told the candidates
+apart, so two rows whose averages differ by less than their standard errors have not really
+been separated and need more replicates. A ``search_rank`` line appears when the winner is
+not the parameter set the search itself would have reported.
+
+The stage runs under ``edition = 2`` and above, where it defaults to ten candidates at ten
+replicates each. Under the legacy edition it is off, because an unchanged configuration file
+has to keep behaving as it always has; a legacy fit with a stochastic model prints a warning
+saying so, and turns the stage on by setting the two keys itself. Setting
+``best_fit_replicates = 0`` turns it off anywhere. Nothing happens for a fit with no
+stochastic model, and no fitting method searches any differently either way.
+
+A run whose ``wall_time_fit`` budget is already spent skips the stage and says so, since a
+budget is a promise about the whole run and this costs more simulations. It is also skipped,
+with a warning at startup, when ``stochastic_seed`` is one of the ``_honorbngl`` modes and
+every stochastic model in the fit carries an explicit ``seed`` argument, because then every
+replicate would reproduce the same trajectory and there would be nothing to average.
+
+This covers the answer the fit reports, and not the search that produced it. The same noise
+also affects the search while it is running, where a lucky value recorded for a population
+member can never be displaced except by a luckier one. That is a larger piece of work, and
+the table above is a way to measure how much it matters for your model before deciding
+whether to worry about it.
+
+``smoothing`` is a different setting for a related problem. It runs every evaluation of the
+whole fit several times and averages the simulated curves, which multiplies the cost of the
+entire fit, and it still leaves the final choice being made among the best of many noisy
+values. The two work together: with ``smoothing`` on, each of the replicate runs here is a
+whole smoothed evaluation, so the cost of this stage is candidates times replicates times
+``smoothing`` simulations.
+
+
 Unexpected behavior when generating SBML files in COPASI
 --------------------------------------------------------
 While COPASI is a useful tool for generating SBML files, it is important to note that some settings in COPASI do not get converted into SBML. This can lead to unexpected model behavior in PyBNF. 

--- a/pybnf/algorithms/base.py
+++ b/pybnf/algorithms/base.py
@@ -8,6 +8,7 @@ names locally; the never-patched data classes are imported by name.
 
 
 from . import core
+from . import best_fit_confirmation
 from . import multistart_report
 from .core import (
     FailedSimulation,
@@ -824,9 +825,18 @@ class Algorithm(ABC):
         :return: List of PSet(s) to be run next or 'STOP' string.
         """
 
-    def add_to_trajectory(self, res):
-        """
-        Adds the information from a Result to the Trajectory instance
+    def score_result(self, res):
+        """Make sure this Result carries an objective value, and return it.
+
+        Does nothing when the workers already scored it (the default path, where an
+        ObjectiveCalculator was scattered). Otherwise normalizes, post-processes, and
+        scores it here on the master, which is the path a smoothing / model-parallel /
+        gradient fit takes. Anything that goes wrong penalizes this one evaluation with an
+        infinite objective rather than crashing the run (lanl/PyBNF#388).
+
+        Split out of :meth:`add_to_trajectory` so the end-of-fit confirmation stage
+        (#659), which scores results it deliberately does not put in the trajectory, goes
+        through exactly the same path the fit did.
         """
         # Evaluate objective if it wasn't done on workers.
         if res.score is None:  # Check if the objective wasn't evaluated on the workers
@@ -853,6 +863,13 @@ class Algorithm(ABC):
                 logger.warning(f'Simulation corresponding to Result {res.name} contained NaNs or Infs')
                 logger.warning(f'Discarding Result {res.name} as having an infinite objective function value')
                 print1(f'Simulation data in Result {res.name} has NaN or Inf values.  Discarding this parameter set')
+        return res.score
+
+    def add_to_trajectory(self, res):
+        """
+        Adds the information from a Result to the Trajectory instance
+        """
+        self.score_result(res)
         logger.debug(f'Adding Result {res.name} to Trajectory with score {res.score:.4f}')
         self.trajectory.add(res.pset, res.score, res.name)
 
@@ -960,14 +977,24 @@ class Algorithm(ABC):
             return self.model_list, None
         return self.model_list[model_slice[0]:model_slice[1]], None
 
-    def make_job(self, params):
+    def make_job(self, params, replicate_offset=0):
         """
         Creates a new Job using the specified params, and additional specifications that are already saved in the
         Algorithm object
         If smoothing or model-level parallelism is turned on, makes grouped subjobs.
 
+        ``replicate_offset`` shifts every job's replicate index by a fixed amount. Under
+        the default ``stochastic_seed`` policy a stochastic simulation's seed is derived
+        from the parameter values and the replicate index and nothing else, so running the
+        same parameter set again with the same index reproduces the same trajectory
+        exactly. The end-of-fit confirmation stage (#659) needs fresh trajectories for a
+        parameter set the fit has already run, so it asks for an offset past every index
+        the fit itself used. Zero, the default, is the ordinary path and is unchanged.
+
         :param params:
         :type params: PSet
+        :param replicate_offset: Amount to add to every job's replicate index
+        :type replicate_offset: int
         :return: list of Jobs
         """
         if params.name:
@@ -994,7 +1021,7 @@ class Algorithm(ABC):
                                        params, thisname, self.sim_dir, self.config.config['wall_time_sim'],
                                        self.calc_future, self.config.config['normalization'], dict(),
                                        bool(self.config.config['delete_old_files']),
-                                       replicate_index=rep,
+                                       replicate_index=replicate_offset + rep,
                                        stochastic_seed_policy=self.config.config['stochastic_seed'],
                                        model_slice=mslice))
                 replica_subjob_ids.append((replica_id, newnames))
@@ -1016,7 +1043,7 @@ class Algorithm(ABC):
                                    self.sim_dir, self.config.config['wall_time_sim'], self.calc_future,
                                    self.config.config['normalization'], dict(),
                                    bool(self.config.config['delete_old_files']),
-                                   replicate_index=i,
+                                   replicate_index=replicate_offset + i,
                                    stochastic_seed_policy=self.config.config['stochastic_seed'],
                                    model_slice=mslice))
             new_group = JobGroup(job_id, newnames)
@@ -1040,6 +1067,7 @@ class Algorithm(ABC):
                                    params, thisname, self.sim_dir, self.config.config['wall_time_sim'],
                                    self.calc_future, self.config.config['normalization'], dict(),
                                    bool(self.config.config['delete_old_files']),
+                                   replicate_index=replicate_offset,
                                    stochastic_seed_policy=self.config.config['stochastic_seed'],
                                    model_slice=mslice))
             new_group = MultimodelJobGroup(job_id, newnames)
@@ -1053,6 +1081,7 @@ class Algorithm(ABC):
                     self.sim_dir, self.config.config['wall_time_sim'], self.calc_future,
                     self.config.config['normalization'], self.config.postprocessing,
                     bool(self.config.config['delete_old_files']),
+                    replicate_index=replicate_offset,
                     stochastic_seed_policy=self.config.config['stochastic_seed'],
                     model_slice=mslice)]
 
@@ -1309,7 +1338,7 @@ class Algorithm(ABC):
 
         logger.info("Cancelling %d pending jobs" % len(pending))
         client.cancel(list(pending.keys()))
-        self._finalize_run()
+        self._finalize_run(client)
 
     def expected_parallelism(self):
         """How many parameter sets this fit has out for evaluation at once once it is under
@@ -1430,9 +1459,14 @@ class Algorithm(ABC):
             # record for this run.
             logger.info(note.strip())
 
-    def _finalize_run(self):
+    def _finalize_run(self, client=None):
         """The end-of-fit path: stop reason, final parameter sets, best-fit artifacts,
         teardown.
+
+        ``client`` is the dask client the run was driven with, which the best-fit
+        confirmation stage (#659) needs because it submits simulations of its own. It is
+        optional so a caller that has no client -- some tests -- still gets every other
+        artifact; that stage is the only thing skipped without one.
 
         Reached the same way however the search ended -- the algorithm's own stop
         criterion, an exhausted job pool, or the wall-time budget -- because a budgeted run
@@ -1459,6 +1493,12 @@ class Algorithm(ABC):
             logger.warning('No parameter set completed, so there is no best fit to report')
             print1('No simulation completed, so there is no best fit to report.')
         else:
+            # Decide which of the top parameter sets is really the best before anything
+            # reads the best fit below. For a stochastic model the search ranked its
+            # candidates on one noisy simulation each, so the entry holding the lowest
+            # value is often just the one that got lucky (#659). A no-op for every
+            # deterministic fit.
+            self._confirm_best_fit(client)
             self.output_results('final')
             best_name = self.trajectory.best_fit_name()
             best_pset = self.trajectory.best_fit()
@@ -1587,6 +1627,222 @@ class Algorithm(ABC):
                 f.write(self.stop_reason + '\n')
         except Exception:
             logger.exception('Failed to write stop_reason.txt')
+
+    def _best_fit_confirmation_settings(self):
+        """How many candidate parameter sets to run again at the end of a stochastic fit,
+        and how many times to run each, as a ``(candidates, replicates)`` pair (#659).
+
+        Ten and ten under a modern edition, which the issue's arithmetic says removes about
+        ninety percent of the optimism in the reported objective value. Off under the
+        legacy edition, whose whole contract is that a conf that does not name an edition
+        keeps behaving exactly as it always has (ADR-0031); a legacy fit that wants the
+        stage names the two keys itself, and one whose models are stochastic is told so at
+        config load. An explicit value wins under either edition.
+        """
+        modern = edition.is_modern(edition.resolve_edition(self.config.config.get('edition')))
+        default = 10 if modern else 0
+        candidates = self.config.config.get('best_fit_candidates')
+        replicates = self.config.config.get('best_fit_replicates')
+        return (default if candidates is None else int(candidates),
+                default if replicates is None else int(replicates))
+
+    def _replicates_would_differ(self):
+        """Whether running a parameter set again would actually give a different answer.
+
+        True when some model is stochastic, with one exception: under an ``_honorbngl``
+        seed policy an explicit ``seed=>N`` in a BNGL action is honored verbatim, so every
+        run of that model reproduces one trajectory. When that pins every stochastic model
+        in the fit there is nothing for replicates to average over, and running them would
+        only spend simulations. This is the same trap ``smoothing`` guards against in
+        ``Configuration._check_smoothing_misuse``.
+        """
+        models = list(self.config.models.values())
+        stochastic = [m for m in models if getattr(m, 'stochastic', False)]
+        if not stochastic:
+            return False
+        policy = str(self.config.config.get('stochastic_seed') or 'auto')
+        if policy.endswith('_honorbngl') and all(getattr(m, 'seeded', False) for m in stochastic):
+            return False
+        return True
+
+    def _confirm_best_fit(self, client):
+        """Decide which of the top parameter sets a stochastic fit really found, by running
+        each of them again several times and ranking them by average objective value (#659).
+
+        A stochastic model gives a different objective value every time it is run, so every
+        value the search recorded is a noisy measurement of that parameter set rather than
+        a fixed number. The search picks its answer by taking the best value it ever saw,
+        over tens of thousands of parameter sets, so the winner of that comparison is very
+        often the parameter set that happened to get a lucky simulation. Two things then
+        come out wrong: the reported objective value is the best of many noisy draws and so
+        is optimistic by a wide margin, and the reported parameter values are not the best
+        ones found.
+
+        This runs the top ``best_fit_candidates`` parameter sets ``best_fit_replicates``
+        more times each, ranks them by their average, records the winner as the run's best
+        fit (:meth:`pybnf.pset.Trajectory.pin_best`, so every later artifact agrees on it),
+        and writes ``Results/best_fit_confirmation.txt``. All of the simulations go out at
+        once, which uses processors that would otherwise sit idle at the end of a run.
+
+        A no-op unless at least one model is stochastic, and a no-op without a dask client
+        to submit the work to. Deliberately scoped to the final answer: the same noise also
+        biases the search while it runs, which is a much larger piece of work.
+
+        Every failure is logged and swallowed. The fit has finished by this point, and this
+        stage must never be the reason a finished run dies.
+        """
+        try:
+            n_candidates, n_replicates = self._best_fit_confirmation_settings()
+            if n_candidates < 1 or n_replicates < 2:
+                return
+            if not self._replicates_would_differ():
+                return
+            if client is None:
+                logger.info('No dask client available, so the best fit of this stochastic '
+                            'fit was not confirmed by running its top parameter sets again')
+                return
+            if self._budget_spent():
+                # A wall-time budget is a promise about the whole run, and this stage costs
+                # candidates x replicates more simulations. A run that is already out of
+                # time spends nothing further, since overrunning it risks the run being
+                # killed before it has written anything at all.
+                msg = ('The wall-time budget is spent, so the best fit was not confirmed by '
+                       'running the top parameter sets again. This fit used a stochastic '
+                       'model, so the objective value it reports is the best of many noisy '
+                       'single simulations and is optimistic. Raise wall_time_fit to leave '
+                       'room for the check.')
+                logger.info(msg)
+                print1('Warning: ' + msg)
+                return
+            candidates = self.trajectory.top_fits(n_candidates)
+            if not candidates:
+                return
+            print1('Confirming the best fit: this fit used a stochastic model, so the top '
+                   '%d parameter set(s) are each being run %d more times to see which of '
+                   'them is really best.' % (len(candidates), n_replicates))
+            scored = self._run_confirmation_replicates(client, candidates, n_replicates)
+        except Exception:
+            logger.exception('Failed to confirm the best fit by running the top parameter '
+                             'sets again; reporting the best fit the search picked')
+            print1('Could not confirm the best fit by running the top parameter sets again, '
+                   'so the best fit the search picked is reported as is. See log for details.')
+            return
+        try:
+            self._emit_best_fit_confirmation(scored, n_replicates)
+        except Exception:
+            logger.exception('Failed to write the best-fit confirmation report')
+
+    def _run_confirmation_replicates(self, client, candidates, n_replicates):
+        """Run each candidate ``n_replicates`` more times and collect its objective values.
+
+        Returns one :class:`~pybnf.algorithms.best_fit_confirmation.Candidate` per input
+        candidate, in the order the search ranked them. Every simulation is submitted
+        before any result is collected.
+
+        Each replicate is a whole evaluation as this fit defines one, built by
+        :meth:`make_job` and scored by :meth:`score_result`, so its objective value is the
+        same quantity the search recorded and the two are directly comparable. Under
+        ``smoothing`` that means one replicate is itself an average of ``smoothing``
+        simulations.
+
+        The replicate indices start past every index the fit itself used, because under the
+        default seed policy a stochastic simulation's seed comes from the parameter values
+        and the replicate index, so reusing an index would reproduce a trajectory the fit
+        has already seen instead of drawing a new one.
+        """
+        smoothing = max(1, int(self.config.config.get('smoothing') or 1))
+        grouped = smoothing > 1 or self.config.config.get('parallelize_models', 1) > 1
+
+        jobs = []
+        owner = dict()  # job name of a finished evaluation -> index of the candidate it belongs to
+        for i, (_, _, chosen_pset) in enumerate(candidates):
+            for r in range(n_replicates):
+                # A copy so the run gets its own name (which is the name of the folder it
+                # writes to) without renaming the parameter set the trajectory holds.
+                replicate_pset = copy.copy(chosen_pset)
+                replicate_pset.name = 'bestfit_check%d_run%d' % (i + 1, r + 1)
+                owner[replicate_pset.name] = i
+                jobs += self.make_job(replicate_pset, replicate_offset=(r + 1) * smoothing)
+
+        logger.info('Confirming the best fit: submitting %d job(s) for %d candidate '
+                    'parameter set(s) at %d replicate(s) each'
+                    % (len(jobs), len(candidates), n_replicates))
+
+        pending = dict()
+        futures = []
+        for job in jobs:
+            f = client.submit(core.run_job, job, False, self.failed_logs_dir,
+                              models=getattr(self, 'models_future', None),
+                              calc=getattr(self, 'calc_future', None))
+            futures.append(f)
+            pending[f] = (job.params, job.job_id)
+
+        scores = [[] for _ in candidates]
+        failures = [0 for _ in candidates]
+        pool = core.as_completed(futures, with_results=True, raise_errors=False)
+        for f, raw in pool:
+            res = result_from_completed(f, raw, pending[f][0], pending[f][1])
+            del pending[f]
+            if not isinstance(res, core.Result):
+                # A cancelled future, which the run loop treats as fatal. Here the fit is
+                # already over, so it costs this replicate and nothing more.
+                logger.warning('A best-fit confirmation job was cancelled')
+                continue
+            if grouped:
+                res = self._fold_group_result(res)
+                if res is None:
+                    continue
+            index = owner.get(res.name)
+            if index is None:
+                logger.warning('Ignoring unexpected best-fit confirmation result %s' % res.name)
+                continue
+            if isinstance(res, FailedSimulation):
+                failures[index] += 1
+                continue
+            score = self.score_result(res)
+            if score is None or not np.isfinite(score):
+                failures[index] += 1
+            else:
+                scores[index].append(float(score))
+
+        return [best_fit_confirmation.Candidate(name=name, pset=candidate_pset,
+                                                search_objective=float(obj),
+                                                scores=tuple(scores[i]), failures=failures[i])
+                for i, (obj, name, candidate_pset) in enumerate(candidates)]
+
+    def _emit_best_fit_confirmation(self, candidates, n_replicates):
+        """Record the winner as this run's best fit and write
+        ``Results/best_fit_confirmation.txt`` (#659).
+
+        The winner is pinned on the trajectory rather than handed to the caller, so
+        everything downstream of here -- the saved simulations, the best-fit model file,
+        the information criteria, a refine's start point, a bootstrap replicate's recorded
+        answer -- reports the same parameter set without any of them having to know this
+        stage exists.
+
+        A refine writes to the ``_refine`` name, as the other artifacts of a second phase
+        do, rather than writing over the searching fit's own table.
+        """
+        best = best_fit_confirmation.winner(candidates)
+        if best is None:
+            logger.warning('No candidate parameter set produced a usable objective value '
+                           'when it was run again, so the best fit the search picked stands')
+        else:
+            self.trajectory.pin_best(best.pset,
+                                     best_fit_confirmation.mean_objective(best), best.name)
+            logger.info('Best-fit confirmation: %s wins with an average objective of %.10g '
+                        'over %d run(s); the search had recorded %.10g for it'
+                        % (best.name, best_fit_confirmation.mean_objective(best),
+                           len(best.scores), best.search_objective))
+
+        name = 'best_fit_confirmation_refine.txt' if self.refine else 'best_fit_confirmation.txt'
+        path = str(Path(self.res_dir) / name)
+        lines = best_fit_confirmation.summary_lines(candidates, n_replicates)
+        with open(path, 'w') as f:
+            f.write('\n'.join(lines) + '\n')
+        logger.info('Wrote the best-fit confirmation table %s' % path)
+        for line in best_fit_confirmation.console_lines(candidates, n_replicates, path):
+            print1(line)
 
     def _copy_best_fit_sims(self, best_pset, best_name):
         """Copy the best-fit parameter set's simulation outputs into Results/.

--- a/pybnf/algorithms/best_fit_confirmation.py
+++ b/pybnf/algorithms/best_fit_confirmation.py
@@ -1,0 +1,195 @@
+"""The end-of-fit stage that confirms the best fit of a stochastic model (#659).
+
+When a model is stochastic, running it twice with the same parameter values gives two
+different answers, so the objective value PyBNF computes is a noisy measurement rather
+than a fixed number. A fit picks its answer by taking the best objective value it ever
+saw, and every one of those values came from a single simulation. A long fit scores tens
+of thousands of parameter sets, so the winner of that comparison is very often the
+parameter set that happened to get a lucky simulation rather than the parameter set that
+is genuinely best.
+
+Two things come out wrong, and nothing in the output used to say so. The reported
+objective value is the best of many noisy draws, so it is optimistic by a wide margin.
+And the reported parameter values are not the best ones found, because a slightly worse
+parameter set with a lucky draw beats a better one with an average draw.
+
+The fix is one extra stage at the end of the fit. Take the top few parameter sets rather
+than only the single best, run each of them again several times, rank them by their
+average objective value, and report that winner. On a run where the good candidates
+differ from each other by about as much as one simulation's noise, this removes about
+ninety percent of the optimism.
+
+This module holds the row type, the arithmetic, and the report text. It keeps no state
+and touches no files, so it is testable on its own. The orchestration -- choosing the
+candidates, submitting the simulations, and recording the winner -- lives in
+:meth:`pybnf.algorithms.base.Algorithm._confirm_best_fit`.
+"""
+
+import math
+from collections import namedtuple
+from statistics import fmean, stdev
+
+#: One candidate parameter set and how it did when it was run again.
+#:
+#: ``name`` is the simulation name the search gave it, which is also the folder its
+#: original simulation was written to. ``pset`` is the parameter set itself.
+#: ``search_objective`` is the single noisy value the search recorded for it, kept so the
+#: report can show how far off that value was. ``scores`` is the list of objective values
+#: from the replicate runs, with failed and non-finite runs left out, and ``failures``
+#: counts the runs that produced no usable value.
+Candidate = namedtuple('Candidate', 'name pset search_objective scores failures',
+                       defaults=((), 0))
+
+
+def mean_objective(candidate):
+    """The average objective value over this candidate's replicate runs.
+
+    ``inf`` when every replicate failed, so a candidate that cannot be simulated sorts
+    last instead of winning.
+    """
+    if not candidate.scores:
+        return math.inf
+    return fmean(candidate.scores)
+
+
+def standard_deviation(candidate):
+    """How much this candidate's objective value varies from one run to the next, or
+    ``None`` when fewer than two runs produced a value."""
+    if len(candidate.scores) < 2:
+        return None
+    return stdev(candidate.scores)
+
+
+def standard_error(candidate):
+    """The uncertainty in this candidate's average objective value, or ``None`` when
+    fewer than two runs produced a value.
+
+    This is the number that says whether the ranking below it means anything. Two
+    candidates whose averages differ by less than their standard errors have not been
+    told apart by this stage.
+    """
+    sd = standard_deviation(candidate)
+    if sd is None:
+        return None
+    return sd / math.sqrt(len(candidate.scores))
+
+
+def ranked(candidates):
+    """The candidates ordered by average objective value, best first.
+
+    Ties keep the order they were given in, which is the order the search ranked them,
+    so the table is the same on every run of the same fit.
+    """
+    return sorted(range(len(candidates)), key=lambda i: (mean_objective(candidates[i]), i))
+
+
+def winner(candidates):
+    """The candidate with the best average objective value, or ``None`` when not one of
+    them produced a usable value."""
+    order = ranked(candidates)
+    if not order:
+        return None
+    best = candidates[order[0]]
+    if not best.scores:
+        return None
+    return best
+
+
+def _number_text(value):
+    if value is None:
+        return 'n/a'
+    if isinstance(value, float) and math.isnan(value):
+        return 'n/a'
+    return '%.10g' % value
+
+
+def summary_lines(candidates, replicates):
+    """The whole text of ``Results/best_fit_confirmation.txt``, as a list of lines."""
+    order = ranked(candidates)
+    best = winner(candidates)
+    lines = [
+        '# This fit used at least one stochastic model, so running the same parameter',
+        '#   values twice gives two different objective values. The search picked its',
+        '#   answer by taking the best objective value it ever saw, and every one of those',
+        '#   came from a single simulation, so the winner of that comparison was often just',
+        '#   the parameter set that got a lucky simulation.',
+        '# To settle it, the top parameter sets of the search were each run again several',
+        '#   times and ranked by their average objective value. The winner of that ranking',
+        '#   is what the run reports as its best fit.',
+        '#',
+        '# search_objective: the single noisy value the search recorded for this parameter',
+        '#   set. It is the value that made this parameter set look good enough to be worth',
+        '#   checking, and it is usually better than the average below.',
+        '# mean_objective: the average over the replicate runs. This is what the ranking',
+        '#   uses and it is the honest value to quote.',
+        '# standard_error: the uncertainty in that average. Two rows whose averages differ',
+        '#   by less than their standard errors have not really been told apart, so run',
+        '#   more replicates if you need to separate them.',
+        '# std_deviation: how much one run of this parameter set differs from the next.',
+        '# runs: replicate runs that produced a usable value.',
+        '# failed: replicate runs that produced none.',
+        '#',
+    ]
+    lines.append('candidates\t%d' % len(candidates))
+    lines.append('replicates_requested\t%d' % replicates)
+    if best is not None:
+        lines.append('winner\t%s' % best.name)
+        lines.append('winner_mean_objective\t%.10g' % mean_objective(best))
+        lines.append('winner_standard_error\t%s' % _number_text(standard_error(best)))
+        lines.append('winner_search_objective\t%s' % _number_text(best.search_objective))
+        if best.search_objective is not None and math.isfinite(best.search_objective):
+            lines.append('# optimism is how much better the search made the winner look than')
+            lines.append('#   running it again says it is.')
+            lines.append('optimism\t%.10g' % (mean_objective(best) - best.search_objective))
+        # A row other than the first says the search picked the wrong parameter set, which
+        # is the half of this that changes the answer rather than only the number.
+        if order and order[0] != 0:
+            lines.append('# search_rank is where the winner sat in the search\'s own ranking.')
+            lines.append('#   Anything but 1 means the search would have reported a different')
+            lines.append('#   parameter set.')
+            lines.append('search_rank\t%d' % (order[0] + 1))
+    else:
+        lines.append('# No candidate produced a usable objective value when it was run again,')
+        lines.append('#   so the best fit is the one the search picked.')
+        lines.append('winner\tnone')
+    lines.append('#')
+    lines.append('# rank\tname\tmean_objective\tstandard_error\tstd_deviation\truns\tfailed'
+                 '\tsearch_objective')
+    for rank, i in enumerate(order, start=1):
+        c = candidates[i]
+        lines.append('%d\t%s\t%s\t%s\t%s\t%d\t%d\t%s'
+                     % (rank, c.name, _number_text(mean_objective(c)),
+                        _number_text(standard_error(c)),
+                        _number_text(standard_deviation(c)),
+                        len(c.scores), c.failures,
+                        _number_text(c.search_objective)))
+    return lines
+
+
+def console_lines(candidates, replicates, path):
+    """The short version printed at the end of the run, as a list of lines."""
+    best = winner(candidates)
+    if best is None:
+        return ['Best-fit confirmation: none of the %d candidate parameter sets could be '
+                'run again, so the best fit is the one the search picked. Details: %s'
+                % (len(candidates), path)]
+    order = ranked(candidates)
+    lines = ['Best-fit confirmation: ran the top %d parameter sets %d more times each and '
+             'ranked them by average objective value.' % (len(candidates), replicates)]
+    sem = standard_error(best)
+    if sem is None:
+        lines.append('  Best average objective %.6g (%s).'
+                     % (mean_objective(best), best.name))
+    else:
+        lines.append('  Best average objective %.6g, give or take %.3g (%s).'
+                     % (mean_objective(best), sem, best.name))
+    if best.search_objective is not None and math.isfinite(best.search_objective):
+        lines.append('  The search reported %.6g for it, which was %.3g too good because '
+                     'that came from one simulation.'
+                     % (best.search_objective, mean_objective(best) - best.search_objective))
+    if order and order[0] != 0:
+        lines.append('  This is not the parameter set the search would have reported. It '
+                     'was number %d in the search ranking, and the one the search liked '
+                     'best does worse when it is run again.' % (order[0] + 1))
+    lines.append('  Details: %s' % path)
+    return lines

--- a/pybnf/config.py
+++ b/pybnf/config.py
@@ -314,6 +314,9 @@ class Configuration:
         # `stochastic` flag (#471). Legacy models set the flag at parse time, so the check is
         # order-independent for them.
         self._check_smoothing_misuse()
+        # Same deferral, same reason: the end-of-fit stage that confirms the best fit of a
+        # stochastic fit keys off the models' `stochastic` flags (#659).
+        self._check_best_fit_confirmation()
         # New-era observable: column-header overrides (ADR-0028, Chunk 4). Runs after every
         # experimental Data exists (so it can rename columns across all of them) and before
         # the objective is built (so the objective's by-name column match + per-observable
@@ -1071,6 +1074,58 @@ class Configuration:
                 'so PyBNF overrides the BNGL seed per replicate.'
                 % (self.config['smoothing'], self.config['stochastic_seed'])
             )
+
+    def _check_best_fit_confirmation(self):
+        """Validate the two best-fit confirmation keys, and tell a fit that needs the stage
+        but is not getting it (#659).
+
+        Called from ``__init__`` right after ``_check_smoothing_misuse`` and for the same
+        reason: an edition-2 model's ``stochastic`` flag is only set once the experiment
+        lines have been turned into actions (#471), so a check placed any earlier reads
+        every stochastic fit as deterministic.
+
+        Two things get said here. A legacy conf (no ``edition`` line) does not run the
+        stage, because the legacy edition's contract is that an unchanged conf keeps
+        behaving exactly as it always has, so a legacy fit with a stochastic model is told
+        that the objective value it is about to report will be too good and what to set to
+        fix that. And a fit that has asked for the stage but has pinned its stochastic
+        models to one seed is told that its replicates will all come out the same.
+        """
+        candidates = self.config.get('best_fit_candidates')
+        replicates = self.config.get('best_fit_replicates')
+        for key, value in (('best_fit_candidates', candidates), ('best_fit_replicates', replicates)):
+            if value is not None and value < 0:
+                raise PybnfError('%s must be zero or a positive whole number, not %s'
+                                 % (key, value))
+
+        md = self.models
+        stochastic = [m for m in md.values() if getattr(m, 'stochastic', False)]
+        if not stochastic:
+            return
+
+        modern = edition.is_modern(edition.resolve_edition(self.config.get('edition')))
+        on = (10 if modern else 0) if replicates is None else replicates
+        n_candidates = (10 if modern else 0) if candidates is None else candidates
+        if on < 2 or n_candidates < 1:
+            if not modern and replicates is None:
+                print1(
+                    'Warning: at least one of your models is stochastic, so running it twice with '
+                    'the same parameter values gives two different objective values. This fit will '
+                    'report the single best value it ever saw, which is optimistic, and the '
+                    'parameter set that saw it, which is often just the one that got a lucky '
+                    'simulation rather than the best one found. Set best_fit_replicates = 10 (and '
+                    'best_fit_candidates = 10) to have PyBNF run the top parameter sets again at '
+                    'the end of the fit and report the one that is really best.')
+            return
+
+        if self.config['stochastic_seed'].endswith('_honorbngl') and \
+                all(isinstance(m, BNGLModel) and m.seeded for m in stochastic):
+            print1(
+                'Warning: you asked for best_fit_replicates=%i, but stochastic_seed=%s honors the '
+                'explicit "seed" argument in your simulation commands, so every replicate would '
+                'reproduce the same trajectory. PyBNF will skip confirming the best fit. Switch to '
+                'stochastic_seed=auto (default) or stochastic_seed=random to enable it.'
+                % (on, self.config['stochastic_seed']))
 
     def _add_inline_analytical_target(self, md):
         """Synthesize the AnalyticalModel for an inline named objective (ADR-0059 item 6).

--- a/pybnf/config_schema.py
+++ b/pybnf/config_schema.py
@@ -201,6 +201,22 @@ class GlobalConfig(PyBNFConfigModel):
     refine_method: str = 'sim'
     bng_command: str = Field(default_factory=_default_bng_command)
     smoothing: int = 1
+    # The end-of-fit stage that decides which parameter set a stochastic fit really found
+    # (#659). A stochastic model gives a different objective value every time it is run, and
+    # a fit picks its answer by taking the best value it ever saw, so the winner is often
+    # just the parameter set that got a lucky simulation: the reported objective is too
+    # good and the reported parameters are not the best ones found. So at the end of the
+    # fit the top `best_fit_candidates` parameter sets are each run `best_fit_replicates`
+    # more times, and the one with the best average objective value is reported.
+    #
+    # Both are ignored unless at least one model is stochastic. None == the key was not
+    # named, which resolves at the read site (Algorithm._best_fit_confirmation_settings)
+    # to 10 and 10 under edition >= 2 and to off under the legacy edition, whose contract
+    # is that an unchanged conf keeps behaving exactly as it always has. Setting
+    # best_fit_replicates to 0 turns the stage off; the cost is candidates x replicates
+    # simulations (x smoothing, when smoothing is also on) after the search has ended.
+    best_fit_candidates: Optional[int] = None
+    best_fit_replicates: Optional[int] = None
     backup_every: int = 1
     # Also checkpoint the best fit's information criteria (#560): every backup that finds a
     # new best fit re-simulates it once and writes Results/information_criteria_backup.txt,

--- a/pybnf/parse.py
+++ b/pybnf/parse.py
@@ -84,7 +84,11 @@ numkeys_int = ['verbosity', 'parallel_count', 'delete_old_files', 'population_si
                # General multi-start for the metaheuristics (de / ss / pso / ade, #498/
                # ADR-0071): the number of independent starts, keeping the global best
                # (1 = a single run).
-               'n_starts']
+               'n_starts',
+               # The end-of-fit stage that confirms which parameter set a stochastic fit
+               # really found (#659): how many of the top parameter sets to run again, and
+               # how many times to run each of them.
+               'best_fit_candidates', 'best_fit_replicates']
 numkeys_float = ['min_objective', 'cognitive', 'social', 'particle_weight',
                  'particle_weight_final', 'adaptive_n_max', 'adaptive_n_stop', 'adaptive_abs_tol', 'adaptive_rel_tol',
                  'mutation_rate', 'mutation_factor', 'stop_tolerance',

--- a/pybnf/pset.py
+++ b/pybnf/pset.py
@@ -2810,6 +2810,12 @@ class Trajectory:
     Tracks the various PSet instances and the corresponding objective function values
     """
 
+    #: The entry ``pin_best`` named as this trajectory's answer, as the same
+    #: ``(-obj, name, PSet)`` tuple the heap holds, or None. Declared on the class so an
+    #: Algorithm unpickled from a backup written by an older PyBNF reads as unpinned
+    #: rather than raising.
+    _pinned = None
+
     def __init__(self, max_output):
         # self._trajectory is a heap-based priority queue
         # Contains tuples (-score, name, PSet) - allows us to efficiently toss the worst PSet when we get a new one
@@ -2817,6 +2823,7 @@ class Trajectory:
         # As long as you follow the rule of no duplicate names, this is safe and won't compare PSets.
         self._trajectory = []
         self.max_output = max_output
+        self._pinned = None
 
     def _valid_pset(self, pset):
         """
@@ -2848,6 +2855,13 @@ class Trajectory:
         else:
             # Add the current pset, and throw away the worst one
             heapq.heappushpop(self._trajectory, (-obj, name, pset))
+
+        # A pinned best names one entry as this trajectory's answer, decided from what had
+        # been scored at the time. A new evaluation can beat it, so the pin does not
+        # outlive the addition. This is what keeps a refine phase, which shares the fit's
+        # trajectory, from reporting the pre-refine point (#659).
+        if self._pinned is not None:
+            self._pinned = None
 
         if append_file:
             with open(append_file, 'a') as af:
@@ -2919,12 +2933,67 @@ class Trajectory:
     def __len__(self):
         """The number of parameter sets recorded so far.
 
-        ``best_fit`` / ``best_fit_name`` / ``best_score`` all take the ``max`` of the
+        ``best_fit`` / ``best_fit_name`` / ``best_score`` fall back to the ``max`` of the
         underlying heap, so they are only defined on a non-empty Trajectory; this is how
         a caller asks whether there is a best fit at all -- e.g. a run that stopped
         before its first result came back (#529).
         """
         return len(self._trajectory)
+
+    def top_fits(self, n, distinct=True):
+        """The n best entries, best objective value first.
+
+        Returns a list of ``(objective, name, PSet)`` triples, shorter than n when the
+        trajectory holds fewer entries than that. With ``distinct`` (the default) a set of
+        parameter values appears once however many times it was scored, so asking for ten
+        candidates gets ten different parameter sets rather than ten records of the same
+        one -- which is what a search that re-evaluates its population would otherwise
+        give.
+
+        Used by the end-of-fit stage that runs the top candidates again to decide which of
+        them is really best (#659). Note that the objective value here is whatever the
+        search recorded, which for a stochastic model came from a single simulation.
+        """
+        if n <= 0:
+            return []
+        chosen = []
+        seen = []
+        for entry in sorted(self._trajectory, reverse=True):
+            pset = entry[2]
+            if distinct:
+                if any(pset == other for other in seen):
+                    continue
+                seen.append(pset)
+            chosen.append((-entry[0], entry[1], pset))
+            if len(chosen) == n:
+                break
+        return chosen
+
+    def pin_best(self, pset, obj, name):
+        """Name one parameter set as this trajectory's best fit, whatever the recorded
+        objective values say.
+
+        The end-of-fit confirmation stage (#659) decides the answer of a stochastic fit by
+        running the top candidates again and averaging, so its winner is usually not the
+        entry holding the lowest recorded value. That entry got there on a single lucky
+        simulation. Pinning here rather than at each of the many places that ask for the
+        best fit means the whole run -- the saved simulations, the best-fit model file, the
+        information criteria, the refine start point, the bootstrap replicate -- reports
+        the same parameter set.
+
+        The pin is dropped as soon as anything else is added, since a new evaluation can
+        beat it.
+        """
+        self._pinned = (-obj, name, pset)
+
+    def clear_pinned_best(self):
+        """Forget a pinned best fit, so the recorded objective values decide again."""
+        self._pinned = None
+
+    def pinned_best(self):
+        """The pinned entry as a ``(-obj, name, PSet)`` tuple, or None when none is
+        pinned."""
+        return getattr(self, '_pinned', None)
 
     def best_fit(self):
         """
@@ -2932,7 +3001,7 @@ class Trajectory:
 
         :return: PSet
         """
-        return max(self._trajectory)[2]
+        return (self.pinned_best() or max(self._trajectory))[2]
 
     def best_fit_name(self):
         """
@@ -2941,14 +3010,14 @@ class Trajectory:
 
         :return: str
         """
-        return max(self._trajectory)[1]
+        return (self.pinned_best() or max(self._trajectory))[1]
 
     def best_score(self):
         """
         Returns the best objective value in this trajectory
         :return: float
         """
-        return -max(self._trajectory)[0]
+        return -(self.pinned_best() or max(self._trajectory))[0]
 
 
 class OutOfBoundsException(Exception):

--- a/tests/golden_configs/effective_config_golden.json
+++ b/tests/golden_configs/effective_config_golden.json
@@ -21,6 +21,14 @@
     ]
    ],
    [
+    "best_fit_candidates",
+    null
+   ],
+   [
+    "best_fit_replicates",
+    null
+   ],
+   [
     "beta",
     [
      1.0
@@ -449,6 +457,14 @@
     [
      "target.exp"
     ]
+   ],
+   [
+    "best_fit_candidates",
+    null
+   ],
+   [
+    "best_fit_replicates",
+    null
    ],
    [
     "beta",
@@ -913,6 +929,14 @@
     ]
    ],
    [
+    "best_fit_candidates",
+    null
+   ],
+   [
+    "best_fit_replicates",
+    null
+   ],
+   [
     "beta",
     [
      1.0
@@ -1359,6 +1383,14 @@
    [
     "backup_information_criteria",
     1
+   ],
+   [
+    "best_fit_candidates",
+    null
+   ],
+   [
+    "best_fit_replicates",
+    null
    ],
    [
     "beta",
@@ -1901,6 +1933,14 @@
    [
     "backup_information_criteria",
     1
+   ],
+   [
+    "best_fit_candidates",
+    null
+   ],
+   [
+    "best_fit_replicates",
+    null
    ],
    [
     "beta",
@@ -2477,6 +2517,14 @@
     1
    ],
    [
+    "best_fit_candidates",
+    null
+   ],
+   [
+    "best_fit_replicates",
+    null
+   ],
+   [
     "beta",
     [
      1.0
@@ -3043,6 +3091,14 @@
     1
    ],
    [
+    "best_fit_candidates",
+    null
+   ],
+   [
+    "best_fit_replicates",
+    null
+   ],
+   [
     "beta",
     [
      1.0
@@ -3471,6 +3527,14 @@
    [
     "backup_information_criteria",
     1
+   ],
+   [
+    "best_fit_candidates",
+    null
+   ],
+   [
+    "best_fit_replicates",
+    null
    ],
    [
     "beta",
@@ -3935,6 +3999,14 @@
     1
    ],
    [
+    "best_fit_candidates",
+    null
+   ],
+   [
+    "best_fit_replicates",
+    null
+   ],
+   [
     "beta",
     [
      1.0
@@ -4385,6 +4457,14 @@
     1
    ],
    [
+    "best_fit_candidates",
+    null
+   ],
+   [
+    "best_fit_replicates",
+    null
+   ],
+   [
     "bngl_backend",
     "auto"
    ],
@@ -4732,6 +4812,14 @@
    [
     "backup_information_criteria",
     1
+   ],
+   [
+    "best_fit_candidates",
+    null
+   ],
+   [
+    "best_fit_replicates",
+    null
    ],
    [
     "beta",
@@ -5134,6 +5222,14 @@
     1
    ],
    [
+    "best_fit_candidates",
+    null
+   ],
+   [
+    "best_fit_replicates",
+    null
+   ],
+   [
     "bngl_backend",
     "auto"
    ],
@@ -5417,6 +5513,14 @@
    [
     "backup_information_criteria",
     1
+   ],
+   [
+    "best_fit_candidates",
+    null
+   ],
+   [
+    "best_fit_replicates",
+    null
    ],
    [
     "bngl_backend",
@@ -5716,6 +5820,14 @@
    [
     "backup_information_criteria",
     1
+   ],
+   [
+    "best_fit_candidates",
+    null
+   ],
+   [
+    "best_fit_replicates",
+    null
    ],
    [
     "bngl_backend",
@@ -6062,6 +6174,14 @@
    [
     "backup_information_criteria",
     1
+   ],
+   [
+    "best_fit_candidates",
+    null
+   ],
+   [
+    "best_fit_replicates",
+    null
    ],
    [
     "bngl_backend",
@@ -6411,6 +6531,14 @@
    [
     "backup_information_criteria",
     1
+   ],
+   [
+    "best_fit_candidates",
+    null
+   ],
+   [
+    "best_fit_replicates",
+    null
    ],
    [
     "bngl_backend",
@@ -6768,6 +6896,14 @@
    [
     "backup_information_criteria",
     1
+   ],
+   [
+    "best_fit_candidates",
+    null
+   ],
+   [
+    "best_fit_replicates",
+    null
    ],
    [
     "bngl_backend",
@@ -7149,6 +7285,14 @@
    [
     "backup_information_criteria",
     1
+   ],
+   [
+    "best_fit_candidates",
+    null
+   ],
+   [
+    "best_fit_replicates",
+    null
    ],
    [
     "bngl_backend",
@@ -7536,6 +7680,14 @@
     1
    ],
    [
+    "best_fit_candidates",
+    null
+   ],
+   [
+    "best_fit_replicates",
+    null
+   ],
+   [
     "bngl_backend",
     "auto"
    ],
@@ -7907,6 +8059,14 @@
    [
     "backup_information_criteria",
     1
+   ],
+   [
+    "best_fit_candidates",
+    null
+   ],
+   [
+    "best_fit_replicates",
+    null
    ],
    [
     "beta",
@@ -8301,6 +8461,14 @@
     1
    ],
    [
+    "best_fit_candidates",
+    null
+   ],
+   [
+    "best_fit_replicates",
+    null
+   ],
+   [
     "bngl_backend",
     "auto"
    ],
@@ -8656,6 +8824,14 @@
    [
     "backup_information_criteria",
     1
+   ],
+   [
+    "best_fit_candidates",
+    null
+   ],
+   [
+    "best_fit_replicates",
+    null
    ],
    [
     "bngl_backend",
@@ -9015,6 +9191,14 @@
     1
    ],
    [
+    "best_fit_candidates",
+    null
+   ],
+   [
+    "best_fit_replicates",
+    null
+   ],
+   [
     "bngl_backend",
     "auto"
    ],
@@ -9370,6 +9554,14 @@
    [
     "backup_information_criteria",
     1
+   ],
+   [
+    "best_fit_candidates",
+    null
+   ],
+   [
+    "best_fit_replicates",
+    null
    ],
    [
     "bngl_backend",
@@ -9729,6 +9921,14 @@
     1
    ],
    [
+    "best_fit_candidates",
+    null
+   ],
+   [
+    "best_fit_replicates",
+    null
+   ],
+   [
     "bngl_backend",
     "auto"
    ],
@@ -10061,6 +10261,14 @@
    [
     "backup_information_criteria",
     1
+   ],
+   [
+    "best_fit_candidates",
+    null
+   ],
+   [
+    "best_fit_replicates",
+    null
    ],
    [
     "bngl_backend",
@@ -10419,6 +10627,14 @@
     1
    ],
    [
+    "best_fit_candidates",
+    null
+   ],
+   [
+    "best_fit_replicates",
+    null
+   ],
+   [
     "bngl_backend",
     "auto"
    ],
@@ -10762,6 +10978,14 @@
    [
     "backup_information_criteria",
     1
+   ],
+   [
+    "best_fit_candidates",
+    null
+   ],
+   [
+    "best_fit_replicates",
+    null
    ],
    [
     "beta",
@@ -11158,6 +11382,14 @@
     1
    ],
    [
+    "best_fit_candidates",
+    null
+   ],
+   [
+    "best_fit_replicates",
+    null
+   ],
+   [
     "beta",
     [
      0.5,
@@ -11542,6 +11774,14 @@
     1
    ],
    [
+    "best_fit_candidates",
+    null
+   ],
+   [
+    "best_fit_replicates",
+    null
+   ],
+   [
     "beta",
     [
      1.0
@@ -11879,6 +12119,14 @@
    [
     "backup_information_criteria",
     1
+   ],
+   [
+    "best_fit_candidates",
+    null
+   ],
+   [
+    "best_fit_replicates",
+    null
    ],
    [
     "bngl_backend",
@@ -12225,6 +12473,14 @@
    [
     "backup_information_criteria",
     1
+   ],
+   [
+    "best_fit_candidates",
+    null
+   ],
+   [
+    "best_fit_replicates",
+    null
    ],
    [
     "bngl_backend",
@@ -12574,6 +12830,14 @@
    [
     "backup_information_criteria",
     1
+   ],
+   [
+    "best_fit_candidates",
+    null
+   ],
+   [
+    "best_fit_replicates",
+    null
    ],
    [
     "bngl_backend",

--- a/tests/test_benchmark_harness.py
+++ b/tests/test_benchmark_harness.py
@@ -95,6 +95,12 @@ _EXCLUDE = frozenset({
     # benchmark here is a sampler/metaheuristic that never activates the gradient path, so
     # its value is inert for this oracle.
     'sensitivity_fallback',
+    # Post-freeze best-fit confirmation keys (#659): how many of the top parameter sets to
+    # run again at the end of a stochastic fit, and how many times each. Both default to
+    # None, which under the legacy edition these pre-migration confs run as means the stage
+    # is off, and every benchmark here carries an analytical .target model that is not
+    # stochastic anyway.
+    'best_fit_candidates', 'best_fit_replicates',
 })
 
 

--- a/tests/test_best_fit_confirmation.py
+++ b/tests/test_best_fit_confirmation.py
@@ -1,0 +1,684 @@
+"""The end-of-fit stage that confirms the best fit of a stochastic fit (#659).
+
+A stochastic model gives a different objective value every time it is run, so a fit that
+picks its answer by taking the best value it ever saw usually picks the parameter set that
+got a lucky simulation. The fix runs the top parameter sets again several times each and
+ranks them by their average.
+
+Three layers are covered here, in this order.
+
+  * ``pybnf.algorithms.best_fit_confirmation``: the arithmetic and the report text. It
+    holds no state and touches no files, so it is tested on its own.
+  * ``pybnf.pset.Trajectory``: ``top_fits`` picks the candidates, and ``pin_best`` is how
+    the winner becomes the run's answer everywhere at once.
+  * ``Algorithm._confirm_best_fit``: the stage itself, driven by the same synchronous fake
+    dask client ``test_run_loop`` uses. The fake model here is deliberately noisy in a
+    controlled way -- its objective value depends on the replicate index -- so a test can
+    set up the exact situation the issue describes: a mediocre parameter set that got one
+    lucky simulation sitting on top of a genuinely better one.
+"""
+import math
+import os
+
+import numpy as np
+import pytest
+
+from .context import algorithms, config, printing, pset
+import pybnf.algorithms.base as base
+from pybnf.algorithms import best_fit_confirmation as bfc
+from pybnf.pset import Trajectory, PSet, FreeParameter
+
+
+# --------------------------------------------------------------------------- #
+# The report module: arithmetic and text
+# --------------------------------------------------------------------------- #
+def _candidate(name, search_objective, scores, failures=0):
+    return bfc.Candidate(name=name, pset=None, search_objective=search_objective,
+                         scores=tuple(scores), failures=failures)
+
+
+def test_mean_is_the_average_of_the_replicate_values():
+    c = _candidate('a', 1.0, [2.0, 4.0, 6.0])
+    assert bfc.mean_objective(c) == 4.0
+    np.testing.assert_allclose(bfc.standard_deviation(c), 2.0)
+    np.testing.assert_allclose(bfc.standard_error(c), 2.0 / math.sqrt(3))
+
+
+def test_a_candidate_with_no_usable_value_sorts_last_and_never_wins():
+    good = _candidate('good', 1.0, [3.0])
+    dead = _candidate('dead', 0.1, [], failures=10)
+    assert bfc.mean_objective(dead) == math.inf
+    assert bfc.standard_deviation(dead) is None
+    assert bfc.standard_error(dead) is None
+    assert bfc.ranked([dead, good]) == [1, 0]
+    assert bfc.winner([dead, good]).name == 'good'
+
+
+def test_no_winner_when_nothing_could_be_run_again():
+    assert bfc.winner([_candidate('a', 1.0, []), _candidate('b', 2.0, [])]) is None
+    assert bfc.winner([]) is None
+
+
+def test_ties_keep_the_order_the_search_ranked_them_in():
+    a = _candidate('a', 1.0, [5.0])
+    b = _candidate('b', 2.0, [5.0])
+    assert bfc.ranked([a, b]) == [0, 1]
+    assert bfc.ranked([b, a]) == [0, 1]
+
+
+def test_summary_reports_the_optimism_and_the_search_rank_of_the_winner():
+    """The two facts the issue is about: the reported objective was too good, and the
+    search would have reported a different parameter set."""
+    lucky = _candidate('lucky', 1.0, [10.0, 10.0])     # looked best, is not
+    real = _candidate('real', 3.0, [4.0, 4.0])         # looked worse, is best
+    text = '\n'.join(bfc.summary_lines([lucky, real], replicates=2))
+
+    assert 'winner\treal' in text
+    assert 'winner_mean_objective\t4' in text
+    # The search said 3.0 for the winner but running it again says 4.0.
+    assert 'optimism\t1' in text
+    # The winner sat second in the search's own ranking.
+    assert 'search_rank\t2' in text
+    rows = [l for l in text.splitlines() if l and not l.startswith('#') and l[0].isdigit()]
+    assert rows[0].startswith('1\treal\t4')
+    assert rows[1].startswith('2\tlucky\t10')
+
+
+def test_summary_has_no_search_rank_when_the_search_already_had_it_right():
+    text = '\n'.join(bfc.summary_lines(
+        [_candidate('a', 1.0, [2.0]), _candidate('b', 3.0, [5.0])], replicates=1))
+    assert 'search_rank' not in text
+    assert 'winner\ta' in text
+
+
+def test_summary_says_so_when_no_candidate_could_be_run_again():
+    text = '\n'.join(bfc.summary_lines([_candidate('a', 1.0, [], failures=3)], replicates=3))
+    assert 'winner\tnone' in text
+    assert 'the best fit is the one the search picked' in text
+
+
+def test_console_lines_name_the_file_and_flag_a_changed_answer():
+    lines = bfc.console_lines([_candidate('lucky', 1.0, [10.0, 10.0]),
+                               _candidate('real', 3.0, [4.0, 4.0])],
+                              replicates=2, path='/tmp/x.txt')
+    text = '\n'.join(lines)
+    assert '/tmp/x.txt' in text
+    assert 'not the parameter set the search would have reported' in text
+
+
+# --------------------------------------------------------------------------- #
+# Trajectory: choosing the candidates and recording the winner
+# --------------------------------------------------------------------------- #
+def _ps(value, name=None):
+    p = PSet([FreeParameter('v1__FREE', 'uniform_var', 0, 100, value)])
+    p.name = name
+    return p
+
+
+def test_top_fits_returns_the_best_entries_best_first():
+    t = Trajectory(100)
+    for name, value, obj in [('a', 1.0, 9.0), ('b', 2.0, 3.0), ('c', 3.0, 5.0)]:
+        t.add(_ps(value), obj, name)
+    assert [(o, n) for o, n, _ in t.top_fits(2)] == [(3.0, 'b'), (5.0, 'c')]
+    assert len(t.top_fits(10)) == 3
+    assert t.top_fits(0) == []
+
+
+def test_top_fits_counts_each_set_of_parameter_values_once():
+    """A search that re-evaluates its population records the same parameter values many
+    times. Asking for three candidates should get three different ones, not three records
+    of the same one."""
+    t = Trajectory(100)
+    t.add(_ps(1.0), 3.0, 'a')
+    t.add(_ps(1.0), 3.5, 'a2')     # same values, scored again
+    t.add(_ps(2.0), 4.0, 'b')
+    assert [n for _, n, _ in t.top_fits(3)] == ['a', 'b']
+    assert [n for _, n, _ in t.top_fits(3, distinct=False)] == ['a', 'a2', 'b']
+
+
+def test_pinning_a_best_fit_overrides_the_recorded_values():
+    t = Trajectory(100)
+    t.add(_ps(1.0), 1.0, 'lucky')
+    t.add(_ps(2.0), 2.0, 'real')
+    assert t.best_fit_name() == 'lucky'
+
+    t.pin_best(_ps(2.0), 4.0, 'real')
+    assert t.best_fit_name() == 'real'
+    assert t.best_score() == 4.0
+    assert t.best_fit()['v1__FREE'] == 2.0
+
+
+def test_a_new_evaluation_drops_the_pin():
+    """A refine shares the fit's trajectory, so a pin left over from the fit would make the
+    run report the point the refine started from instead of the one it reached."""
+    t = Trajectory(100)
+    t.add(_ps(1.0), 1.0, 'lucky')
+    t.pin_best(_ps(1.0), 4.0, 'lucky')
+    t.add(_ps(3.0), 0.5, 'refined')
+    assert t.pinned_best() is None
+    assert t.best_fit_name() == 'refined'
+
+
+def test_clearing_the_pin_restores_the_recorded_best():
+    t = Trajectory(100)
+    t.add(_ps(1.0), 1.0, 'a')
+    t.pin_best(_ps(1.0), 9.0, 'a')
+    t.clear_pinned_best()
+    assert t.best_score() == 1.0
+
+
+# --------------------------------------------------------------------------- #
+# Fakes: a noisy model, a noise-reading objective, a synchronous dask client
+# --------------------------------------------------------------------------- #
+#: Objective value of one run, as (parameter value, replicate index) -> value. Anything
+#: not listed scores as its parameter value, so a test only spells out the runs it cares
+#: about. Replicate index 0 is what the search itself used.
+NOISE = {}
+
+
+class _NoisyModelCopy:
+    """Reports back the replicate index it was run with, which is the only thing that
+    changes from one run of the same parameter set to the next."""
+
+    def __init__(self, name):
+        self.name = name
+        self._pybnf_replicate_index = 0
+
+    def execute(self, folder, file_prefix, timeout):
+        from pybnf import data as data_mod
+        d = data_mod.Data()
+        d.cols = {'time': 0, 'v1_result': 1}
+        d.data = np.array([[0.0, float(self._pybnf_replicate_index)]], dtype=float)
+        return {'time_course': d}
+
+    def save_all(self, prefix):
+        pass
+
+
+class _NoisyModel:
+    suffixes = []
+
+    def __init__(self, name='m', stochastic=True, seeded=False):
+        self.name = name
+        self.stochastic = stochastic
+        self.seeded = seeded
+
+    def copy_with_param_set(self, params):
+        return _NoisyModelCopy(self.name)
+
+    def save_all(self, prefix):
+        pass
+
+
+class _NoisyObjective:
+    """Scores a run from its parameter value and the replicate index the model reported,
+    through the NOISE table."""
+
+    def evaluate_multiple(self, simdata, exp_data, ps, constraints, show_warnings=True):
+        value = float(ps['v1__FREE'])
+        replicate = int(simdata['m']['time_course'].data[0][1])
+        return float(NOISE.get((value, replicate), value))
+
+
+class _FakeFuture:
+    def __init__(self, result):
+        self._result = result
+        self.status = 'finished'
+
+    def result(self):
+        return self._result
+
+
+class _FakeClient:
+    """Runs each submitted callable inline and returns a finished future."""
+
+    def __init__(self):
+        self.submitted = []
+
+    def submit(self, fn, *args, **kwargs):
+        self.submitted.append(args[0])   # the Job
+        return _FakeFuture(fn(*args))
+
+
+class _FakeAsCompleted:
+    def __init__(self, futures, with_results=False, raise_errors=True, timeout=None):
+        assert with_results and not raise_errors
+        self._queue = list(futures)
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if not self._queue:
+            raise StopIteration
+        f = self._queue.pop(0)
+        return f, f.result()
+
+
+class _ConcreteAlgorithm(algorithms.Algorithm):
+    def start_run(self):
+        return []
+
+    def got_result(self, res):
+        return []
+
+
+def _algo(tmp_path, *, models=None, edition=2, candidates=None, replicates=None,
+          smoothing=1, stochastic_seed='auto', parallelize_models=1):
+    out = str(tmp_path)
+    sim_dir = out + '/Simulations'
+    res_dir = out + '/Results'
+    os.makedirs(sim_dir, exist_ok=True)
+    os.makedirs(res_dir, exist_ok=True)
+
+    if models is None:
+        models = {'m': _NoisyModel()}
+
+    algo = object.__new__(_ConcreteAlgorithm)
+    algo.config = type('Cfg', (), {})()
+    algo.config.config = {
+        'smoothing': smoothing, 'parallelize_models': parallelize_models,
+        'local_objective_eval': 1, 'wall_time_sim': None, 'normalization': None,
+        'stochastic_seed': stochastic_seed, 'delete_old_files': 0,
+        'edition': edition, 'best_fit_candidates': candidates,
+        'best_fit_replicates': replicates, 'num_to_output': 100,
+    }
+    algo.config.postprocessing = {}
+    algo.config.constraints = []
+    algo.config.models = models
+
+    algo.objective = _NoisyObjective()
+    algo.exp_data = {}
+    algo.trajectory = Trajectory(100)
+    algo.job_id_counter = 0
+    algo.job_group_dir = {}
+    algo.model_list = list(models.values())
+    algo.sim_dir = sim_dir
+    algo.res_dir = res_dir
+    algo.failed_logs_dir = out + '/FailedSimLogs'
+    os.makedirs(algo.failed_logs_dir, exist_ok=True)
+    algo.calc_future = None
+    algo.models_future = None
+    algo.refine = False
+    return algo
+
+
+@pytest.fixture(autouse=True)
+def _clean_noise():
+    NOISE.clear()
+    yield
+    NOISE.clear()
+
+
+@pytest.fixture
+def _sync_dask(monkeypatch):
+    monkeypatch.setattr(algorithms.core, 'as_completed', _FakeAsCompleted)
+
+
+# --------------------------------------------------------------------------- #
+# Settings and gating
+# --------------------------------------------------------------------------- #
+def test_the_stage_is_on_by_default_under_a_modern_edition(tmp_path):
+    assert _algo(tmp_path, edition=2)._best_fit_confirmation_settings() == (10, 10)
+
+
+def test_the_stage_is_off_by_default_under_the_legacy_edition(tmp_path):
+    """A conf that names no edition keeps behaving exactly as it always has."""
+    assert _algo(tmp_path, edition=None)._best_fit_confirmation_settings() == (0, 0)
+
+
+def test_an_explicit_setting_wins_under_either_edition(tmp_path):
+    assert _algo(tmp_path, edition=None, candidates=4,
+                 replicates=6)._best_fit_confirmation_settings() == (4, 6)
+    assert _algo(tmp_path, edition=2, candidates=0,
+                 replicates=0)._best_fit_confirmation_settings() == (0, 0)
+
+
+def test_replicates_differ_only_when_a_model_is_stochastic(tmp_path):
+    assert _algo(tmp_path)._replicates_would_differ() is True
+    deterministic = {'m': _NoisyModel(stochastic=False)}
+    assert _algo(tmp_path, models=deterministic)._replicates_would_differ() is False
+
+
+def test_replicates_do_not_differ_when_every_stochastic_model_pins_its_seed(tmp_path):
+    """Under an _honorbngl policy an explicit seed in the model is honored, so every run
+    reproduces one trajectory and there is nothing to average."""
+    pinned = {'m': _NoisyModel(seeded=True)}
+    algo = _algo(tmp_path, models=pinned, stochastic_seed='auto_honorbngl')
+    assert algo._replicates_would_differ() is False
+    # One unpinned stochastic model is enough for replicates to mean something.
+    mixed = {'m': _NoisyModel(seeded=True), 'n': _NoisyModel(name='n', seeded=False)}
+    assert _algo(tmp_path, models=mixed,
+                 stochastic_seed='auto_honorbngl')._replicates_would_differ() is True
+
+
+@pytest.mark.parametrize('kwargs', [
+    dict(models={'m': _NoisyModel(stochastic=False)}),  # nothing stochastic
+    dict(edition=None),                                 # legacy: off by default
+    dict(replicates=1),                                 # too few replicates to average
+    dict(candidates=0),                                 # no candidates asked for
+])
+def test_the_stage_does_nothing_when_it_does_not_apply(tmp_path, _sync_dask, kwargs):
+    algo = _algo(tmp_path, **kwargs)
+    algo.trajectory.add(_ps(1.0), 1.0, 'a')
+    client = _FakeClient()
+    algo._confirm_best_fit(client)
+    assert client.submitted == []
+    assert algo.trajectory.pinned_best() is None
+    assert not os.path.exists(algo.res_dir + '/best_fit_confirmation.txt')
+
+
+def test_the_stage_does_nothing_once_the_wall_time_budget_is_spent(
+        tmp_path, _sync_dask, monkeypatch):
+    """A budget is a promise about the whole run, and this stage costs a hundred more
+    simulations. A run that is already out of time says what it is skipping instead."""
+    printed = []
+    monkeypatch.setattr(base, 'print1', lambda msg, *a, **k: printed.append(msg))
+    algo = _algo(tmp_path, candidates=2, replicates=2)
+    algo.trajectory.add(_ps(1.0), 1.0, 'a')
+    algo.budget = type('B', (), {'expired': lambda self: True})()
+    client = _FakeClient()
+
+    algo._confirm_best_fit(client)
+
+    assert client.submitted == []
+    assert algo.trajectory.pinned_best() is None
+    assert any('wall-time budget is spent' in m for m in printed)
+
+
+def test_the_stage_does_nothing_without_a_client(tmp_path):
+    algo = _algo(tmp_path, candidates=2, replicates=2)
+    algo.trajectory.add(_ps(1.0), 1.0, 'a')
+    algo._confirm_best_fit(None)
+    assert algo.trajectory.pinned_best() is None
+
+
+# --------------------------------------------------------------------------- #
+# The stage itself
+# --------------------------------------------------------------------------- #
+def test_a_lucky_parameter_set_loses_to_a_better_one_when_both_are_run_again(
+        tmp_path, _sync_dask, monkeypatch):
+    """The situation the issue describes. Parameter set 1.0 is genuinely worse than 2.0,
+    but the one simulation the search gave it came out at 0.1, so the search ranked it
+    first. Running both again three times each puts 2.0 back on top, and the run reports
+    2.0 with its honest average rather than 1.0 with 0.1."""
+    printed = []
+    monkeypatch.setattr(base, 'print1', lambda msg, *a, **k: printed.append(msg))
+
+    for replicate in (1, 2, 3):
+        NOISE[(1.0, replicate)] = 5.0     # the lucky set is really a 5
+        NOISE[(2.0, replicate)] = 2.0     # the better set is really a 2
+
+    algo = _algo(tmp_path, candidates=2, replicates=3)
+    algo.trajectory.add(_ps(1.0), 0.1, 'lucky')
+    algo.trajectory.add(_ps(2.0), 2.0, 'real')
+    client = _FakeClient()
+
+    algo._confirm_best_fit(client)
+
+    # Two candidates, three replicates each.
+    assert len(client.submitted) == 6
+    # The run's answer is now the genuinely better parameter set, at its honest value.
+    assert algo.trajectory.best_fit()['v1__FREE'] == 2.0
+    assert algo.trajectory.best_score() == 2.0
+    assert algo.trajectory.best_fit_name() == 'real'
+
+    text = open(algo.res_dir + '/best_fit_confirmation.txt').read()
+    assert 'winner\treal' in text
+    assert 'search_rank\t2' in text
+    assert 'not the parameter set the search would have reported' in '\n'.join(printed)
+
+
+def test_the_reported_objective_stops_being_the_luckiest_draw(tmp_path, _sync_dask):
+    """Even when the search picked the right parameter set, the value it reported was the
+    best of many noisy draws. After the stage the reported value is an average."""
+    for replicate in (1, 2, 3, 4):
+        NOISE[(1.0, replicate)] = 5.0
+
+    algo = _algo(tmp_path, candidates=1, replicates=4)
+    algo.trajectory.add(_ps(1.0), 0.5, 'best')
+    algo._confirm_best_fit(_FakeClient())
+
+    assert algo.trajectory.best_fit_name() == 'best'
+    assert algo.trajectory.best_score() == 5.0
+    text = open(algo.res_dir + '/best_fit_confirmation.txt').read()
+    assert 'optimism\t4.5' in text
+
+
+def test_every_replicate_gets_a_fresh_index_past_the_ones_the_fit_used(tmp_path, _sync_dask):
+    """Under the default seed policy the seed comes from the parameter values and the
+    replicate index, so reusing index 0 would reproduce the simulation the search already
+    ran instead of drawing a new one."""
+    algo = _algo(tmp_path, candidates=2, replicates=3)
+    algo.trajectory.add(_ps(1.0), 1.0, 'a')
+    algo.trajectory.add(_ps(2.0), 2.0, 'b')
+    client = _FakeClient()
+
+    algo._confirm_best_fit(client)
+
+    indices = sorted(job.replicate_index for job in client.submitted)
+    assert indices == [1, 1, 2, 2, 3, 3]
+
+
+def test_the_indices_clear_the_smoothing_replicates_too(tmp_path, _sync_dask):
+    """With smoothing on, the fit itself already used indices 0 .. smoothing-1 for every
+    parameter set, so the confirmation runs have to start above them."""
+    algo = _algo(tmp_path, candidates=1, replicates=2, smoothing=3)
+    algo.trajectory.add(_ps(1.0), 1.0, 'a')
+    client = _FakeClient()
+
+    algo._confirm_best_fit(client)
+
+    # 1 candidate x 2 replicates x 3 smoothing sub-runs, none of them reusing 0, 1 or 2.
+    assert len(client.submitted) == 6
+    assert sorted(job.replicate_index for job in client.submitted) == [3, 4, 5, 6, 7, 8]
+    # Each replicate is still one whole evaluation, so it is one score, not three.
+    text = open(algo.res_dir + '/best_fit_confirmation.txt').read()
+    row = [l for l in text.splitlines() if l.startswith('1\t')][0]
+    assert row.split('\t')[5] == '2'   # the "runs" column
+
+
+def test_a_failed_replicate_is_counted_and_the_rest_still_decide(tmp_path, _sync_dask):
+    class _SometimesFails(_NoisyModel):
+        def copy_with_param_set(self, params):
+            copy = _NoisyModelCopy(self.name)
+            original = copy.execute
+
+            def execute(folder, prefix, timeout):
+                from pybnf.pset import FailedSimulationError
+                if copy._pybnf_replicate_index == 2:
+                    raise FailedSimulationError('forced failure')
+                return original(folder, prefix, timeout)
+
+            copy.execute = execute
+            return copy
+
+    NOISE[(1.0, 1)] = 7.0
+    NOISE[(1.0, 3)] = 9.0
+    algo = _algo(tmp_path, models={'m': _SometimesFails()}, candidates=1, replicates=3)
+    algo.trajectory.add(_ps(1.0), 1.0, 'a')
+
+    algo._confirm_best_fit(_FakeClient())
+
+    assert algo.trajectory.best_score() == 8.0    # mean of 7 and 9; the failure is left out
+    row = [l for l in open(algo.res_dir + '/best_fit_confirmation.txt').read().splitlines()
+           if l.startswith('1\t')][0]
+    fields = row.split('\t')
+    assert fields[5] == '2' and fields[6] == '1'  # 2 runs, 1 failed
+
+
+def test_the_search_answer_stands_when_no_replicate_can_be_run(tmp_path, _sync_dask):
+    class _AlwaysFails(_NoisyModel):
+        def copy_with_param_set(self, params):
+            copy = _NoisyModelCopy(self.name)
+
+            def execute(folder, prefix, timeout):
+                from pybnf.pset import FailedSimulationError
+                raise FailedSimulationError('forced failure')
+
+            copy.execute = execute
+            return copy
+
+    algo = _algo(tmp_path, models={'m': _AlwaysFails()}, candidates=1, replicates=2)
+    algo.trajectory.add(_ps(1.0), 1.0, 'a')
+
+    algo._confirm_best_fit(_FakeClient())
+
+    assert algo.trajectory.pinned_best() is None
+    assert algo.trajectory.best_score() == 1.0
+    assert 'winner\tnone' in open(algo.res_dir + '/best_fit_confirmation.txt').read()
+
+
+def test_a_broken_stage_never_kills_a_finished_fit(tmp_path, _sync_dask, monkeypatch):
+    algo = _algo(tmp_path, candidates=1, replicates=2)
+    algo.trajectory.add(_ps(1.0), 1.0, 'a')
+    monkeypatch.setattr(_ConcreteAlgorithm, 'make_job',
+                        lambda self, params, replicate_offset=0: 1 / 0)
+
+    algo._confirm_best_fit(_FakeClient())    # does not raise
+
+    assert algo.trajectory.best_score() == 1.0
+
+
+def test_a_refine_writes_its_own_table(tmp_path, _sync_dask):
+    algo = _algo(tmp_path, candidates=1, replicates=2)
+    algo.refine = True
+    algo.trajectory.add(_ps(1.0), 1.0, 'a')
+
+    algo._confirm_best_fit(_FakeClient())
+
+    assert os.path.exists(algo.res_dir + '/best_fit_confirmation_refine.txt')
+    assert not os.path.exists(algo.res_dir + '/best_fit_confirmation.txt')
+
+
+# --------------------------------------------------------------------------- #
+# Wiring into the end-of-fit path
+# --------------------------------------------------------------------------- #
+def test_the_rest_of_the_end_of_fit_path_uses_the_confirmed_parameter_set(
+        tmp_path, _sync_dask, monkeypatch):
+    """The winner is recorded on the trajectory rather than passed around, so everything
+    the run writes after this stage -- the saved simulations, the best-fit model file, the
+    information criteria -- describes the same parameter set."""
+    for replicate in (1, 2):
+        NOISE[(1.0, replicate)] = 5.0
+        NOISE[(2.0, replicate)] = 2.0
+
+    algo = _algo(tmp_path, candidates=2, replicates=2)
+    algo.trajectory.add(_ps(1.0), 0.1, 'lucky')
+    algo.trajectory.add(_ps(2.0), 2.0, 'real')
+    algo.stop_reason = None
+    algo.output_counter = 0
+
+    handed = {}
+    monkeypatch.setattr(_ConcreteAlgorithm, 'output_results', lambda self, name='', **k: None)
+    monkeypatch.setattr(_ConcreteAlgorithm, '_copy_best_fit_sims',
+                        lambda self, p, n: handed.update(pset=p, name=n))
+    for skipped in ('_rerun_best_fit_to_save_data', '_emit_best_fit_bngl',
+                    '_emit_profiled_noise', '_emit_inference_data',
+                    '_finalize_backup_pickle', '_teardown_sim_dir'):
+        monkeypatch.setattr(_ConcreteAlgorithm, skipped, lambda self, *a, **k: None)
+    monkeypatch.setattr(_ConcreteAlgorithm, '_compute_information_criteria',
+                        lambda self, p: None)
+    monkeypatch.setattr(_ConcreteAlgorithm, '_emit_information_criteria', lambda self, ic: None)
+
+    algo._finalize_run(_FakeClient())
+
+    assert handed['name'] == 'real'
+    assert handed['pset']['v1__FREE'] == 2.0
+
+
+def test_run_hands_its_client_to_the_end_of_fit_path(tmp_path, monkeypatch):
+    """The stage submits simulations, so it needs the client the fit was driven with."""
+    seen = []
+    monkeypatch.setattr(_ConcreteAlgorithm, '_finalize_run',
+                        lambda self, client=None: seen.append(client))
+
+    algo = _algo(tmp_path)
+    algo.config.config.update({'backup_every': 10 ** 9, 'population_size': 1})
+    algo.stop_reason = None
+    algo.completed_simulations = 0
+    algo.budget = None
+    algo.variables = []
+    monkeypatch.setattr(_ConcreteAlgorithm, '_budget_spent', lambda self: True)
+    monkeypatch.setattr(_ConcreteAlgorithm, '_wall_time_stop_reason', lambda self, n: 'stopped')
+    monkeypatch.setattr(_ConcreteAlgorithm, '_emit_start_point', lambda self, p, resumed: None)
+
+    client = _FakeClient()
+    client.scatter = lambda objs, broadcast=False: [_FakeFuture(o) for o in objs]
+    client.cancel = lambda futures: None
+    algo.run(client)
+
+    assert seen == [client]
+
+
+# --------------------------------------------------------------------------- #
+# make_job's replicate offset
+# --------------------------------------------------------------------------- #
+def test_replicate_offset_shifts_a_plain_job(tmp_path):
+    algo = _algo(tmp_path)
+    assert algo.make_job(_ps(1.0, 'j'))[0].replicate_index == 0
+    assert algo.make_job(_ps(1.0, 'j'), replicate_offset=5)[0].replicate_index == 5
+
+
+def test_replicate_offset_shifts_a_whole_smoothing_group(tmp_path):
+    algo = _algo(tmp_path, smoothing=3)
+    assert [j.replicate_index for j in algo.make_job(_ps(1.0, 'j'))] == [0, 1, 2]
+    assert [j.replicate_index for j in
+            algo.make_job(_ps(1.0, 'k'), replicate_offset=3)] == [3, 4, 5]
+
+
+# --------------------------------------------------------------------------- #
+# What the configuration says at startup
+# --------------------------------------------------------------------------- #
+class _FakeBNGL(pset.BNGLModel):
+    def __init__(self, name, *, seeded=False, stochastic=False):
+        self.name = name
+        self.seeded = seeded
+        self.stochastic = stochastic
+        self.has_observables = True
+        self.file_path = '/tmp/%s.bngl' % name
+
+
+def _cfg(models, *, candidates=None, replicates=None, edition=2, stochastic_seed='auto'):
+    cfg = object.__new__(config.Configuration)
+    cfg.models = models
+    cfg.config = {'best_fit_candidates': candidates, 'best_fit_replicates': replicates,
+                  'edition': edition, 'stochastic_seed': stochastic_seed}
+    return cfg
+
+
+def test_a_legacy_stochastic_fit_is_told_its_answer_will_be_optimistic(capsys):
+    _cfg({'m': _FakeBNGL('m', stochastic=True)}, edition=None)._check_best_fit_confirmation()
+    assert 'best_fit_replicates = 10' in capsys.readouterr().out
+
+
+def test_nothing_is_said_when_no_model_is_stochastic(capsys):
+    _cfg({'m': _FakeBNGL('m')}, edition=None)._check_best_fit_confirmation()
+    assert capsys.readouterr().out == ''
+
+
+def test_nothing_is_said_when_a_legacy_fit_has_already_turned_the_stage_on(capsys):
+    _cfg({'m': _FakeBNGL('m', stochastic=True)}, edition=None,
+         candidates=10, replicates=10)._check_best_fit_confirmation()
+    assert capsys.readouterr().out == ''
+
+
+def test_nothing_is_said_when_a_legacy_fit_has_turned_the_stage_off_on_purpose(capsys):
+    _cfg({'m': _FakeBNGL('m', stochastic=True)}, edition=None,
+         replicates=0)._check_best_fit_confirmation()
+    assert capsys.readouterr().out == ''
+
+
+def test_a_modern_fit_that_pins_every_seed_is_told_the_stage_cannot_help(capsys):
+    _cfg({'m': _FakeBNGL('m', seeded=True, stochastic=True)},
+         stochastic_seed='auto_honorbngl')._check_best_fit_confirmation()
+    assert 'skip confirming the best fit' in capsys.readouterr().out
+
+
+def test_a_negative_setting_is_refused():
+    for bad in ({'best_fit_candidates': -1}, {'best_fit_replicates': -3}):
+        key, value = next(iter(bad.items()))
+        cfg = _cfg({'m': _FakeBNGL('m')})
+        cfg.config[key] = value
+        with pytest.raises(printing.PybnfError, match=key):
+            cfg._check_best_fit_confirmation()


### PR DESCRIPTION
Closes #659.

## The problem

When a model is stochastic, running it twice with the same parameter values gives two different answers. The objective value PyBNF computes is therefore a noisy measurement rather than a fixed number.

A fit picked its answer by taking the best objective value it ever saw, and every one of those values came from a single simulation. A long fit scores tens of thousands of parameter sets, so the winner of that comparison was very often just the parameter set that happened to get a lucky simulation.

Two things came out wrong and nothing in the output said so. The reported objective value was the best of many noisy draws, so it was optimistic by a wide margin. And the reported parameter values were not the best ones found, because a slightly worse parameter set with a lucky draw beats a better one with an average draw.

## The change

A fit that uses at least one stochastic model now ends with one more stage. It takes the top `best_fit_candidates` parameter sets, runs each of them `best_fit_replicates` more times, ranks them by their average objective value, and reports that winner as the best fit.

Ten and ten by default. That is a hundred simulations against a run that may have done a hundred thousand, and all of them are submitted at once, which uses processors that would otherwise sit idle at the end of a run.

`Results/best_fit_confirmation.txt` records the result. Here is the real file from the run described below:

```
candidates	3
replicates_requested	4
winner	iter2p0h4
winner_mean_objective	72838.74908
winner_standard_error	5521.750431
winner_search_objective	54877.73818
optimism	17961.0109
# rank	name	mean_objective	standard_error	std_deviation	runs	failed	search_objective
1	iter2p0h4	72838.74908	5521.750431	11043.50086	4	0	54877.73818
2	init4	87262.13928	3134.119241	6268.238482	4	0	99030.06578
3	iter2p5h3	100953.6321	3221.85557	6443.71114	4	0	101437.2518
```

The winner is recorded on the trajectory rather than passed around, so everything the run writes after this stage describes the same parameter set. That includes the saved simulations, the best-fit model file, the information criteria, a refine's starting point, and a bootstrap replicate's recorded answer. The record is dropped as soon as anything else is scored, which is what keeps a refine phase, which shares the fit's trajectory, from reporting the point it started from.

## When it runs

The stage is on under `edition = 2` and above. Under the legacy edition it is off, because an unchanged configuration file has to keep behaving exactly as it always has, and a legacy fit with a stochastic model is told at startup which two keys turn it on.

It is also skipped in three cases. When no model is stochastic. When the `wall_time_fit` budget is already spent, because a budget is a promise about the whole run and this costs more simulations. And when `stochastic_seed` is one of the `_honorbngl` modes and every stochastic model pins its seed, because then every replicate would reproduce the same trajectory. Each of those says what it is skipping and why.

No fitting method searches any differently. This covers the answer the fit reports and not the search that produced it, which is the larger piece of work the issue sets aside.

## Two smaller pieces this needed

`make_job` takes a `replicate_offset`. Under the default seed policy a stochastic simulation's seed comes from the parameter values and the replicate index and nothing else, so running a parameter set again at the same index reproduces the same trajectory exactly. The new stage asks for indices past every one the fit itself used. Zero, the default, is the ordinary path and is unchanged.

The scoring half of `add_to_trajectory` moved into `score_result`, so the new stage scores results it deliberately does not put in the trajectory through exactly the same path the fit used.

## Verification

The full test suite passes (4788 passed, 14 skipped). 42 new tests in `tests/test_best_fit_confirmation.py` cover the arithmetic, the report text, the trajectory changes, the gates, and the stage itself driven by a fake dask client with a model whose objective depends on the replicate index. I checked that each of them fails when the corresponding piece of the change is removed.

For a real check, I ran the NFsim receptor example (`examples/receptor_nf`) for three iterations with three candidates at four replicates. The fit reported an objective of 54878. Running that same parameter set four more times gave an average of 72839 give or take 5522, so the reported value was about 18000 too good. That is the file shown above.

## Not in this change

`Results/information_criteria.txt` computes its log-likelihood by re-simulating the best fit once, so for a stochastic model with a likelihood objective it is still a single noisy draw, and it will now disagree with the average this stage reports. Averaging a likelihood over stochastic replicates is a question of its own, so I have not touched it here. Filed separately as #676.

